### PR TITLE
chore: drop mariadb 10.6 dependency for CI runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Install MariaDB Client
         run: |
           sudo apt update
-          sudo apt-get install mariadb-client-10.6
+          sudo apt-get install mariadb-client
 
       - name: Setup
         run: |


### PR DESCRIPTION
Fix CI test after Github updated Ubuntu in the CI runner.