### PR TITLE
fix: stale state after slide deletion

### DIFF
--- a/frontend/src/components/AlignmentGuides.vue
+++ b/frontend/src/components/AlignmentGuides.vue
@@ -13,12 +13,11 @@ import { useElementBounding } from '@vueuse/core'
 import { slide, slideDimensions } from '@/stores/slide'
 import { activePosition, activeElementIds, pairElementId } from '@/stores/element'
 
-const PROXIMITY_THRESHOLD = 15
-
-const activeDiv = computed(() => {
-	if (activeElementIds.value.length == 0) return
-	return document.querySelector('.groupDiv')
+const props = defineProps({
+	selectedRef: Object,
 })
+
+const PROXIMITY_THRESHOLD = 15
 
 const pairedDiv = computed(() => {
 	return document.querySelector(`[data-index="${pairElementId.value}"]`)
@@ -91,7 +90,7 @@ const commonGuideStyles = {
 const getVerticalGuideStyles = (direction) => {
 	if (!pairElement.value || !activePosition.value || !visibilityMap.value[direction]) return ''
 
-	const activeBounds = getElementBounds(activeDiv.value)
+	const activeBounds = getElementBounds(props.selectedRef)
 	const pairedBounds = getElementBounds(pairedDiv.value)
 
 	const left = direction == 'left' ? activeBounds.left - 1 : activeBounds.right
@@ -117,7 +116,7 @@ const rightGuideStyles = computed(() => getVerticalGuideStyles('right'))
 const getHorizontalGuideStyles = (direction, diffWithPaired) => {
 	if (!pairElement.value || !activePosition.value || !visibilityMap.value[direction]) return ''
 
-	const activeBounds = getElementBounds(activeDiv.value)
+	const activeBounds = getElementBounds(props.selectedRef)
 	const pairedBounds = getElementBounds(pairedDiv.value)
 
 	const top = direction == 'top' ? activeBounds.top - 1 : activeBounds.bottom
@@ -220,7 +219,7 @@ const getDiffFromCenter = (axis) => {
 	if (!activePosition.value) return
 	let slideCenter, elementCenter
 
-	const activeBounds = getElementBounds(activeDiv.value)
+	const activeBounds = getElementBounds(props.selectedRef)
 
 	if (axis == 'X') {
 		slideCenter = slideDimensions.width / slideDimensions.scale / 2
@@ -257,9 +256,9 @@ const setCurrentDiffs = () => {
 		if (activeElementIds.value.includes(index)) return
 
 		const elementDiv = document.querySelector(`[data-index="${index}"]`)
-		if (!elementDiv || !activeDiv.value) return
+		if (!elementDiv || !props.selectedRef) return
 
-		const activeBounds = getElementBounds(activeDiv.value)
+		const activeBounds = getElementBounds(props.selectedRef)
 		const elementBounds = getElementBounds(elementDiv)
 
 		const diffLeft = activeBounds.left - elementBounds.left

--- a/frontend/src/components/SelectionBox.vue
+++ b/frontend/src/components/SelectionBox.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-show="width" ref="groupDiv" class="groupDiv" :style="boxStyles"></div>
+	<div v-show="width" ref="selected" :style="boxStyles"></div>
 </template>
 
 <script setup>
@@ -15,7 +15,7 @@ import {
 
 const emit = defineEmits(['updateFocus'])
 
-const groupDiv = useTemplateRef('groupDiv')
+const selectedRef = useTemplateRef('selected')
 
 const top = ref(0)
 const left = ref(0)
@@ -183,7 +183,7 @@ const handleSelection = (val) => {
 	// move multiple elements to group div after setting position relative to the selection box
 	val.forEach((index) => {
 		const elementDiv = document.querySelector(`[data-index="${index}"]`)
-		groupDiv.value?.appendChild(elementDiv)
+		selectedRef.value?.appendChild(elementDiv)
 	})
 }
 
@@ -281,9 +281,5 @@ onBeforeUnmount(() => {
 	document.removeEventListener('mousedown', handleMouseDown)
 	document.removeEventListener('mouseleave', handleMouseLeave)
 	document.removeEventListener('mouseup', handleMouseUp)
-})
-
-defineExpose({
-	resetSelection,
 })
 </script>

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -94,7 +94,7 @@ const slideClasses = computed(() => {
 	const classes = ['slide', 'h-[540px]', 'w-[960px]', 'shadow-2xl']
 
 	const outlineClasses = props.highlight ? ['outline', 'outline-1.5', 'outline-blue-400'] : []
-	const shadowClasses = activeElementIds.value.length ? ['shadow-gray-300'] : []
+	const shadowClasses = activeElementIds.value.length ? ['shadow-gray-200'] : ['shadow-gray-400']
 	const cursorClasses = isDragging.value ? ['cursor-move'] : ['cursor-default']
 
 	return [...classes, outlineClasses, shadowClasses, cursorClasses]

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -160,10 +160,6 @@ watch(
 			addDragAndResize()
 		} else if (oldVal) {
 			removeDragAndResize(oldVal)
-
-			nextTick(async () => {
-				slide.value.thumbnail = await getSlideThumbnail()
-			})
 		}
 	},
 	{ immediate: true },
@@ -187,7 +183,7 @@ watch(
 	() => {
 		const currentSlide = presentation.data?.slides[slideIndex.value]
 		if (!currentSlide) return
-		loadSlide(currentSlide)
+		loadSlide()
 	},
 	{ immediate: true },
 )

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -2,9 +2,13 @@
 	<div ref="slideContainer" class="slideContainer flex items-center justify-center w-full h-full">
 		<div ref="target" :style="targetStyles">
 			<div ref="slideRef" :class="slideClasses" :style="slideStyles">
-				<SelectionBox @updateFocus="updateFocus" />
+				<SelectionBox ref="selectionBox" @updateFocus="updateFocus" />
 
-				<AlignmentGuides ref="guides" v-if="showGuides" />
+				<AlignmentGuides
+					v-if="showGuides"
+					ref="guides"
+					:selectedRef="selectionBoxRef.$el"
+				/>
 
 				<component
 					ref="element"
@@ -81,6 +85,7 @@ const router = useRouter()
 const slideContainerRef = useTemplateRef('slideContainer')
 const slideTargetRef = useTemplateRef('target')
 const slideRef = useTemplateRef('slideRef')
+const selectionBoxRef = useTemplateRef('selectionBox')
 const guides = useTemplateRef('guides')
 
 const { isDragging, dragTarget, movement } = useDragAndDrop()
@@ -119,7 +124,7 @@ const scale = computed(() => {
 })
 
 const addDragAndResize = () => {
-	let el = document.querySelector('.groupDiv')
+	let el = selectionBoxRef.value.$el
 	if (!el) return
 	nextTick(() => {
 		dragTarget.value = el

--- a/frontend/src/pages/Slideshow.vue
+++ b/frontend/src/pages/Slideshow.vue
@@ -13,7 +13,11 @@
 				@before-leave="beforeSlideLeave"
 				@leave="slideLeave"
 			>
-				<div :key="slideIndex" :style="slideStyles" @click="changeSlide(slideIndex + 1)">
+				<div
+					:key="slideIndex"
+					:style="slideStyles"
+					@click="changeSlide(slideIndex + 1, false)"
+				>
 					<component
 						v-for="(element, index) in slide.elements"
 						:key="index"
@@ -153,9 +157,9 @@ const handleFullScreenChange = async () => {
 
 const handleKeyDown = (e) => {
 	if (e.key == 'ArrowRight' || e.key == 'ArrowDown') {
-		changeSlide(slideIndex.value + 1)
+		changeSlide(slideIndex.value + 1, false)
 	} else if (e.key == 'ArrowLeft' || e.key == 'ArrowUp') {
-		changeSlide(slideIndex.value - 1)
+		changeSlide(slideIndex.value - 1, false)
 	}
 }
 
@@ -188,7 +192,7 @@ watch(
 
 		const currentSlide = presentation.data.slides[slideIndex.value]
 		if (!currentSlide) return
-		loadSlide(currentSlide)
+		loadSlide()
 	},
 	{ immediate: true },
 )

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -20,8 +20,8 @@ const slide = ref({
 })
 
 const getSavedData = () => {
-	if (!presentation.data) return {}
-	const currentSlide = presentation.data.slides[slideIndex.value]
+	const currentSlide = presentation.data?.slides[slideIndex.value]
+	if (!currentSlide) return {}
 
 	return {
 		elements: JSON.parse(currentSlide.elements || '[]'),
@@ -83,7 +83,7 @@ const updateSlideState = async () => {
 	}
 }
 
-const loadSlide = (index) => {
+const loadSlide = () => {
 	const { background, transition, transition_duration, elements, thumbnail } =
 		presentation.data.slides[slideIndex.value]
 
@@ -96,14 +96,15 @@ const loadSlide = (index) => {
 	}
 }
 
-const changeSlide = async (index) => {
+const changeSlide = async (index, updateCurrent = true) => {
 	if (index < 0 || index >= presentation.data.slides.length) return
 	resetFocus()
 	applyReverseTransition.value = index < slideIndex.value
-	await nextTick(async () => {
-		await updateSlideState()
+
+	nextTick(async () => {
+		if (updateCurrent) await updateSlideState()
 		slideIndex.value = index
-		loadSlide(slideIndex.value)
+		loadSlide()
 	})
 }
 
@@ -146,7 +147,11 @@ const deleteSlide = async () => {
 		index: slideIndex.value,
 	})
 	await presentation.reload()
-	await changeSlide(slideIndex.value - 1)
+	const newIndex =
+		slideIndex.value === presentation.data.slides.length
+			? slideIndex.value - 1
+			: slideIndex.value
+	await changeSlide(newIndex, false)
 }
 
 const duplicateSlide = async (e) => {

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -147,11 +147,8 @@ const deleteSlide = async () => {
 		index: slideIndex.value,
 	})
 	await presentation.reload()
-	const newIndex =
-		slideIndex.value === presentation.data.slides.length
-			? slideIndex.value - 1
-			: slideIndex.value
-	await changeSlide(newIndex, false)
+	if (slideIndex.value == presentation.data.slides.length)
+		await changeSlide(slideIndex.value - 1, false)
 }
 
 const duplicateSlide = async (e) => {


### PR DESCRIPTION
#### Changes
- After deletion of slide, correctly clear the stale values for it in the presentation object.
- Set the next visible slide to be the previous slide only when last slide is deleted. Otherwise show the slide on the same index which is next slide.