### PR TITLE
fix: navigate to editor when requestFullscreen not initiated by user gesture

### DIFF
--- a/frontend/src/components/PresentationHeader.vue
+++ b/frontend/src/components/PresentationHeader.vue
@@ -64,7 +64,7 @@ const renamePresentationDoc = async (newName) => {
 const saveTitle = async () => {
 	if (newTitle.value && newTitle.value != presentation.data.title) {
 		let nameSlug = await renamePresentationDoc(newTitle.value)
-		await router.push({
+		router.replace({
 			name: 'PresentationEditor',
 			params: { presentationId: nameSlug },
 		})

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -57,16 +57,15 @@ const presentationList = createResource({
 	auto: true,
 })
 
-const navigateToPresentation = async (name, present) => {
+const navigateToPresentation = (name, present) => {
 	name = name || previewPresentation.value.name
 	if (present) {
-		await router.push({
+		router.replace({
 			name: 'Slideshow',
 			params: { presentationId: name },
-			query: { present: true },
 		})
 	} else {
-		await router.push({
+		router.push({
 			name: 'PresentationEditor',
 			params: { presentationId: name },
 		})

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -221,7 +221,6 @@ const startSlideShow = async () => {
 	router.replace({
 		name: 'Slideshow',
 		params: { presentationId: presentationId.value },
-		query: { present: true },
 	})
 }
 

--- a/frontend/src/pages/Slideshow.vue
+++ b/frontend/src/pages/Slideshow.vue
@@ -153,7 +153,7 @@ const handleFullScreenChange = () => {
 		slideContainerRef.value.addEventListener('mousemove', resetCursorVisibility)
 	} else {
 		slideContainerRef.value.removeEventListener('mousemove', resetCursorVisibility)
-		router.replace({ name: 'PresentationEditor', query: null })
+		router.replace({ name: 'PresentationEditor' })
 	}
 }
 
@@ -179,7 +179,9 @@ const initFullscreenMode = async () => {
 	const fullscreenMethod = fullscreenMethods.find((method) => method)
 
 	if (fullscreenMethod) {
-		fullscreenMethod.call(container)
+		fullscreenMethod.call(container).catch((e) => {
+			router.replace({ name: 'PresentationEditor' })
+		})
 		inSlideShow.value = true
 	}
 }

--- a/frontend/src/pages/Slideshow.vue
+++ b/frontend/src/pages/Slideshow.vue
@@ -165,23 +165,22 @@ const handleKeyDown = (e) => {
 	}
 }
 
-const startSlideShow = async () => {
-	const elem = slideContainerRef.value
+const initFullscreenMode = async () => {
+	const container = slideContainerRef.value
+	if (!container) return
 
-	if (elem.requestFullscreen) {
-		elem.requestFullscreen()
-	} else if (elem.webkitRequestFullscreen) {
-		elem.webkitRequestFullscreen()
-	} else if (elem.msRequestFullscreen) {
-		elem.msRequestFullscreen()
-	}
-}
+	const fullscreenMethods = [
+		container.requestFullscreen,
+		container.webkitRequestFullscreen, // Safari
+		container.msRequestFullscreen, // IE
+		container.mozRequestFullScreen, // Firefox
+	]
 
-const initPresentMode = async () => {
-	const present = route.query.present
-	if (present) {
-		present && (await startSlideShow())
-		inSlideShow.value = present
+	const fullscreenMethod = fullscreenMethods.find((method) => method)
+
+	if (fullscreenMethod) {
+		fullscreenMethod.call(container)
+		inSlideShow.value = true
 	}
 }
 
@@ -200,7 +199,7 @@ watch(
 )
 
 onMounted(async () => {
-	await initPresentMode()
+	await initFullscreenMode()
 	document.addEventListener('keydown', handleKeyDown)
 	document.addEventListener('fullscreenchange', handleFullScreenChange)
 })


### PR DESCRIPTION
#### Changes
Since entering the Fullscreen mode using requestFullscreen API requires [Transient Activation](https://developer.mozilla.org/en-US/docs/Web/Security/User_activation#transient_activation) to trigger as part of the [security requirements](https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullscreen#security) for this feature to work, navigate back to the Presentation Editor whenever the Slideshow Page is mounted without a previous UI click or if the element fails to enter the fullscreen mode due to some other reason (since the trigger will have to take place again from the Editor itself in order to fulfill the security check).