### PR TITLE
fix: element incorrectly inheriting styles

### DIFF
--- a/frontend/src/components/AlignmentGuides.vue
+++ b/frontend/src/components/AlignmentGuides.vue
@@ -67,9 +67,6 @@ const visibilityMap = computed(() => {
 	}
 })
 
-// when an element is snapped to a new position, enable movement after a few frames
-const skipFrames = ref(0)
-
 const guideStyles = computed(() => {
 	return {
 		left: leftGuideStyles.value,
@@ -289,7 +286,9 @@ const updatePrevDiffs = () => {
 	prevDiffs.value = JSON.parse(JSON.stringify(diffs.value))
 }
 
-const updateMovementBasedOnSnap = (dx, dy) => {
+const getMovementBasedOnSnap = (initialPosition) => {
+	const { dx, dy } = initialPosition
+
 	setCurrentDiffs()
 
 	const { offsetX, offsetY } = getCenterOffsets(dx, dy)
@@ -301,29 +300,10 @@ const updateMovementBasedOnSnap = (dx, dy) => {
 	const updatedDx = dx + offsetX + offsetLeft
 	const updatedDy = dy + offsetY + offsetTop
 
-	return { updatedDx, updatedDy }
-}
-
-const updateElementPosition = (dx, dy) => {
-	if (!activePosition.value) return
-
-	const { updatedDx, updatedDy } = updateMovementBasedOnSnap(dx, dy)
-
-	const didSnap = dx != updatedDx || dy != updatedDy
-
-	if (!skipFrames.value)
-		activePosition.value = {
-			left: activePosition.value.left + updatedDx,
-			top: activePosition.value.top + updatedDy,
-		}
-	else skipFrames.value -= 1
-
-	if (didSnap) {
-		skipFrames.value = 15
-	}
+	return { dx: updatedDx, dy: updatedDy }
 }
 
 defineExpose({
-	updateElementPosition,
+	getMovementBasedOnSnap,
 })
 </script>

--- a/frontend/src/components/AlignmentGuides.vue
+++ b/frontend/src/components/AlignmentGuides.vue
@@ -26,7 +26,7 @@ const pairedDiv = computed(() => {
 const pairedRect = useElementBounding(pairedDiv)
 
 const pairElement = computed(() => {
-	return slide.value.elements[pairElementId.value]
+	return slide.value.elements.find((element) => element.id == pairElementId.value)
 })
 
 const prevDiffs = ref({
@@ -252,10 +252,10 @@ const canElementPair = (diffLeft, diffRight, diffTop, diffBottom) => {
 }
 
 const setCurrentDiffs = () => {
-	slide.value.elements.forEach((element, index) => {
-		if (activeElementIds.value.includes(index)) return
+	slide.value.elements.forEach((element) => {
+		if (activeElementIds.value.includes(element.id)) return
 
-		const elementDiv = document.querySelector(`[data-index="${index}"]`)
+		const elementDiv = document.querySelector(`[data-index="${element.id}"]`)
 		if (!elementDiv || !props.selectedRef) return
 
 		const activeBounds = getElementBounds(props.selectedRef)
@@ -267,10 +267,10 @@ const setCurrentDiffs = () => {
 		const diffBottom = activeBounds.bottom - elementBounds.bottom
 
 		const canPair = canElementPair(diffLeft, diffRight, diffTop, diffBottom)
-		const isPaired = pairElementId.value == index
+		const isPaired = pairElementId.value == element.id
 
 		if (canPair) {
-			pairElementId.value = index
+			pairElementId.value = element.id
 		} else if (isPaired) {
 			pairElementId.value = null
 		}

--- a/frontend/src/components/AlignmentGuides.vue
+++ b/frontend/src/components/AlignmentGuides.vue
@@ -268,14 +268,14 @@ const setCurrentDiffs = () => {
 
 		if (canPair) {
 			pairElementId.value = element.id
+
+			diffs.value.left = diffLeft
+			diffs.value.right = diffRight
+			diffs.value.top = diffTop
+			diffs.value.bottom = diffBottom
 		} else if (isPaired) {
 			pairElementId.value = null
 		}
-
-		diffs.value.left = diffLeft
-		diffs.value.right = diffRight
-		diffs.value.top = diffTop
-		diffs.value.bottom = diffBottom
 	})
 
 	diffs.value.centerX = getDiffFromCenter('X')

--- a/frontend/src/components/AlignmentGuides.vue
+++ b/frontend/src/components/AlignmentGuides.vue
@@ -10,7 +10,7 @@
 import { ref, computed } from 'vue'
 import { useElementBounding } from '@vueuse/core'
 
-import { slide, slideDimensions } from '@/stores/slide'
+import { slide, slideBounds } from '@/stores/slide'
 import { activePosition, activeElementIds, pairElementId } from '@/stores/element'
 
 const props = defineProps({
@@ -159,8 +159,8 @@ const centerYGuideStyles = computed(() => {
 })
 
 const getScaledValue = (value, axis) => {
-	if (axis == 'X') return (value - slideDimensions.left) / slideDimensions.scale
-	return (value - slideDimensions.top) / slideDimensions.scale
+	if (axis == 'X') return (value - slideBounds.left) / slideBounds.scale
+	return (value - slideBounds.top) / slideBounds.scale
 }
 
 const getElementBounds = (div) => {
@@ -170,8 +170,8 @@ const getElementBounds = (div) => {
 		top: getScaledValue(rect.top, 'Y'),
 		right: getScaledValue(rect.right, 'X'),
 		bottom: getScaledValue(rect.bottom, 'Y'),
-		height: rect.height / slideDimensions.scale,
-		width: rect.width / slideDimensions.scale,
+		height: rect.height / slideBounds.scale,
+		width: rect.width / slideBounds.scale,
 	}
 }
 
@@ -219,10 +219,10 @@ const getDiffFromCenter = (axis) => {
 	const activeBounds = getElementBounds(props.selectedRef)
 
 	if (axis == 'X') {
-		slideCenter = slideDimensions.width / slideDimensions.scale / 2
+		slideCenter = slideBounds.width / slideBounds.scale / 2
 		elementCenter = activeBounds.left + activeBounds.width / 2
 	} else {
-		slideCenter = slideDimensions.height / slideDimensions.scale / 2
+		slideCenter = slideBounds.height / slideBounds.scale / 2
 		elementCenter = activeBounds.top + activeBounds.height / 2
 	}
 

--- a/frontend/src/components/AlignmentGuides.vue
+++ b/frontend/src/components/AlignmentGuides.vue
@@ -275,6 +275,11 @@ const setCurrentDiffs = () => {
 			diffs.value.bottom = diffBottom
 		} else if (isPaired) {
 			pairElementId.value = null
+
+			diffs.value.left = null
+			diffs.value.right = null
+			diffs.value.top = null
+			diffs.value.bottom = null
 		}
 	})
 

--- a/frontend/src/components/AlignmentGuides.vue
+++ b/frontend/src/components/AlignmentGuides.vue
@@ -60,10 +60,10 @@ const visibilityMap = computed(() => {
 	return {
 		centerX: Math.abs(diffs.value.centerX) < PROXIMITY_THRESHOLD,
 		centerY: Math.abs(diffs.value.centerY) < PROXIMITY_THRESHOLD,
-		left: Math.abs(diffs.value.left) < PROXIMITY_THRESHOLD,
-		right: Math.abs(diffs.value.right) < PROXIMITY_THRESHOLD,
-		top: Math.abs(diffs.value.top) < PROXIMITY_THRESHOLD,
-		bottom: Math.abs(diffs.value.bottom) < PROXIMITY_THRESHOLD,
+		left: Math.abs(diffs.value.left) < 5,
+		right: Math.abs(diffs.value.right) < 5,
+		top: Math.abs(diffs.value.top) < 5,
+		bottom: Math.abs(diffs.value.bottom) < 5,
 	}
 })
 

--- a/frontend/src/components/ImageElement.vue
+++ b/frontend/src/components/ImageElement.vue
@@ -3,12 +3,10 @@
 </template>
 
 <script setup>
-import { computed, useAttrs } from 'vue'
+import { computed } from 'vue'
 
 import { setActiveElements } from '@/stores/element'
 import { inSlideShow } from '@/stores/presentation'
-
-const attrs = useAttrs()
 
 const element = defineModel('element', {
 	type: Object,
@@ -28,6 +26,6 @@ const imageStyle = computed(() => ({
 
 const selectImage = (e) => {
 	if (inSlideShow.value) return
-	setActiveElements([attrs['data-index']])
+	setActiveElements([element.value.id])
 }
 </script>

--- a/frontend/src/components/SelectionBox.vue
+++ b/frontend/src/components/SelectionBox.vue
@@ -15,7 +15,7 @@ import {
 	inject,
 } from 'vue'
 
-import { slide, slideDimensions } from '@/stores/slide'
+import { slide, slideBounds } from '@/stores/slide'
 import {
 	activePosition,
 	activeDimensions,
@@ -60,8 +60,8 @@ const boxStyles = computed(() => ({
 const initSelection = (e) => {
 	activeElementIds.value = []
 	nextTick(() => {
-		const currentX = (e.clientX - slideDimensions.left) / slideDimensions.scale
-		const currentY = (e.clientY - slideDimensions.top) / slideDimensions.scale
+		const currentX = (e.clientX - slideBounds.left) / slideBounds.scale
+		const currentY = (e.clientY - slideBounds.top) / slideBounds.scale
 
 		bounds.left = currentX
 		bounds.top = currentY
@@ -77,8 +77,8 @@ const initSelection = (e) => {
 }
 
 const updateSelection = (e) => {
-	const currentX = (e.clientX - slideDimensions.left) / slideDimensions.scale
-	const currentY = (e.clientY - slideDimensions.top) / slideDimensions.scale
+	const currentX = (e.clientX - slideBounds.left) / slideBounds.scale
+	const currentY = (e.clientY - slideBounds.top) / slideBounds.scale
 
 	bounds.width = Math.abs(currentX - startX.value)
 	bounds.height = Math.abs(currentY - startY.value)
@@ -109,10 +109,10 @@ const getElementsWithinBoxSurface = () => {
 			.querySelector(`[data-index="${element.id}"]`)
 			.getBoundingClientRect()
 
-		const elementLeft = (elementRect.left - slideDimensions.left) / slideDimensions.scale
-		const elementTop = (elementRect.top - slideDimensions.top) / slideDimensions.scale
-		const elementRight = elementLeft + elementRect.width / slideDimensions.scale
-		const elementBottom = elementTop + elementRect.height / slideDimensions.scale
+		const elementLeft = (elementRect.left - slideBounds.left) / slideBounds.scale
+		const elementTop = (elementRect.top - slideBounds.top) / slideBounds.scale
+		const elementRight = elementLeft + elementRect.width / slideBounds.scale
+		const elementBottom = elementTop + elementRect.height / slideBounds.scale
 
 		const withinWidth =
 			(boxRight >= elementLeft && boxLeft <= elementLeft) ||
@@ -156,10 +156,10 @@ const cropSelectionToFitContent = (elementIds) => {
 	elementIds.forEach((id) => {
 		const elementRect = document.querySelector(`[data-index="${id}"]`).getBoundingClientRect()
 
-		const elementLeft = (elementRect.left - slideDimensions.left) / slideDimensions.scale
-		const elementTop = (elementRect.top - slideDimensions.top) / slideDimensions.scale
-		const elementRight = elementLeft + elementRect.width / slideDimensions.scale
-		const elementBottom = elementTop + elementRect.height / slideDimensions.scale
+		const elementLeft = (elementRect.left - slideBounds.left) / slideBounds.scale
+		const elementTop = (elementRect.top - slideBounds.top) / slideBounds.scale
+		const elementRight = elementLeft + elementRect.width / slideBounds.scale
+		const elementBottom = elementTop + elementRect.height / slideBounds.scale
 
 		if (elementLeft < l) l = elementLeft
 		if (elementTop < t) t = elementTop

--- a/frontend/src/components/SelectionBox.vue
+++ b/frontend/src/components/SelectionBox.vue
@@ -88,9 +88,9 @@ const getElementsWithinBoxSurface = () => {
 	const boxRight = left.value + width.value
 	const boxBottom = top.value + height.value
 
-	slide.value.elements.forEach((element, index) => {
+	slide.value.elements.forEach((element) => {
 		const elementRect = document
-			.querySelector(`[data-index="${index}"]`)
+			.querySelector(`[data-index="${element.id}"]`)
 			.getBoundingClientRect()
 
 		const elementLeft = (elementRect.left - slideDimensions.left) / slideDimensions.scale
@@ -107,7 +107,7 @@ const getElementsWithinBoxSurface = () => {
 			(elementBottom >= boxTop && elementTop <= boxTop)
 
 		if (withinWidth && withinHeight) {
-			elements.push(index)
+			elements.push(element.id)
 		}
 	})
 
@@ -137,11 +137,8 @@ const cropSelectionToFitContent = () => {
 		b = 0
 
 	// crop selection to selected element edges
-	activeElementIds.value.forEach((index) => {
-		const element = slide.value.elements[index]
-		const elementRect = document
-			.querySelector(`[data-index="${index}"]`)
-			.getBoundingClientRect()
+	activeElementIds.value.forEach((id) => {
+		const elementRect = document.querySelector(`[data-index="${id}"]`).getBoundingClientRect()
 
 		const elementLeft = (elementRect.left - slideDimensions.left) / slideDimensions.scale
 		const elementTop = (elementRect.top - slideDimensions.top) / slideDimensions.scale
@@ -167,10 +164,13 @@ const setElementPositions = () => {
 	}
 
 	// set positions relative to the selection box
-	activeElementIds.value.forEach((index) => {
-		let element = slide.value.elements[index]
-		element.left = element.left - left.value
-		element.top = element.top - top.value
+	activeElementIds.value.forEach((id) => {
+		slide.value.elements.forEach((element) => {
+			if (element.id == id) {
+				element.left = element.left - left.value
+				element.top = element.top - top.value
+			}
+		})
 	})
 }
 
@@ -193,7 +193,7 @@ const resetSelection = (oldVal) => {
 			let elementDiv = document.querySelector(`[data-index="${index}"]`)
 			if (!elementDiv) return
 
-			let element = slide.value.elements[index]
+			let element = slide.value.elements.find((el) => el.id == index)
 			element.left = element.left + left.value
 			element.top = element.top + top.value
 

--- a/frontend/src/components/SelectionBox.vue
+++ b/frontend/src/components/SelectionBox.vue
@@ -11,6 +11,7 @@ import {
 	activeDimensions,
 	activeElementIds,
 	setActiveElements,
+	moveElement,
 } from '@/stores/element'
 
 const emit = defineEmits(['updateFocus'])
@@ -166,10 +167,11 @@ const setElementPositions = () => {
 	// set positions relative to the selection box
 	activeElementIds.value.forEach((id) => {
 		slide.value.elements.forEach((element) => {
-			if (element.id == id) {
-				element.left = element.left - left.value
-				element.top = element.top - top.value
-			}
+			if (element.id != id) return
+			moveElement(id, {
+				dx: -left.value,
+				dy: -top.value,
+			})
 		})
 	})
 }
@@ -193,9 +195,10 @@ const resetSelection = (oldVal) => {
 			let elementDiv = document.querySelector(`[data-index="${index}"]`)
 			if (!elementDiv) return
 
-			let element = slide.value.elements.find((el) => el.id == index)
-			element.left = element.left + left.value
-			element.top = element.top + top.value
+			moveElement(index, {
+				dx: left.value,
+				dy: top.value,
+			})
 
 			let slideDiv = document.querySelector('.slide')
 			slideDiv.appendChild(elementDiv)

--- a/frontend/src/components/SelectionBox.vue
+++ b/frontend/src/components/SelectionBox.vue
@@ -12,6 +12,7 @@ import {
 	onMounted,
 	onBeforeUnmount,
 	reactive,
+	inject,
 } from 'vue'
 
 import { slide, slideDimensions } from '@/stores/slide'
@@ -24,6 +25,9 @@ import {
 } from '@/stores/element'
 
 const emit = defineEmits(['updateFocus'])
+
+const slideDiv = inject('slideDiv')
+const slideContainerDiv = inject('slideContainerDiv')
 
 const selectedRef = useTemplateRef('selected')
 
@@ -177,7 +181,7 @@ const resetSelection = (oldVal) => {
 const handleMouseDown = (e) => {
 	// ignore long press outside slideContainer and slide elements
 	if (
-		!['slide', 'slideContainer'].some((cls) => e.target.classList.contains(cls)) &&
+		![slideDiv.value, slideContainerDiv.value].includes(e.target) &&
 		!e.target.hasAttribute('data-index')
 	)
 		return
@@ -210,8 +214,7 @@ const handleMouseUp = (e) => {
 const moveElementsToSlide = (elementIds) => {
 	elementIds.forEach((elementId) => {
 		let elementDiv = document.querySelector(`[data-index="${elementId}"]`)
-		let slideDiv = document.querySelector('.slide')
-		slideDiv.appendChild(elementDiv)
+		slideDiv.value.appendChild(elementDiv)
 		moveElement(elementId, {
 			dx: bounds.left,
 			dy: bounds.top,

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -10,13 +10,11 @@
 					:selectedRef="selectionBoxRef.$el"
 				/>
 
-				<component
-					ref="element"
-					v-for="(element, index) in slide.elements"
-					:key="index"
-					:is="SlideElement"
+				<SlideElement
+					v-for="element in slide.elements"
+					:key="element.id"
 					:element="element"
-					:data-index="index"
+					:data-index="element.id"
 				/>
 			</div>
 
@@ -176,10 +174,8 @@ watch(
 	() => focusElementId.value,
 	(newVal, oldVal) => {
 		if (oldVal) {
-			let element = slide.value.elements[oldVal]
-			slide.value.elements[oldVal].content = document.querySelector(
-				`[data-index="${oldVal}"]`,
-			).innerText
+			let element = slide.value.elements.find((el) => el.id == oldVal)
+			element.content = document.querySelector(`[data-index="${oldVal}"]`).innerText
 		}
 	},
 	{ immediate: true },
@@ -210,7 +206,8 @@ watch(
 	() => activeDimensions.value,
 	(dimensions) => {
 		if (!dimensions) return
-		let element = slide.value.elements[activeElementIds.value[0]]
+		const id = activeElementIds.value[0]
+		let element = slide.value.elements.find((el) => el.id == id)
 		if (element && dimensions.width != element.width) {
 			const newWidth = dimensions.width / scale.value
 			element.width = newWidth

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -69,6 +69,7 @@ import {
 	pairElementId,
 	resetFocus,
 	updateActivePosition,
+	setActivePosition,
 } from '@/stores/element'
 
 import { useDragAndDrop } from '@/utils/drag'
@@ -128,10 +129,10 @@ const addDragAndResize = () => {
 	nextTick(() => {
 		dragTarget.value = el
 		const { left, top } = selectionBoxRef.value.getBoxBounds()
-		activePosition.value = {
+		setActivePosition({
 			left: left + slideDimensions.left,
 			top: top + slideDimensions.top,
-		}
+		})
 	})
 	if (activeElementIds.value.length == 1) {
 		resizeTarget.value = document.querySelector(`[data-index="${activeElementIds.value[0]}"]`)
@@ -140,7 +141,7 @@ const addDragAndResize = () => {
 }
 
 const removeDragAndResize = (val) => {
-	activePosition.value = null
+	setActivePosition(null)
 	activeDimensions.value = null
 	dragTarget.value = null
 	resizeTarget.value = null

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -58,7 +58,7 @@ import {
 	loadSlide,
 	selectSlide,
 	getSlideThumbnail,
-	slideDimensions,
+	slideBounds,
 } from '@/stores/slide'
 import {
 	activePosition,
@@ -136,14 +136,14 @@ const updateFocus = (e) => {
 	selectSlide(e)
 }
 
-const updateSlideDimensions = () => {
+const updateSlideBounds = () => {
 	const slideRect = slideRef.value.getBoundingClientRect()
 
-	slideDimensions.width = slideRect.width
-	slideDimensions.height = slideRect.height
-	slideDimensions.left = slideRect.left
-	slideDimensions.top = slideRect.top
-	slideDimensions.scale = scale.value
+	slideBounds.width = slideRect.width
+	slideBounds.height = slideRect.height
+	slideBounds.left = slideRect.left
+	slideBounds.top = slideRect.top
+	slideBounds.scale = scale.value
 }
 
 const handleDimensionChange = (dimensions) => {
@@ -169,8 +169,8 @@ const initDraggable = () => {
 	// set initial position of the selection box
 	const { left, top } = selectionBoxRef.value.getBoxBounds()
 	setActivePosition({
-		left: left + slideDimensions.left,
-		top: top + slideDimensions.top,
+		left: left + slideBounds.left,
+		top: top + slideBounds.top,
 	})
 }
 
@@ -223,8 +223,8 @@ const applyMovement = (positionChange) => {
 
 	// update selection box position to match the element
 	selectionBoxRef.value.setBoxBounds({
-		left: activePosition.value.left - slideDimensions.left,
-		top: activePosition.value.top - slideDimensions.top,
+		left: activePosition.value.left - slideBounds.left,
+		top: activePosition.value.top - slideBounds.top,
 	})
 }
 
@@ -287,7 +287,7 @@ watch(
 		if (!transform.value) return
 		// wait for the new transform to render before updating dimensions
 		nextTick(() => {
-			updateSlideDimensions()
+			updateSlideBounds()
 		})
 	},
 )
@@ -304,7 +304,7 @@ watch(
 
 onMounted(() => {
 	if (!slideRef.value) return
-	updateSlideDimensions()
+	updateSlideBounds()
 })
 
 provide('slideDiv', slideRef)

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -292,16 +292,6 @@ watch(
 	},
 )
 
-watch(
-	() => presentation.data,
-	() => {
-		const currentSlide = presentation.data?.slides[slideIndex.value]
-		if (!currentSlide) return
-		loadSlide()
-	},
-	{ immediate: true },
-)
-
 onMounted(() => {
 	if (!slideRef.value) return
 	updateSlideBounds()

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -70,6 +70,7 @@ import {
 	resetFocus,
 	updateActivePosition,
 	setActivePosition,
+	resizeElement,
 } from '@/stores/element'
 
 import { useDragAndDrop } from '@/utils/drag'
@@ -165,6 +166,19 @@ const updateSlideDimensions = () => {
 	slideDimensions.scale = scale.value
 }
 
+const handleDimensionChange = (dimensions) => {
+	const elementId = activeElementIds.value[0]
+
+	// update element dimensions in slide object
+	resizeElement(elementId, dimensions)
+
+	// update selection box dimensions to match the element
+	selectionBoxRef.value.setBoxBounds({
+		width: dimensions.width,
+		height: dimensions.height,
+	})
+}
+
 watch(
 	() => activeElementIds.value,
 	(newVal, oldVal) => {
@@ -240,16 +254,7 @@ watch(
 	() => activeDimensions.value,
 	(dimensions) => {
 		if (!dimensions) return
-		const id = activeElementIds.value[0]
-		let element = slide.value.elements.find((el) => el.id == id)
-		if (element && dimensions.width != element.width) {
-			const newWidth = dimensions.width / scale.value
-			element.width = newWidth
-		}
-		selectionBoxRef.value.setBoxBounds({
-			width: dimensions.width,
-			height: dimensions.height,
-		})
+		handleDimensionChange(dimensions)
 	},
 )
 

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -39,7 +39,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, useTemplateRef, nextTick, onMounted } from 'vue'
+import { ref, computed, watch, useTemplateRef, nextTick, onMounted, provide } from 'vue'
 import { useRouter } from 'vue-router'
 import { useElementBounding } from '@vueuse/core'
 
@@ -230,7 +230,7 @@ watch(
 		} else delayPositionUpdates.value -= 1
 
 		if (didSnap) {
-			delayPositionUpdates.value = 15
+			delayPositionUpdates.value = DELAY_COUNT
 		}
 	},
 )
@@ -267,6 +267,9 @@ onMounted(() => {
 	if (!slideRef.value) return
 	updateSlideDimensions()
 })
+
+provide('slideDiv', slideRef)
+provide('slideContainerDiv', slideContainerRef)
 </script>
 
 <style src="../assets/styles/resizer.css"></style>

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -81,7 +81,8 @@ const props = defineProps({
 	highlight: Boolean,
 })
 
-const POSITION_UPDATE_DELAY = 15
+let recentlySnapped = false
+let snapTimer = null
 
 const router = useRouter()
 
@@ -237,15 +238,18 @@ const handlePositionChange = (movement) => {
 
 	const isElementSnapped = hasSnapped(positionChange, snapPositionChange)
 
-	if (!delayPositionUpdates.value) {
-		applyMovement(snapPositionChange)
-	} else {
-		// delay position updates right after snapping
-		delayPositionUpdates.value -= 1
+	if (!recentlySnapped) {
+		requestAnimationFrame(() => {
+			applyMovement(snapPositionChange)
+		})
 	}
 
 	if (isElementSnapped) {
-		delayPositionUpdates.value = POSITION_UPDATE_DELAY
+		recentlySnapped = true
+		clearTimeout(snapTimer)
+		snapTimer = setTimeout(() => {
+			recentlySnapped = false
+		}, 300)
 	}
 }
 

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -68,6 +68,7 @@ import {
 	focusElementId,
 	pairElementId,
 	resetFocus,
+	updateActivePosition,
 } from '@/stores/element'
 
 import { useDragAndDrop } from '@/utils/drag'
@@ -191,6 +192,10 @@ watch(
 	{ immediate: true },
 )
 
+const DELAY_COUNT = 15
+
+const delayPositionUpdates = ref(0)
+
 watch(
 	() => movement.value,
 	() => {
@@ -198,7 +203,26 @@ watch(
 
 		const { x, y } = movement.value
 
-		guides.value.updateElementPosition(x / scale.value, y / scale.value)
+		const initialPosition = {
+			dx: x / scale.value,
+			dy: y / scale.value,
+		}
+
+		const snappedPosition = guides.value.getMovementBasedOnSnap(initialPosition)
+
+		const didSnap =
+			initialPosition.dx != snappedPosition.dx || initialPosition.dy != snappedPosition.dy
+
+		if (!delayPositionUpdates.value)
+			updateActivePosition({
+				dx: snappedPosition.dx,
+				dy: snappedPosition.dy,
+			})
+		else delayPositionUpdates.value -= 1
+
+		if (didSnap) {
+			delayPositionUpdates.value = 15
+		}
 	},
 )
 

--- a/frontend/src/components/SlideElement.vue
+++ b/frontend/src/components/SlideElement.vue
@@ -1,11 +1,11 @@
 <template>
 	<div :style="elementStyle">
-		<component :is="getDynamicComponent(element.type)" :element="element" v-bind="$attrs" />
+		<component :is="getDynamicComponent(element.type)" :element="element" />
 	</div>
 </template>
 
 <script setup>
-import { computed, useAttrs } from 'vue'
+import { computed } from 'vue'
 
 import TextElement from '@/components/TextElement.vue'
 import ImageElement from '@/components/ImageElement.vue'
@@ -13,22 +13,20 @@ import VideoElement from '@/components/VideoElement.vue'
 
 import { activeElementIds, pairElementId, focusElementId } from '@/stores/element'
 
-const attrs = useAttrs()
-
 const element = defineModel('element', {
 	type: Object,
 	default: null,
 })
 
 const outline = computed(() => {
-	if (activeElementIds.value.concat([focusElementId.value]).includes(attrs['data-index']))
+	if (activeElementIds.value.concat([focusElementId.value]).includes(element.value.id))
 		return '#70B6F0 solid 2px'
-	else if (pairElementId.value == attrs['data-index']) return '#70b6f080 solid 2px'
+	else if (pairElementId.value === element.value.id) return '#70b6f080 solid 2px'
 	else return 'none'
 })
 
 const elementStyle = computed(() => ({
-	position: activeElementIds.value.includes(attrs['data-index']) ? 'absolute' : 'fixed',
+	position: activeElementIds.value.includes(element.value.id) ? 'absolute' : 'fixed',
 	width: `${element.value.width}px` || 'auto',
 	height: 'auto',
 	left: `${element.value.left}px`,

--- a/frontend/src/components/TextElement.vue
+++ b/frontend/src/components/TextElement.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		class="focus:outline-none"
-		:contenteditable="focusElementId == $attrs['data-index']"
+		:contenteditable="focusElementId == element.id"
 		:style="textStyle"
 		@click="selectElement"
 		@focus="setCursorPosition"
@@ -12,13 +12,11 @@
 </template>
 
 <script setup>
-import { computed, nextTick, useAttrs } from 'vue'
+import { computed, nextTick } from 'vue'
 
 import { inSlideShow } from '@/stores/presentation'
 import { focusElementId, setActiveElements } from '@/stores/element'
 import { handleSingleAndDoubleClick } from '@/utils/helpers'
-
-const attrs = useAttrs()
 
 const element = defineModel('element', {
 	type: Object,
@@ -33,14 +31,14 @@ const textStyle = computed(() => ({
 	fontStyle: element.value.fontStyle,
 	textDecoration: element.value.textDecoration,
 	textTransform: element.value.textTransform,
-	userSelect: focusElementId.value == attrs['data-index'] ? 'text' : 'none',
+	userSelect: focusElementId.value == element.value.id ? 'text' : 'none',
 	opacity: element.value.opacity / 100,
 	lineHeight: element.value.lineHeight,
 	letterSpacing: `${element.value.letterSpacing}px`,
 	wordWrap: 'break-word',
 	textAlign: element.value.textAlign,
 	color: element.value.color,
-	cursor: focusElementId.value == attrs['data-index'] ? 'text' : '',
+	cursor: focusElementId.value == element.value.id ? 'text' : '',
 }))
 
 const selectElement = (e) => {
@@ -50,14 +48,14 @@ const selectElement = (e) => {
 
 const setActiveText = (e) => {
 	e.stopPropagation()
-	if (focusElementId.value == attrs['data-index']) return
-	setActiveElements([attrs['data-index']])
+	if (focusElementId.value == element.value.id) return
+	setActiveElements([element.value.id])
 }
 
 const setFocusElement = (e) => {
 	e.stopPropagation()
-	if (focusElementId.value == attrs['data-index']) return
-	setActiveElements([attrs['data-index']], true)
+	if (focusElementId.value == element.value.id) return
+	setActiveElements([element.value.id], true)
 	nextTick(() => {
 		e.target.focus()
 	})

--- a/frontend/src/components/VideoElement.vue
+++ b/frontend/src/components/VideoElement.vue
@@ -9,7 +9,7 @@
 			:playbackRate="element.playbackRate"
 		/>
 		<div
-			v-if="activeElementIds.includes($attrs['data-index'])"
+			v-if="activeElementIds.includes(element.id)"
 			class="absolute left-[calc(50%-12px)] top-[calc(50%-12px)] flex h-6 w-6 cursor-pointer items-center justify-center rounded bg-blue-400"
 		>
 			<component
@@ -22,14 +22,12 @@
 </template>
 
 <script setup>
-import { ref, computed, useTemplateRef, useAttrs } from 'vue'
+import { ref, computed, useTemplateRef } from 'vue'
 
 import { Play, Pause } from 'lucide-vue-next'
 
 import { inSlideShow } from '@/stores/presentation'
 import { activeElementIds, setActiveElements } from '@/stores/element'
-
-const attrs = useAttrs()
 
 const el = useTemplateRef('videoElement')
 const isPlaying = ref(false)
@@ -49,7 +47,7 @@ const videoStyle = computed(() => ({
 
 const handleVideoControls = (e) => {
 	e.stopPropagation()
-	const isActive = activeElementIds.value.includes(attrs['data-index'])
+	const isActive = activeElementIds.value.includes(element.value.id)
 	if (inSlideShow.value || (isActive && e.target !== el.value)) {
 		const video = el.value
 		if (video.paused) {
@@ -59,6 +57,6 @@ const handleVideoControls = (e) => {
 			isPlaying.value = false
 			video.pause()
 		}
-	} else setActiveElements([attrs['data-index']])
+	} else setActiveElements([element.value.id])
 }
 </script>

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -70,6 +70,7 @@ import {
 	activePosition,
 	activeElements,
 	toggleTextProperty,
+	updateActivePosition,
 } from '@/stores/element'
 
 let autosaveInterval = null
@@ -98,10 +99,7 @@ const handleArrowKeys = (key) => {
 	else if (key == 'ArrowUp') dy = -1
 	else if (key == 'ArrowDown') dy = 1
 
-	activePosition.value = {
-		left: activePosition.value.left + dx,
-		top: activePosition.value.top + dy,
-	}
+	updateActivePosition({ dx, dy })
 }
 
 const handleElementShortcuts = (e) => {

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -224,10 +224,9 @@ const startSlideShow = async () => {
 
 watch(
 	() => route.params.presentationId,
-	async (id) => {
+	(id) => {
 		if (!id) return
 		presentationId.value = id
-		await presentation.fetch()
 	},
 	{ immediate: true },
 )

--- a/frontend/src/pages/Slideshow.vue
+++ b/frontend/src/pages/Slideshow.vue
@@ -18,12 +18,11 @@
 					:style="slideStyles"
 					@click="changeSlide(slideIndex + 1, false)"
 				>
-					<component
-						v-for="(element, index) in slide.elements"
-						:key="index"
-						:is="SlideElement"
+					<SlideElement
+						v-for="element in slide.elements"
+						:key="element.id"
 						:element="element"
-						:data-index="index"
+						:data-index="element.id"
 					/>
 				</div>
 			</Transition>

--- a/frontend/src/pages/Slideshow.vue
+++ b/frontend/src/pages/Slideshow.vue
@@ -187,14 +187,9 @@ const initFullscreenMode = async () => {
 
 watch(
 	() => route.params.presentationId,
-	async (id) => {
+	(id) => {
 		if (!id) return
 		presentationId.value = id
-		await presentation.fetch()
-
-		const currentSlide = presentation.data.slides[slideIndex.value]
-		if (!currentSlide) return
-		loadSlide()
 	},
 	{ immediate: true },
 )

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -1,7 +1,7 @@
 import { ref, computed, nextTick } from 'vue'
 import { call } from 'frappe-ui'
 
-import { slide } from './slide'
+import { slide, slideDimensions } from './slide'
 
 import { generateUniqueId } from '../utils/helpers'
 import { guessTextColorFromBackground } from '../utils/color'
@@ -178,6 +178,15 @@ const moveElement = (elementId, movement) => {
 	element.top += movement.dy
 }
 
+const resizeElement = (elementId, dimensions) => {
+	let element = slide.value.elements.find((el) => el.id == elementId)
+
+	if (element && dimensions.width != element.width) {
+		const newWidth = dimensions.width / slideDimensions.scale
+		element.width = newWidth
+	}
+}
+
 const setActivePosition = (position) => {
 	activePosition.value = position
 }
@@ -205,6 +214,7 @@ export {
 	selectAllElements,
 	toggleTextProperty,
 	moveElement,
+	resizeElement,
 	setActivePosition,
 	updateActivePosition,
 }

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -171,6 +171,20 @@ const toggleTextProperty = (property, value) => {
 	element[property] = newStyle
 }
 
+const moveElement = (elementId, movement) => {
+	let element = slide.value.elements.find((el) => el.id === elementId)
+
+	element.left += movement.dx
+	element.top += movement.dy
+}
+
+const updateActivePosition = (positionChange) => {
+	activePosition.value = {
+		left: activePosition.value?.left + positionChange.dx,
+		top: activePosition.value?.top + positionChange.dy,
+	}
+}
+
 export {
 	activePosition,
 	activeDimensions,
@@ -186,4 +200,6 @@ export {
 	deleteElements,
 	selectAllElements,
 	toggleTextProperty,
+	moveElement,
+	updateActivePosition,
 }

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -178,11 +178,15 @@ const moveElement = (elementId, movement) => {
 	element.top += movement.dy
 }
 
+const setActivePosition = (position) => {
+	activePosition.value = position
+}
+
 const updateActivePosition = (positionChange) => {
-	activePosition.value = {
+	setActivePosition({
 		left: activePosition.value?.left + positionChange.dx,
 		top: activePosition.value?.top + positionChange.dy,
-	}
+	})
 }
 
 export {
@@ -201,5 +205,6 @@ export {
 	selectAllElements,
 	toggleTextProperty,
 	moveElement,
+	setActivePosition,
 	updateActivePosition,
 }

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -1,7 +1,7 @@
 import { ref, computed, nextTick } from 'vue'
 import { call } from 'frappe-ui'
 
-import { slide, slideDimensions } from './slide'
+import { slide, slideBounds } from './slide'
 
 import { generateUniqueId } from '../utils/helpers'
 import { guessTextColorFromBackground } from '../utils/color'
@@ -182,7 +182,7 @@ const resizeElement = (elementId, dimensions) => {
 	let element = slide.value.elements.find((el) => el.id == elementId)
 
 	if (element && dimensions.width != element.width) {
-		const newWidth = dimensions.width / slideDimensions.scale
+		const newWidth = dimensions.width / slideBounds.scale
 		element.width = newWidth
 	}
 }

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -3,6 +3,7 @@ import { call } from 'frappe-ui'
 
 import { slide } from './slide'
 
+import { generateUniqueId } from '../utils/helpers'
 import { guessTextColorFromBackground } from '../utils/color'
 
 const activePosition = ref(null)
@@ -14,8 +15,8 @@ const pairElementId = ref(null)
 
 const activeElements = computed(() => {
 	let elements = []
-	slide.value.elements.forEach((element, index) => {
-		if (activeElementIds.value.includes(index)) {
+	slide.value.elements.forEach((element) => {
+		if (activeElementIds.value.includes(element.id)) {
 			elements.push(element)
 		}
 	})
@@ -37,6 +38,7 @@ const addTextElement = () => {
 	const lastTextElement = slide.value.elements.reverse().find((element) => element.type == 'text')
 
 	const element = {
+		id: generateUniqueId(),
 		left: 100,
 		top: 100,
 		content: 'Text',
@@ -62,11 +64,12 @@ const addTextElement = () => {
 		element.letterSpacing = 0
 	}
 	slide.value.elements.push(element)
-	nextTick(() => setActiveElements([slide.value.elements.length - 1]))
+	nextTick(() => setActiveElements([element.id]))
 }
 
 const addMediaElement = (file, type) => {
 	let element = {
+		id: generateUniqueId(),
 		width: 300,
 		left: 200,
 		top: 75,
@@ -89,7 +92,7 @@ const addMediaElement = (file, type) => {
 		element.playbackRate = 1
 	}
 	slide.value.elements.push(element)
-	nextTick(() => setActiveElements([slide.value.elements.length - 1]))
+	nextTick(() => setActiveElements([element.id]))
 }
 
 const duplicateElements = async (e) => {
@@ -103,10 +106,11 @@ const duplicateElements = async (e) => {
 
 	oldElements.forEach((element) => {
 		let newElement = JSON.parse(JSON.stringify(element))
+		newElement.id = generateUniqueId()
 		newElement.top += 40
 		newElement.left += 40
 		slide.value.elements.push(newElement)
-		newSelection.push(slide.value.elements.indexOf(newElement))
+		newSelection.push(newElement.id)
 	})
 
 	nextTick(() => (activeElementIds.value = newSelection))
@@ -124,14 +128,14 @@ const deleteElements = async (e) => {
 	const idsToDelete = activeElementIds.value
 	resetFocus()
 	nextTick(() => {
-		slide.value.elements = slide.value.elements.filter((_, index) => {
-			return !idsToDelete.includes(index)
+		slide.value.elements = slide.value.elements.filter((element) => {
+			return !idsToDelete.includes(element.id)
 		})
 	})
 }
 
 const selectAllElements = () => {
-	activeElementIds.value = slide.value.elements.map((_, index) => index)
+	activeElementIds.value = slide.value.elements.map((element) => element.id)
 }
 
 const resetFocus = () => {
@@ -163,7 +167,8 @@ const toggleTextProperty = (property, value) => {
 				? oldStyle.replace(value, '')
 				: oldStyle + ' ' + value
 	}
-	slide.value.elements[activeElementIds.value[0]][property] = newStyle
+	let element = slide.value.elements.find((element) => element.id == activeElementIds.value[0])
+	element[property] = newStyle
 }
 
 export {

--- a/frontend/src/stores/presentation.js
+++ b/frontend/src/stores/presentation.js
@@ -1,5 +1,6 @@
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import { createResource } from 'frappe-ui'
+import { loadSlide } from './slide'
 
 const presentationId = ref('')
 
@@ -11,5 +12,13 @@ const presentation = createResource({
 const inSlideShow = ref(false)
 
 const applyReverseTransition = ref(false)
+
+watch(
+	() => presentationId.value,
+	async () => {
+		await presentation.fetch()
+		loadSlide()
+	},
+)
 
 export { presentationId, presentation, inSlideShow, applyReverseTransition }

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -37,8 +37,8 @@ const getCurrentData = () => {
 	}
 
 	if (activePosition.value) {
-		const dx = activePosition.value.left - slideDimensions.left
-		const dy = activePosition.value.top - slideDimensions.top
+		const dx = activePosition.value.left - slideBounds.left
+		const dy = activePosition.value.top - slideBounds.top
 
 		const elementsCopy = JSON.parse(JSON.stringify(slide.value.elements))
 		elementsCopy.forEach((element) => {
@@ -115,7 +115,7 @@ const saveChanges = async () => {
 	if (!presentation.data || !slideDirty.value) return
 	slide.value.elements = slide.value.elements.map((element) => {
 		let rect = document.querySelector(`[data-index="${element.id}"]`).getBoundingClientRect()
-		element.width = rect.width / slideDimensions.scale
+		element.width = rect.width / slideBounds.scale
 		return element
 	})
 	saving.value = true
@@ -168,14 +168,14 @@ const selectSlide = (e) => {
 	resetFocus()
 }
 
-const slideDimensions = reactive({})
+const slideBounds = reactive({})
 
 export {
 	slideIndex,
 	slideDirty,
 	saving,
 	slide,
-	slideDimensions,
+	slideBounds,
 	getSlideThumbnail,
 	loadSlide,
 	saveChanges,

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -41,8 +41,8 @@ const getCurrentData = () => {
 		const dy = activePosition.value.top - slideDimensions.top
 
 		const elementsCopy = JSON.parse(JSON.stringify(slide.value.elements))
-		elementsCopy.forEach((element, index) => {
-			if (activeElementIds.value.includes(index)) {
+		elementsCopy.forEach((element) => {
+			if (activeElementIds.value.includes(element.id)) {
 				element.left = element.left + dx
 				element.top = element.top + dy
 			}
@@ -113,8 +113,8 @@ const saving = ref(false)
 
 const saveChanges = async () => {
 	if (!presentation.data || !slideDirty.value) return
-	slide.value.elements = slide.value.elements.map((element, index) => {
-		let rect = document.querySelector(`[data-index="${index}"]`).getBoundingClientRect()
+	slide.value.elements = slide.value.elements.map((element) => {
+		let rect = document.querySelector(`[data-index="${element.id}"]`).getBoundingClientRect()
 		element.width = rect.width / slideDimensions.scale
 		return element
 	})

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -33,4 +33,8 @@ const debounce = (fn: Function, wait = 300) => {
 	}
 }
 
-export { handleSingleAndDoubleClick, debounce }
+const generateUniqueId = () => {
+	return Math.random().toString(36).slice(2, 11)
+}
+
+export { handleSingleAndDoubleClick, debounce, generateUniqueId }


### PR DESCRIPTION
### Bug
On delete of an element, if the next element has auto width, it inherits the width of the deleted element since its new index is that of the deleted element and Vue requires a unique `:key` value.


https://github.com/user-attachments/assets/54dccb85-f236-4831-a4aa-6a1c93898009


<br>


### Fix
Instead of using the index of the element on the slide, use unique ids generated on the client side to avoid any sort of unwanted leakage of styles from one element to the other.


https://github.com/user-attachments/assets/98dee32f-3626-4167-be89-1a86005f1f05

