### PR TITLE
fix: jitter while snapping to position + misc

### DIFF
--- a/frontend/src/components/AlignmentGuides.vue
+++ b/frontend/src/components/AlignmentGuides.vue
@@ -17,7 +17,7 @@ const props = defineProps({
 	scale: Number,
 })
 
-const PROXIMITY_THRESHOLD = 14
+const PROXIMITY_THRESHOLD = 15
 
 const activeDiv = computed(() => {
 	if (activeElementIds.value.length == 0) return
@@ -315,7 +315,7 @@ const updateElementPosition = (dx, dy) => {
 	else skip.value -= 1
 
 	if (didSnap) {
-		skip.value = 20
+		skip.value = 15
 	}
 }
 

--- a/frontend/src/components/AlignmentGuides.vue
+++ b/frontend/src/components/AlignmentGuides.vue
@@ -1,6 +1,6 @@
 <template>
 	<div
-		v-for="guide in ['centerX', 'centerY', 'left', 'right']"
+		v-for="guide in ['centerX', 'centerY', 'left', 'right', 'top', 'bottom']"
 		:key="guide"
 		:style="guideStyles[guide]"
 	></div>

--- a/frontend/src/components/AlignmentGuides.vue
+++ b/frontend/src/components/AlignmentGuides.vue
@@ -45,15 +45,24 @@ const prevDiffs = ref({
 })
 
 const diffs = ref({
-	centerX: 0,
-	centerY: 0,
-	left: 0,
-	right: 0,
-	top: 0,
-	bottom: 0,
+	centerX: null,
+	centerY: null,
+	left: null,
+	right: null,
+	top: null,
+	bottom: null,
 })
 
 const visibilityMap = computed(() => {
+	if (!activePosition.value || diffs.value.centerX == null)
+		return {
+			centerX: false,
+			centerY: false,
+			left: false,
+			right: false,
+			top: false,
+			bottom: false,
+		}
 	return {
 		centerX: Math.abs(diffs.value.centerX) < PROXIMITY_THRESHOLD,
 		centerY: Math.abs(diffs.value.centerY) < PROXIMITY_THRESHOLD,

--- a/frontend/src/components/AlignmentGuides.vue
+++ b/frontend/src/components/AlignmentGuides.vue
@@ -10,12 +10,8 @@
 import { ref, computed } from 'vue'
 import { useElementBounding } from '@vueuse/core'
 
-import { slide, slideRect } from '@/stores/slide'
+import { slide, slideDimensions } from '@/stores/slide'
 import { activePosition, activeElementIds, pairElementId } from '@/stores/element'
-
-const props = defineProps({
-	scale: Number,
-})
 
 const PROXIMITY_THRESHOLD = 15
 
@@ -167,8 +163,8 @@ const centerYGuideStyles = computed(() => {
 })
 
 const getScaledValue = (value, axis) => {
-	if (axis == 'X') return (value - slideRect.value.left) / props.scale
-	return (value - slideRect.value.top) / props.scale
+	if (axis == 'X') return (value - slideDimensions.left) / slideDimensions.scale
+	return (value - slideDimensions.top) / slideDimensions.scale
 }
 
 const getElementBounds = (div) => {
@@ -178,8 +174,8 @@ const getElementBounds = (div) => {
 		top: getScaledValue(rect.top, 'Y'),
 		right: getScaledValue(rect.right, 'X'),
 		bottom: getScaledValue(rect.bottom, 'Y'),
-		height: rect.height / props.scale,
-		width: rect.width / props.scale,
+		height: rect.height / slideDimensions.scale,
+		width: rect.width / slideDimensions.scale,
 	}
 }
 
@@ -227,10 +223,10 @@ const getDiffFromCenter = (axis) => {
 	const activeBounds = getElementBounds(activeDiv.value)
 
 	if (axis == 'X') {
-		slideCenter = slideRect.value.width / 2
+		slideCenter = slideDimensions.width / slideDimensions.scale / 2
 		elementCenter = activeBounds.left + activeBounds.width / 2
 	} else {
-		slideCenter = slideRect.value.height / 2
+		slideCenter = slideDimensions.height / slideDimensions.scale / 2
 		elementCenter = activeBounds.top + activeBounds.height / 2
 	}
 

--- a/frontend/src/components/AlignmentGuides.vue
+++ b/frontend/src/components/AlignmentGuides.vue
@@ -30,7 +30,6 @@ const pairElement = computed(() => {
 	return slide.value.elements[pairElementId.value]
 })
 
-// counters to keep track of how many times the element has been snapped to the center
 const prevDiffs = ref({
 	centerX: 0,
 	centerY: 0,
@@ -69,7 +68,8 @@ const visibilityMap = computed(() => {
 	}
 })
 
-const skip = ref(0)
+// when an element is snapped to a new position, enable movement after a few frames
+const skipFrames = ref(0)
 
 const guideStyles = computed(() => {
 	return {
@@ -312,15 +312,15 @@ const updateElementPosition = (dx, dy) => {
 
 	const didSnap = dx != updatedDx || dy != updatedDy
 
-	if (!skip.value)
+	if (!skipFrames.value)
 		activePosition.value = {
 			left: activePosition.value.left + updatedDx,
 			top: activePosition.value.top + updatedDy,
 		}
-	else skip.value -= 1
+	else skipFrames.value -= 1
 
 	if (didSnap) {
-		skip.value = 15
+		skipFrames.value = 15
 	}
 }
 

--- a/frontend/src/components/PresentationHeader.vue
+++ b/frontend/src/components/PresentationHeader.vue
@@ -14,7 +14,7 @@
 			@click="makeTitleEditable"
 		>
 			<div>{{ presentation.data?.title }}</div>
-			<div class="text-gray-600" v-if="slideDirty">*</div>
+			<div class="text-gray-400 text-xs" v-if="slideDirty">*</div>
 		</div>
 	</div>
 </template>

--- a/frontend/src/components/PresentationHeader.vue
+++ b/frontend/src/components/PresentationHeader.vue
@@ -8,13 +8,14 @@
 			spellcheck="false"
 			@blur="saveTitle"
 		/>
-		<span v-else class="select-none font-semibold text-gray-700" @click="makeTitleEditable">
-			{{ presentation.data?.title }}
-		</span>
-
-		<Badge class="mx-2" :theme="slideDirty ? 'orange' : 'gray'" size="md">
-			{{ slideDirty ? 'Unsaved' : 'Saved' }}
-		</Badge>
+		<div
+			v-else
+			class="select-none font-semibold text-gray-700 flex items-center"
+			@click="makeTitleEditable"
+		>
+			<div>{{ presentation.data?.title }}</div>
+			<div class="text-gray-600" v-if="slideDirty">*</div>
+		</div>
 	</div>
 </template>
 
@@ -22,7 +23,7 @@
 import { ref, useTemplateRef, nextTick } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
-import { Badge, call } from 'frappe-ui'
+import { call } from 'frappe-ui'
 
 import { presentation } from '@/stores/presentation'
 import { slideDirty } from '@/stores/slide'

--- a/frontend/src/components/SelectionBox.vue
+++ b/frontend/src/components/SelectionBox.vue
@@ -136,9 +136,11 @@ const cropSelectionToFitContent = () => {
 	// crop selection to selected element edges
 	activeElementIds.value.forEach((index) => {
 		const element = slide.value.elements[index]
-		const elementDiv = document.querySelector(`[data-index="${index}"]`)
-		const elementWidth = elementDiv.offsetWidth
-		const elementHeight = elementDiv.offsetHeight
+		const elementRect = document
+			.querySelector(`[data-index="${index}"]`)
+			.getBoundingClientRect()
+		const elementWidth = elementRect.width
+		const elementHeight = elementRect.height
 
 		if (element.left < l) l = element.left
 		if (element.top < t) t = element.top

--- a/frontend/src/components/SelectionBox.vue
+++ b/frontend/src/components/SelectionBox.vue
@@ -243,7 +243,7 @@ watch(
 		if (oldVal.length) {
 			resetSelection(oldVal)
 		}
-		if (val.length >= 1) {
+		if (val.length) {
 			document.removeEventListener('mouseup', endSelection)
 			handleSelection(val)
 		}

--- a/frontend/src/components/SelectionBox.vue
+++ b/frontend/src/components/SelectionBox.vue
@@ -59,8 +59,6 @@ const initSelection = (e) => {
 }
 
 const updateSelection = (e) => {
-	document.addEventListener('mouseup', endSelection)
-
 	const dx = (e.clientX - prevX.value) / props.scale
 	const dy = (e.clientY - prevY.value) / props.scale
 
@@ -73,6 +71,8 @@ const updateSelection = (e) => {
 
 	width.value = Math.abs(dx)
 	height.value = Math.abs(dy)
+
+	document.addEventListener('mouseup', endSelection)
 }
 
 const removeSelectionBox = () => {
@@ -122,10 +122,9 @@ const updateSelectedElements = () => {
 }
 
 const endSelection = () => {
-	updateSelectedElements()
-
-	document.removeEventListener('mouseup', endSelection)
 	document.removeEventListener('mousemove', updateSelection)
+
+	updateSelectedElements()
 }
 
 const cropSelectionToFitContent = () => {
@@ -215,6 +214,8 @@ const handleMouseDown = (e) => {
 	mousedownTimer = setTimeout(() => {
 		initSelection(e)
 	}, longpressDuration)
+
+	document.addEventListener('mouseup', handleMouseUp)
 }
 
 const handleMouseLeave = () => {
@@ -238,6 +239,7 @@ watch(
 			resetSelection(oldVal)
 		}
 		if (val.length >= 1) {
+			document.removeEventListener('mouseup', endSelection)
 			handleSelection(val)
 		}
 	},
@@ -267,11 +269,10 @@ watch(
 onMounted(() => {
 	document.addEventListener('mousedown', handleMouseDown)
 	document.addEventListener('mouseleave', handleMouseLeave)
-	document.addEventListener('mouseup', handleMouseUp)
 })
 
 onBeforeUnmount(() => {
-	document.removeEventListener('mousedown', initSelection)
+	document.removeEventListener('mousedown', handleMouseDown)
 	document.removeEventListener('mouseleave', handleMouseLeave)
 	document.removeEventListener('mouseup', handleMouseUp)
 })

--- a/frontend/src/components/SelectionBox.vue
+++ b/frontend/src/components/SelectionBox.vue
@@ -21,6 +21,7 @@ const top = ref(0)
 const left = ref(0)
 const width = ref(0)
 const height = ref(0)
+
 const startX = ref(0)
 const startY = ref(0)
 

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -4,7 +4,7 @@
 			<div ref="slideRef" :class="slideClasses" :style="slideStyles">
 				<SelectionBox @updateFocus="updateFocus" />
 
-				<AlignmentGuides ref="guides" v-if="showGuides" :scale="scale" />
+				<AlignmentGuides ref="guides" v-if="showGuides" />
 
 				<component
 					ref="element"

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -56,6 +56,7 @@ import {
 	duplicateSlide,
 	slideRect,
 	loadSlide,
+	selectSlide,
 	getSlideThumbnail,
 } from '@/stores/slide'
 import {
@@ -120,22 +121,6 @@ const scale = computed(() => {
 	return parseFloat(matrix[1].split(', ')[0])
 })
 
-const selectSlide = (e) => {
-	e.preventDefault()
-	e.stopPropagation()
-	if (isResizing.value) {
-		isResizing.value = false
-		return
-	}
-	if (focusElementId.value) {
-		slide.value.elements[focusElementId.value].content = document.querySelector(
-			`[data-index="${focusElementId.value}"]`,
-		).innerText
-	}
-	resetFocus()
-	slideFocus.value = true
-}
-
 const addDragAndResize = () => {
 	let el = document.querySelector('.groupDiv')
 	if (!el) return
@@ -156,7 +141,11 @@ const removeDragAndResize = (val) => {
 }
 
 const updateFocus = (e) => {
-	if (e.target.classList.contains('slide')) {
+	if (e.target == slideRef.value) {
+		if (isResizing.value) {
+			isResizing.value = false
+			return
+		}
 		selectSlide(e)
 	} else if (e.target == props.containerRef) {
 		resetFocus()

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -49,7 +49,6 @@ import SelectionBox from './SelectionBox.vue'
 import { presentation } from '@/stores/presentation'
 import {
 	slideIndex,
-	slideFocus,
 	slide,
 	insertSlide,
 	deleteSlide,
@@ -141,16 +140,11 @@ const removeDragAndResize = (val) => {
 }
 
 const updateFocus = (e) => {
-	if (e.target == slideRef.value) {
-		if (isResizing.value) {
-			isResizing.value = false
-			return
-		}
-		selectSlide(e)
-	} else if (e.target == props.containerRef) {
-		resetFocus()
-		slideFocus.value = false
+	if (isResizing.value) {
+		isResizing.value = false
+		return
 	}
+	selectSlide(e)
 }
 
 watch(

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -222,7 +222,10 @@ watch(
 	() => transform.value,
 	() => {
 		if (!transform.value) return
-		updateSlideDimensions()
+		// wait for the new transform to render before updating dimensions
+		nextTick(() => {
+			updateSlideDimensions()
+		})
 	},
 )
 

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -98,7 +98,7 @@ const slideClasses = computed(() => {
 
 	const outlineClasses = props.highlight ? ['outline', 'outline-1.5', 'outline-blue-400'] : []
 	const shadowClasses = activeElementIds.value.length ? ['shadow-gray-300'] : []
-	const cursorClasses = activeElementIds.value.length ? ['cursor-move'] : ['cursor-default']
+	const cursorClasses = isDragging.value ? ['cursor-move'] : ['cursor-default']
 
 	return [...classes, outlineClasses, shadowClasses, cursorClasses]
 })

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -195,7 +195,6 @@ watch(
 
 		guides.value.updateElementPosition(x / scale.value, y / scale.value)
 	},
-	{ immediate: true },
 )
 
 watch(

--- a/frontend/src/components/SlideElementsPanel.vue
+++ b/frontend/src/components/SlideElementsPanel.vue
@@ -245,7 +245,7 @@
 			</FileUploader>
 		</Tooltip>
 		<Tooltip text="Slide Properties" :hover-delay="1" placement="left">
-			<div :class="getTabClasses('slide')">
+			<div :class="getTabClasses('slide')" @click="selectSlide">
 				<Layout size="20" :class="getIconClasses('slide')" />
 			</div>
 		</Tooltip>
@@ -275,7 +275,7 @@ import NumberInput from '@/components/controls/NumberInput.vue'
 import ColorPicker from '@/components/controls/ColorPicker.vue'
 
 import { presentation } from '@/stores/presentation'
-import { slide, slideIndex, slideFocus } from '@/stores/slide'
+import { slide, slideIndex, slideFocus, selectSlide } from '@/stores/slide'
 import { activeElements, addTextElement, addMediaElement } from '@/stores/element'
 
 const activeTab = computed(() => {

--- a/frontend/src/components/SlideElementsPanel.vue
+++ b/frontend/src/components/SlideElementsPanel.vue
@@ -269,13 +269,12 @@ import NumberInput from '@/components/controls/NumberInput.vue'
 import ColorPicker from '@/components/controls/ColorPicker.vue'
 
 import { presentation } from '@/stores/presentation'
-import { slide, slideIndex, slideFocus, selectSlide } from '@/stores/slide'
+import { slide, slideIndex, selectSlide } from '@/stores/slide'
 import { activeElements, addTextElement, addMediaElement } from '@/stores/element'
 
 const activeTab = computed(() => {
-	if (slideFocus.value) return 'slide'
-	if (!activeElements.value[0]) return null
-	return activeElements.value[0].type
+	if (activeElements.value[0]) return activeElements.value[0].type
+	return 'slide'
 })
 
 const getTabClasses = (tab) => {

--- a/frontend/src/components/SlideElementsPanel.vue
+++ b/frontend/src/components/SlideElementsPanel.vue
@@ -104,23 +104,17 @@
 						class="flex h-8 w-full items-center gap-3 justify-between rounded border bg-gray-50 p-[2px] px-2"
 					>
 						<div
-							v-for="(direction, index) in ['none', 'solid', 'dashed', 'dotted']"
+							v-for="(style, index) in ['none', 'solid', 'dashed', 'dotted']"
 							:key="index"
 							class="flex h-4/5 w-1/4 cursor-pointer items-center justify-center rounded-sm"
-							:class="
-								activeElements[0].borderStyle == direction ? 'bg-white shadow' : ''
-							"
-							@click="activeElements[0].borderStyle = direction"
+							:class="activeElements[0].borderStyle == style ? 'bg-white shadow' : ''"
+							@click="addBorder(style)"
 						>
-							<Ban
-								v-if="direction == 'none'"
-								size="16"
-								class="stroke-[1.5] text-black"
-							/>
+							<Ban v-if="style == 'none'" size="16" class="stroke-[1.5] text-black" />
 							<div
 								v-else
 								class="h-4 w-5 rounded-sm border border-black"
-								:style="{ borderStyle: direction }"
+								:style="{ borderStyle: style }"
 							></div>
 						</div>
 					</div>
@@ -363,6 +357,11 @@ const handleUploadSuccess = (file, type) => {
 
 const handleUploadFailure = () => {
 	toast.error('Upload failed. Please try again.')
+}
+
+const addBorder = (style) => {
+	activeElements.value[0].borderStyle = style
+	activeElements.value[0].borderWidth = 1
 }
 </script>
 

--- a/frontend/src/components/TextElement.vue
+++ b/frontend/src/components/TextElement.vue
@@ -4,6 +4,7 @@
 		:contenteditable="focusElementId == $attrs['data-index']"
 		:style="textStyle"
 		@click="selectElement"
+		@focus="setCursorPosition"
 		@blur="handleBlur"
 	>
 		{{ element.content }}
@@ -11,7 +12,7 @@
 </template>
 
 <script setup>
-import { computed, useAttrs } from 'vue'
+import { computed, nextTick, useAttrs } from 'vue'
 
 import { inSlideShow } from '@/stores/presentation'
 import { focusElementId, setActiveElements } from '@/stores/element'
@@ -57,6 +58,21 @@ const setFocusElement = (e) => {
 	e.stopPropagation()
 	if (focusElementId.value == attrs['data-index']) return
 	setActiveElements([attrs['data-index']], true)
+	nextTick(() => {
+		e.target.focus()
+	})
+}
+
+const setCursorPosition = (e) => {
+	const range = document.createRange()
+	const selection = window.getSelection()
+
+	range.selectNodeContents(e.target)
+	// set cursor to end of text
+	range.collapse(false)
+
+	selection.removeAllRanges()
+	selection.addRange(range)
 }
 
 const handleBlur = (e) => {

--- a/frontend/src/components/TextPropertyTab.vue
+++ b/frontend/src/components/TextPropertyTab.vue
@@ -9,7 +9,7 @@
 				:class="
 					activeElements[0][style.property]?.includes(style.value) ? 'bg-gray-200' : ''
 				"
-				@click="toggleProperty(style.property, style.value)"
+				@click="toggleTextProperty(style.property, style.value)"
 			>
 				<component :is="style.icon" size="18" :strokeWidth="1.5" />
 			</button>
@@ -106,7 +106,7 @@ import NumberInput from './controls/NumberInput.vue'
 import ColorPicker from './controls/ColorPicker.vue'
 
 import { slide } from '@/stores/slide'
-import { activeElementIds, activeElements } from '@/stores/element'
+import { activeElementIds, activeElements, toggleTextProperty } from '@/stores/element'
 
 const sectionClasses = 'flex flex-col gap-4 border-b p-4'
 const sectionTitleClasses = 'text-2xs font-semibold uppercase text-gray-700'
@@ -156,32 +156,6 @@ const styleProperties = [
 		icon: CaseUpper,
 	},
 ]
-
-const toggleProperty = (property, value) => {
-	const oldStyle = activeElements.value[0][property]
-	let newStyle = ''
-
-	switch (property) {
-		case 'fontWeight':
-			newStyle = oldStyle == 'bold' ? 'normal' : 'bold'
-			break
-		case 'fontStyle':
-			newStyle = oldStyle == 'italic' ? 'normal' : 'italic'
-			break
-		case 'textTransform':
-			newStyle = oldStyle == 'uppercase' ? 'none' : 'uppercase'
-			break
-		default:
-			if (!oldStyle) {
-				newStyle = value
-				break
-			}
-			newStyle = oldStyle.includes(value)
-				? oldStyle.replace(value, '')
-				: oldStyle + ' ' + value
-	}
-	slide.value.elements[activeElementIds.value[0]][property] = newStyle
-}
 </script>
 
 <style scoped>

--- a/frontend/src/components/VideoElement.vue
+++ b/frontend/src/components/VideoElement.vue
@@ -49,7 +49,8 @@ const videoStyle = computed(() => ({
 
 const handleVideoControls = (e) => {
 	e.stopPropagation()
-	if (inSlideShow.value || activeElementIds.value.includes(attrs['data-index'])) {
+	const isActive = activeElementIds.value.includes(attrs['data-index'])
+	if (inSlideShow.value || (isActive && e.target !== el.value)) {
 		const video = el.value
 		if (video.paused) {
 			isPlaying.value = true

--- a/frontend/src/components/controls/SliderInput.vue
+++ b/frontend/src/components/controls/SliderInput.vue
@@ -61,23 +61,21 @@ const changeValue = (e) => {
 const highlightStyles = computed(() => {
 	const { rangeStart, rangeEnd, modelValue: val } = props
 
+	let left = 0
+	let width = 0
+
 	if (rangeStart < 0) {
-		if (val <= 0) {
-			return {
-				left: `${((Math.abs(rangeStart) - Math.abs(val)) / (rangeEnd - rangeStart)) * 100}%`,
-				width: `${(Math.abs(val) / (rangeEnd - rangeStart)) * 100}%`,
-			}
-		} else {
-			return {
-				left: `${(Math.abs(rangeStart) / (rangeEnd - rangeStart)) * 100}%`,
-				width: `${(Math.abs(val) / (rangeEnd - rangeStart)) * 100}%`,
-			}
-		}
+		left = Math.abs(rangeStart)
+		if (val <= 0) left -= Math.abs(val)
+		width = Math.abs(val)
 	} else {
-		return {
-			left: `0`,
-			width: `${((val - rangeStart) / (rangeEnd - rangeStart)) * 100}%`,
-		}
+		left = 0
+		width = val - rangeStart
+	}
+
+	return {
+		left: `${(left / (rangeEnd - rangeStart)) * 100}%`,
+		width: `${(width / (rangeEnd - rangeStart)) * 100}%`,
 	}
 })
 </script>

--- a/frontend/src/components/controls/SliderInput.vue
+++ b/frontend/src/components/controls/SliderInput.vue
@@ -13,10 +13,8 @@
 					@input="$emit('update:modelValue', $event.target.value)"
 				/>
 				<div
-					class="absolute top-0 h-full rounded border border-black bg-black"
-					:style="{
-						width: `${((modelValue - rangeStart) / (rangeEnd - rangeStart)) * 100}%`,
-					}"
+					class="absolute top-0 h-full rounded border bg-black border-black"
+					:style="highlightStyles"
 				></div>
 			</div>
 			<input
@@ -31,7 +29,7 @@
 </template>
 
 <script setup>
-import { ref, useTemplateRef } from 'vue'
+import { ref, useTemplateRef, computed } from 'vue'
 
 const props = defineProps({
 	label: String,
@@ -59,6 +57,29 @@ const changeValue = (e) => {
 	const value = parseFloat(e.target.value)
 	emit('update:modelValue', Math.max(props.rangeStart, Math.min(props.rangeEnd, value)))
 }
+
+const highlightStyles = computed(() => {
+	const { rangeStart, rangeEnd, modelValue: val } = props
+
+	if (rangeStart < 0) {
+		if (val <= 0) {
+			return {
+				left: `${((Math.abs(rangeStart) - Math.abs(val)) / (rangeEnd - rangeStart)) * 100}%`,
+				width: `${(Math.abs(val) / (rangeEnd - rangeStart)) * 100}%`,
+			}
+		} else {
+			return {
+				left: `${(Math.abs(rangeStart) / (rangeEnd - rangeStart)) * 100}%`,
+				width: `${(Math.abs(val) / (rangeEnd - rangeStart)) * 100}%`,
+			}
+		}
+	} else {
+		return {
+			left: `0`,
+			width: `${((val - rangeStart) / (rangeEnd - rangeStart)) * 100}%`,
+		}
+	}
+})
 </script>
 <style scoped>
 input::-webkit-outer-spin-button,

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -49,6 +49,7 @@ import SlideContainer from '@/components/SlideContainer.vue'
 
 import { presentationId, presentation } from '@/stores/presentation'
 import {
+	slide,
 	slideIndex,
 	slideDirty,
 	saving,
@@ -67,6 +68,8 @@ import {
 	addMediaElement,
 	selectAllElements,
 	activePosition,
+	activeElements,
+	toggleTextProperty,
 } from '@/stores/element'
 
 let autosaveInterval = null
@@ -116,6 +119,12 @@ const handleElementShortcuts = (e) => {
 		case 'd':
 			if (e.metaKey) duplicateElements(e)
 			break
+		case 'i':
+			if (e.metaKey) toggleTextProperty('fontStyle', 'italic')
+			break
+		case 'u':
+			if (e.metaKey) toggleTextProperty('textDecoration', 'underline')
+			break
 	}
 }
 
@@ -146,7 +155,11 @@ const handleGlobalShortcuts = (e) => {
 			addTextElement()
 			break
 		case 'b':
-			if (e.metaKey) showNavigator.value = !showNavigator.value
+			if (e.metaKey) {
+				if (activeElementIds.value.length && activeElements.value[0].type == 'text')
+					return toggleTextProperty('fontWeight', 'bold')
+				showNavigator.value = !showNavigator.value
+			}
 			break
 		case 'a':
 			if (e.metaKey) selectAllElements()

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -236,7 +236,7 @@ watch(
 )
 
 const handleAutoSave = () => {
-	if (activeElementIds.value.length) return
+	if (activeElementIds.value.length || focusElementId.value != null) return
 	saveChanges()
 }
 
@@ -247,6 +247,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
 	clearInterval(autosaveInterval)
+	resetFocus()
 	document.removeEventListener('keydown', handleKeyDown)
 })
 </script>

--- a/frontend/src/pages/Slideshow.vue
+++ b/frontend/src/pages/Slideshow.vue
@@ -147,12 +147,14 @@ const resetCursorVisibility = () => {
 	}, 5000)
 }
 
-const handleFullScreenChange = async () => {
+const handleFullScreenChange = () => {
+	inSlideShow.value = document.fullscreenElement != null
+
 	if (document.fullscreenElement) {
 		slideContainerRef.value.addEventListener('mousemove', resetCursorVisibility)
 	} else {
-		router.replace({ name: 'PresentationEditor', query: null })
 		slideContainerRef.value.removeEventListener('mousemove', resetCursorVisibility)
+		router.replace({ name: 'PresentationEditor', query: null })
 	}
 }
 

--- a/frontend/src/pages/Slideshow.vue
+++ b/frontend/src/pages/Slideshow.vue
@@ -13,7 +13,12 @@
 				@before-leave="beforeSlideLeave"
 				@leave="slideLeave"
 			>
-				<div :key="slideIndex" :style="slideStyles" @click="changeSlide(slideIndex + 1)">
+				<div
+					:key="slideIndex"
+					:style="slideStyles"
+					@click="changeSlide(slideIndex + 1)"
+					class="slide"
+				>
 					<component
 						v-for="(element, index) in slide.elements"
 						:key="index"
@@ -54,11 +59,11 @@ const slideCursor = ref('none')
 
 const slideStyles = computed(() => {
 	return {
-		width: '1440px',
-		height: '810px',
+		width: '960px',
+		height: '540px',
 		backgroundColor: slide.value.background || 'white',
 		cursor: slideCursor.value,
-		transform: transform.value,
+		transform: 'scale(1.5)',
 		transition: transition.value,
 		opacity: opacity.value,
 	}

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -1,7 +1,7 @@
 import { ref, computed, nextTick } from 'vue'
 import { call } from 'frappe-ui'
 
-import { slideFocus, slide } from './slide'
+import { slide } from './slide'
 
 import { guessTextColorFromBackground } from '../utils/color'
 
@@ -31,7 +31,6 @@ const setActiveElements = (ids, focus = false) => {
 		activeElementIds.value = ids
 		focusElementId.value = null
 	}
-	slideFocus.value = false
 }
 
 const addTextElement = () => {

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -141,6 +141,32 @@ const resetFocus = () => {
 	pairElementId.value = null
 }
 
+const toggleTextProperty = (property, value) => {
+	const oldStyle = activeElements.value[0][property]
+	let newStyle = ''
+
+	switch (property) {
+		case 'fontWeight':
+			newStyle = oldStyle == 'bold' ? 'normal' : 'bold'
+			break
+		case 'fontStyle':
+			newStyle = oldStyle == 'italic' ? 'normal' : 'italic'
+			break
+		case 'textTransform':
+			newStyle = oldStyle == 'uppercase' ? 'none' : 'uppercase'
+			break
+		default:
+			if (!oldStyle) {
+				newStyle = value
+				break
+			}
+			newStyle = oldStyle.includes(value)
+				? oldStyle.replace(value, '')
+				: oldStyle + ' ' + value
+	}
+	slide.value.elements[activeElementIds.value[0]][property] = newStyle
+}
+
 export {
 	activePosition,
 	activeDimensions,
@@ -155,4 +181,5 @@ export {
 	duplicateElements,
 	deleteElements,
 	selectAllElements,
+	toggleTextProperty,
 }

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -1,7 +1,7 @@
 import { ref, computed, nextTick } from 'vue'
 import { call } from 'frappe-ui'
 
-import { presentationId, presentation, applyReverseTransition } from './presentation'
+import { presentationId, presentation, applyReverseTransition, inSlideShow } from './presentation'
 import { activeElementIds, activePosition, resetFocus } from './element'
 
 import { isEqual } from 'lodash'
@@ -101,7 +101,7 @@ const changeSlide = async (index) => {
 	resetFocus()
 	applyReverseTransition.value = index < slideIndex.value
 	await nextTick(async () => {
-		await updateSlideState()
+		if (!inSlideShow.value) await updateSlideState()
 		slideIndex.value = index
 		loadSlide(slideIndex.value)
 	})

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -160,6 +160,13 @@ const duplicateSlide = async (e) => {
 	changeSlide(slideIndex.value + 1)
 }
 
+const selectSlide = (e) => {
+	e.preventDefault()
+	e.stopPropagation()
+	resetFocus()
+	slideFocus.value = true
+}
+
 export {
 	slideIndex,
 	slideDirty,
@@ -174,4 +181,5 @@ export {
 	insertSlide,
 	deleteSlide,
 	duplicateSlide,
+	selectSlide,
 }

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -66,6 +66,10 @@ const slideDirty = computed(() => {
 
 const getSlideThumbnail = async () => {
 	const slideRef = document.querySelector('.slide')
+	const scale = slideRef.getBoundingClientRect().width / 960
+	if (scale !== 1) {
+		return slide.value.thumbnail
+	}
 	const canvas = await html2canvas(slideRef)
 	return canvas.toDataURL('image/png')
 }

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -10,7 +10,6 @@ import html2canvas from 'html2canvas'
 const slideRect = ref(null)
 
 const slideIndex = ref(0)
-const slideFocus = ref(false)
 
 const slide = ref({
 	background: '#ffffff',
@@ -168,14 +167,12 @@ const selectSlide = (e) => {
 	e.preventDefault()
 	e.stopPropagation()
 	resetFocus()
-	slideFocus.value = true
 }
 
 export {
 	slideIndex,
 	slideDirty,
 	saving,
-	slideFocus,
 	slide,
 	slideRect,
 	getSlideThumbnail,

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -114,7 +114,7 @@ const saveChanges = async () => {
 	if (!presentation.data || !slideDirty.value) return
 	slide.value.elements = slide.value.elements.map((element, index) => {
 		let rect = document.querySelector(`[data-index="${index}"]`).getBoundingClientRect()
-		element.width = rect.width
+		element.width = rect.width / slideDimensions.scale
 		return element
 	})
 	saving.value = true

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -115,9 +115,8 @@ const saving = ref(false)
 const saveChanges = async () => {
 	if (!presentation.data || !slideDirty.value) return
 	slide.value.elements = slide.value.elements.map((element, index) => {
-		let div = document.querySelector(`[data-index="${index}"]`)
-		element.width = div.offsetWidth + 4
-		element.left -= 2
+		let rect = document.querySelector(`[data-index="${index}"]`).getBoundingClientRect()
+		element.width = rect.width
 		return element
 	})
 	saving.value = true

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -1,4 +1,4 @@
-import { ref, computed, nextTick } from 'vue'
+import { ref, computed, nextTick, reactive } from 'vue'
 import { call } from 'frappe-ui'
 
 import { presentationId, presentation, applyReverseTransition, inSlideShow } from './presentation'
@@ -6,8 +6,6 @@ import { activeElementIds, activePosition, resetFocus } from './element'
 
 import { isEqual } from 'lodash'
 import html2canvas from 'html2canvas'
-
-const slideRect = ref(null)
 
 const slideIndex = ref(0)
 
@@ -39,8 +37,8 @@ const getCurrentData = () => {
 	}
 
 	if (activePosition.value) {
-		const dx = activePosition.value.left - slideRect.value.left
-		const dy = activePosition.value.top - slideRect.value.top
+		const dx = activePosition.value.left - slideDimensions.left
+		const dy = activePosition.value.top - slideDimensions.top
 
 		const elementsCopy = JSON.parse(JSON.stringify(slide.value.elements))
 		elementsCopy.forEach((element, index) => {
@@ -168,12 +166,14 @@ const selectSlide = (e) => {
 	resetFocus()
 }
 
+const slideDimensions = reactive({})
+
 export {
 	slideIndex,
 	slideDirty,
 	saving,
 	slide,
-	slideRect,
+	slideDimensions,
 	getSlideThumbnail,
 	loadSlide,
 	saveChanges,

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -40,8 +40,8 @@ const getCurrentData = () => {
 	}
 
 	if (activePosition.value) {
-		const dx = activePosition.value.left - slideRect.value.left + 0.1
-		const dy = activePosition.value.top - slideRect.value.top + 2.1
+		const dx = activePosition.value.left - slideRect.value.left
+		const dy = activePosition.value.top - slideRect.value.top
 
 		const elementsCopy = JSON.parse(JSON.stringify(slide.value.elements))
 		elementsCopy.forEach((element, index) => {


### PR DESCRIPTION

### Fixes

- Reduce jitter while snapping to alignment and proximity guides.

   <details>
   <summary>Before</summary>
   <br>
  
   https://github.com/user-attachments/assets/4e5bf083-4265-4f94-a0e0-1c0d7eb44515
   
   <br>
   </details>

   <details>
   <summary>After</summary>
   <br>

   https://github.com/user-attachments/assets/04d9013f-d27e-4a27-b295-5877af90c60a
   
   <br>
   </details>


- When Slider Input range has negative values, highlight all values with respect to 0 instead of rangeStart.

   <details>
   <summary>Before</summary>
   <br>
 
   ![slider(before)](https://github.com/user-attachments/assets/40f7ceea-7993-4fa8-ade4-ef4ed375ba0d)

   <br>
   </details>

   <details>
   <summary>After</summary>
   <br>
 
   ![slider(after)](https://github.com/user-attachments/assets/db9fb8aa-2d11-4abb-8857-42271711ab48)

   <br>
   </details>

- Avoid unnecessary text overflow when enabling and disabling userSelect property for Text Elements.

   <details>
   <summary>Before</summary>
   <br>

   https://github.com/user-attachments/assets/edaec049-6af3-41ac-846d-3825313623c7

   <br>
   </details>

   <details>
   <summary>After</summary>
   <br>

   https://github.com/user-attachments/assets/734bf2be-3083-4452-a5b0-e2964331f69e

   <br>
   </details>

- Dimensions of Slide and correctly setting flag when entering and exiting Slideshow.

<br>

### UX
- Make the Element Properties Panel (ie. Right Sidebar) persistent. By default show the Slide properties when no active selection.
- When a Text element becomes editable, automatically place the cursor at the end of content.
- Change dirty state indicator in the Header to be less distracting.