### PR TITLE
feat: upload status toasts + misc

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
 		"tinycolor2": "^1.6.0",
 		"vue": "^3.5.4",
 		"vue-router": "^4.2.2",
+		"vue-sonner": "^1.3.0",
 		"vuedraggable": "^4.1.0"
 	},
 	"devDependencies": {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,10 @@
 <template>
-	<div class="text-base">
+	<div>
 		<router-view />
+		<Toaster richColors expand :visibleToasts="2" />
 	</div>
 </template>
+
+<script setup>
+import { Toaster } from 'vue-sonner'
+</script>

--- a/frontend/src/components/SelectionBox.vue
+++ b/frontend/src/components/SelectionBox.vue
@@ -161,7 +161,7 @@ const setElementPositions = () => {
 	// set positions relative to the selection box
 	activeElementIds.value.forEach((index) => {
 		let element = slide.value.elements[index]
-		element.left = element.left - left.value - 2.1
+		element.left = element.left - left.value - 0.1
 		element.top = element.top - top.value - 2.1
 	})
 }
@@ -185,7 +185,7 @@ const resetSelection = (oldVal) => {
 			let elementDiv = document.querySelector(`[data-index="${index}"]`)
 			if (!elementDiv) return
 			let element = slide.value.elements[index]
-			element.left = left.value + element.left + 2.1
+			element.left = left.value + element.left + 0.1
 			element.top = top.value + element.top + 2.1
 			let slideDiv = document.querySelector('.slide')
 			slideDiv.appendChild(elementDiv)

--- a/frontend/src/components/SelectionBox.vue
+++ b/frontend/src/components/SelectionBox.vue
@@ -196,7 +196,16 @@ const resetSelection = (oldVal) => {
 }
 
 const handleMouseDown = (e) => {
-	if (e.target.getAttribute('contenteditable')) return
+	// ignore long press outside slideContainer and slide elements
+	if (
+		!['slide', 'slideContainer'].some((cls) => e.target.classList.contains(cls)) &&
+		!e.target.hasAttribute('data-index')
+	)
+		return
+
+	// ignore long press when userSelect is enabled
+	if (e.target.getAttribute('contenteditable') == 'true') return
+
 	mousedownStart = new Date().getTime()
 	mousedownTimer = setTimeout(() => {
 		initSelection(e)

--- a/frontend/src/components/Slide.vue
+++ b/frontend/src/components/Slide.vue
@@ -281,14 +281,12 @@ watch(
 	(newVal, oldVal) => {
 		if (oldVal) {
 			let element = slide.value.elements[oldVal]
-			element.left += 2
 			element.top += 2
 			slide.value.elements[oldVal].content = document.querySelector(
 				`[data-index="${oldVal}"]`,
 			).innerText
 		}
 		if (newVal) {
-			slide.value.elements[newVal].left -= 2
 			slide.value.elements[newVal].top -= 2
 		}
 	},
@@ -334,11 +332,9 @@ watch(
 	() => pairElementId.value,
 	(newVal, oldVal) => {
 		if (oldVal) {
-			slide.value.elements[oldVal].left += 2
 			slide.value.elements[oldVal].top += 2
 		}
 		if (newVal) {
-			slide.value.elements[newVal].left -= 2
 			slide.value.elements[newVal].top -= 2
 		}
 	},

--- a/frontend/src/components/SlideElementsPanel.vue
+++ b/frontend/src/components/SlideElementsPanel.vue
@@ -224,7 +224,8 @@
 		<Tooltip text="Image" :hover-delay="1" placement="left">
 			<FileUploader
 				:fileTypes="['image/*']"
-				@success="(file) => addMediaElement(file, 'image')"
+				@success="(file) => handleUploadSuccess(file, 'image')"
+				@failure="handleUploadFailure"
 			>
 				<template #default="{ openFileSelector }">
 					<div :class="getTabClasses('image')" @click="openFileSelector">
@@ -236,7 +237,8 @@
 		<Tooltip text="Video" :hover-delay="1" placement="left">
 			<FileUploader
 				:fileTypes="['video/*']"
-				@success="(file) => addMediaElement(file, 'video')"
+				@success="(file) => handleUploadSuccess(file, 'video')"
+				@failure="handleUploadFailure"
 			>
 				<template #default="{ openFileSelector }">
 					<div :class="getTabClasses('video')" @click="openFileSelector">
@@ -255,6 +257,7 @@
 
 <script setup>
 import { ref, computed } from 'vue'
+import { toast } from 'vue-sonner'
 
 import { Tooltip, FileUploader, FormControl } from 'frappe-ui'
 import { FlipHorizontal, FlipVertical, Repeat2, TvMinimalPlay } from 'lucide-vue-next'
@@ -344,6 +347,15 @@ const getPlaybackTextClasses = (option) => {
 
 const togglePlaybackOption = (option) => {
 	activeElements.value[0][option] = !activeElements.value[0][option]
+}
+
+const handleUploadSuccess = (file, type) => {
+	addMediaElement(file, type)
+	toast.success('Uploaded: ' + file.file_name)
+}
+
+const handleUploadFailure = () => {
+	toast.error('Upload failed. Please try again.')
 }
 </script>
 

--- a/frontend/src/components/SlideNavigationPanel.vue
+++ b/frontend/src/components/SlideNavigationPanel.vue
@@ -7,7 +7,7 @@
 		@mouseleave="showCollapseShortcut = false"
 		@wheel="handleWheelEvent"
 	>
-		<div class="flex flex-col h-full px-4 overflow-y-auto">
+		<div class="flex flex-col h-full ps-4 pe-3 overflow-y-auto" :style="scrollbarStyles">
 			<Draggable v-model="presentation.data.slides" item-key="name" @end="handleSortEnd">
 				<template #item="{ element: slide }">
 					<div
@@ -29,10 +29,10 @@
 
 		<div
 			v-if="showNavigator && showCollapseShortcut"
-			class="fixed -left-0.5 bottom-0 z-20 flex h-10 w-44 cursor-pointer items-center justify-between border-t bg-white p-4"
+			class="fixed -left-0.4 bottom-0 z-20 flex h-10 w-44 cursor-pointer items-center justify-between border-t bg-white p-4"
 			@click="toggleNavigator"
 		>
-			<div class="text-2xs text-gray-500">Toggle</div>
+			<div class="text-2xs text-gray-500">Toggle Navigator</div>
 			<div class="flex h-5 w-1/3 items-center justify-center rounded-sm border bg-gray-100">
 				<div class="text-xs text-gray-500">⌘ + B</div>
 			</div>
@@ -51,7 +51,7 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 
 import { call } from 'frappe-ui'
 
@@ -95,13 +95,17 @@ const handleSortEnd = async (event) => {
 }
 
 const handleWheelEvent = (e) => {
-	// allow scroll normal scroll behaviour
+	// allow normal scroll behaviour
 	if (!e.ctrlKey && !e.metaKey) return
 
 	// prevent zoom event from triggering
 	e.preventDefault()
 	e.stopPropagation()
 }
+
+const scrollbarStyles = computed(() => ({
+	'--scrollbar-thumb-color': showCollapseShortcut.value ? '#cfcfcf' : 'transparent',
+}))
 </script>
 
 <style scoped>
@@ -111,5 +115,18 @@ const handleWheelEvent = (e) => {
 
 .sortable-chosen {
 	opacity: 0.8;
+}
+
+::-webkit-scrollbar {
+	width: 4px;
+}
+
+::-webkit-scrollbar-thumb {
+	background-color: var(--scrollbar-thumb-color);
+	border-radius: 20px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+	background-color: #c6c6c6;
 }
 </style>

--- a/frontend/src/pages/Presentation.vue
+++ b/frontend/src/pages/Presentation.vue
@@ -44,7 +44,7 @@
 					size="sm"
 					:variant="'subtle'"
 					:loading="saving"
-					:disabled="!slideDirty || saving"
+					:disabled="!slideDirty"
 					@click="saveChanges"
 				>
 					<template #icon>
@@ -302,8 +302,13 @@ watch(
 	{ immediate: true },
 )
 
+const handleAutoSave = () => {
+	if (activeElementIds.value.length) return
+	saveChanges()
+}
+
 onMounted(() => {
-	autosaveInterval = setInterval(saveChanges, 60000)
+	autosaveInterval = setInterval(handleAutoSave, 60000)
 	document.addEventListener('keydown', handleKeyDown)
 })
 

--- a/frontend/src/pages/Presentation.vue
+++ b/frontend/src/pages/Presentation.vue
@@ -101,6 +101,7 @@
 <script setup>
 import { ref, watch, onMounted, nextTick, useTemplateRef, onBeforeUnmount } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { toast } from 'vue-sonner'
 
 import { call, FileUploadHandler, Spinner } from 'frappe-ui'
 
@@ -247,10 +248,16 @@ const handleMediaDrop = async (e) => {
 		const fileType = file.type.split('/')[0]
 		if (['image', 'video'].includes(fileType)) {
 			const fileUploadHandler = new FileUploadHandler()
-			const fileDoc = await fileUploadHandler.upload(file, {
-				private: false,
-			})
-			addMediaElement(fileDoc, fileType)
+			toast.promise(
+				fileUploadHandler.upload(file, { private: false }).then((fileDoc) => {
+					addMediaElement(fileDoc, fileType)
+				}),
+				{
+					loading: `Uploading File`,
+					success: (data) => 'File Uploaded',
+					error: (data) => 'Upload failed. Please try again.',
+				},
+			)
 		}
 	})
 }

--- a/frontend/src/pages/Presentation.vue
+++ b/frontend/src/pages/Presentation.vue
@@ -69,13 +69,8 @@
 
 			<div
 				ref="slideContainer"
-				class="flex items-center justify-center w-full h-full"
-				:class="{
-					'bg-black': inSlideShow,
-				}"
-				:style="{
-					clipPath: inSlideShow ? 'inset(45px 0 45px 0)' : 'none',
-				}"
+				class="slideContainer flex items-center justify-center w-full h-full"
+				:style="containerStyles"
 			>
 				<Slide
 					v-if="slideContainerRef"
@@ -99,7 +94,7 @@
 </template>
 
 <script setup>
-import { ref, watch, onMounted, nextTick, useTemplateRef, onBeforeUnmount } from 'vue'
+import { ref, computed, watch, onMounted, nextTick, useTemplateRef, onBeforeUnmount } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { toast } from 'vue-sonner'
 
@@ -147,6 +142,14 @@ const newTitle = ref('')
 const renameMode = ref(false)
 const showNavigator = ref(true)
 const isMediaDragOver = ref(false)
+
+const containerStyles = computed(() => {
+	if (!inSlideShow.value) return {}
+	return {
+		clipPath: 'inset(45px 0 45px 0)',
+		backgroundColor: 'black',
+	}
+})
 
 const enableRenameMode = () => {
 	renameMode.value = true

--- a/frontend/src/pages/Presentation.vue
+++ b/frontend/src/pages/Presentation.vue
@@ -15,10 +15,10 @@
 		>
 			<div class="flex items-center gap-2">
 				<img src="../icons/slides.svg" class="h-7" />
-				<div class="select-none font-semibold">Slides</div>
+				<div class="text-base font-semibold">Slides</div>
 			</div>
 
-			<div class="flex justify-center items-center">
+			<div class="flex text-base justify-center items-center">
 				<input
 					spellcheck="false"
 					ref="newTitleRef"
@@ -34,9 +34,10 @@
 				>
 					{{ presentation.data?.title }}
 				</span>
-				<span class="text-gray-500"
-					>&nbsp;&#8729;&nbsp;{{ slideDirty ? 'Unsaved' : 'Saved' }}</span
-				>
+
+				<Badge class="mx-2" :theme="slideDirty ? 'orange' : 'gray'" size="md">
+					{{ slideDirty ? 'Unsaved' : 'Saved' }}
+				</Badge>
 			</div>
 
 			<div class="flex items-center gap-2 justify-end">
@@ -98,7 +99,7 @@ import { ref, computed, watch, onMounted, nextTick, useTemplateRef, onBeforeUnmo
 import { useRoute, useRouter } from 'vue-router'
 import { toast } from 'vue-sonner'
 
-import { call, FileUploadHandler, Spinner } from 'frappe-ui'
+import { call, FileUploadHandler, Spinner, Badge } from 'frappe-ui'
 
 import { Presentation } from 'lucide-vue-next'
 import SlideNavigationPanel from '@/components/SlideNavigationPanel.vue'

--- a/frontend/src/pages/Presentation.vue
+++ b/frontend/src/pages/Presentation.vue
@@ -244,20 +244,22 @@ const handleMediaDrop = async (e) => {
 	e.preventDefault()
 	isMediaDragOver.value = false
 	const files = e.dataTransfer.files
-	files.forEach(async (file) => {
+	const fileUploadHandler = new FileUploadHandler()
+	files.forEach((file, index) => {
 		const fileType = file.type.split('/')[0]
 		if (['image', 'video'].includes(fileType)) {
-			const fileUploadHandler = new FileUploadHandler()
-			toast.promise(
-				fileUploadHandler.upload(file, { private: false }).then((fileDoc) => {
-					addMediaElement(fileDoc, fileType)
-				}),
-				{
-					loading: `Uploading File`,
-					success: (data) => 'File Uploaded',
-					error: (data) => 'Upload failed. Please try again.',
-				},
-			)
+			setTimeout(() => {
+				toast.promise(
+					fileUploadHandler.upload(file, { private: false }).then((fileDoc) => {
+						addMediaElement(fileDoc, fileType)
+					}),
+					{
+						loading: `Uploading (${index + 1}/${files.length}): ${file.name}`,
+						success: (data) => `Uploaded: ${file.name}`,
+						error: (data) => 'Upload failed. Please try again.',
+					},
+				)
+			}, 100)
 		}
 	})
 }

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -45,8 +45,7 @@ const addTextElement = () => {
 		top: 100,
 		content: 'Text',
 		type: 'text',
-		width: 'auto',
-		height: 'auto',
+		textAlign: 'center',
 	}
 
 	if (lastTextElement) {

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -84,7 +84,7 @@ const changeSlide = async (index) => {
 const saving = ref(false)
 
 const saveChanges = async () => {
-	if (!presentation.data || !slideDirty.value || activeElementIds.value.length) return
+	if (!presentation.data || !slideDirty.value) return
 	slide.value.elements = slide.value.elements.map((element, index) => {
 		let div = document.querySelector(`[data-index="${index}"]`)
 		element.width = div.offsetWidth

--- a/yarn.lock
+++ b/yarn.lock
@@ -2076,6 +2076,11 @@ vue-router@^4.2.2:
   dependencies:
     "@vue/devtools-api" "^6.6.4"
 
+vue-sonner@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/vue-sonner/-/vue-sonner-1.3.0.tgz#da8ab9be995dfea781d57a6ac52d170d02473d86"
+  integrity sha512-jAodBy4Mri8rQjVZGQAPs4ZYymc1ywPiwfa81qU0fFl+Suk7U8NaOxIDdI1oBGLeQJqRZi/oxNIuhCLqsBmOwg==
+
 vue@^3.5.4:
   version "3.5.13"
   resolved "https://registry.yarnpkg.com/vue/-/vue-3.5.13.tgz#9f760a1a982b09c0c04a867903fc339c9f29ec0a"


### PR DESCRIPTION
### Description

Added toasts to show status of uploads while loading, success and failure.


https://github.com/user-attachments/assets/d65f6706-717a-40c9-96f8-c044e9ef3cdb

<br>

---


### Fixes

- Fix to avoid visually displacing elements while selected due to change of parent container.

  <details>
  <summary> Before </summary>
  <br>

  https://github.com/user-attachments/assets/4226c928-2bef-4700-a7f7-93f50dc310e4
  </details>
  
  <details>
  <summary> After </summary>
  <br>

  https://github.com/user-attachments/assets/77388c97-dcfa-40ce-bf4e-653e8f0437e1
  </details>

- Fix to make slider input work as expected and avoid long press from input to fallback on the container's long press event.

### Other Minor Changes

- Show dirty state in a badge instead of plain text.
- Override default scrollbar for smaller width of Navigation Panel.
