### PR TITLE
fix: update selected bounds on font style and zoom changes

### DIFF
--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -264,9 +264,13 @@ const activeDiv = computed(() => {
 useResizeObserver(activeDiv, (entries) => {
 	const entry = entries[0]
 	const { width, height } = entry.contentRect
+
+	// case:
+	// when element dimensions are changed not by resizer
+	// but by other updates on properties - font size, line height, letter spacing etc.
 	selectionBoxRef.value.setBoxBounds({
-		width: width * scale.value,
-		height: height * scale.value,
+		width: width,
+		height: height,
 	})
 })
 
@@ -300,6 +304,13 @@ watch(
 		// wait for the new transform to render before updating dimensions
 		nextTick(() => {
 			updateSlideBounds()
+
+			// set initial position of the selection box after zooming / panning
+			const { left, top } = selectionBoxRef.value.getBoxBounds()
+			setActivePosition({
+				left: left + slideBounds.left,
+				top: top + slideBounds.top,
+			})
 		})
 	},
 )

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -41,7 +41,7 @@
 <script setup>
 import { ref, computed, watch, useTemplateRef, nextTick, onMounted, provide } from 'vue'
 import { useRouter } from 'vue-router'
-import { useElementBounding } from '@vueuse/core'
+import { useElementBounding, useResizeObserver } from '@vueuse/core'
 
 import { Trash, Copy, SquarePlus } from 'lucide-vue-next'
 import SlideElement from '@/components/SlideElement.vue'
@@ -152,12 +152,6 @@ const handleDimensionChange = (dimensions) => {
 
 	// update element dimensions in slide object
 	resizeElement(elementId, dimensions)
-
-	// update selection box dimensions to match the element
-	selectionBoxRef.value.setBoxBounds({
-		width: dimensions.width,
-		height: dimensions.height,
-	})
 }
 
 const initDraggable = () => {
@@ -261,6 +255,19 @@ const handleSelectionChange = (newSelection, oldSelection) => {
 		removeDragAndResize()
 	}
 }
+
+const activeDiv = computed(() => {
+	return document.querySelector(`[data-index="${activeElementIds.value[0]}"]`)
+})
+
+useResizeObserver(activeDiv, (entries) => {
+	const entry = entries[0]
+	const { width, height } = entry.contentRect
+	selectionBoxRef.value.setBoxBounds({
+		width: width * scale.value,
+		height: height * scale.value,
+	})
+})
 
 watch(
 	() => activeElementIds.value,

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -257,6 +257,7 @@ const handleSelectionChange = (newSelection, oldSelection) => {
 }
 
 const activeDiv = computed(() => {
+	if (activeElementIds.value.length != 1) return null
 	return document.querySelector(`[data-index="${activeElementIds.value[0]}"]`)
 })
 

--- a/frontend/src/components/SlideElementsPanel.vue
+++ b/frontend/src/components/SlideElementsPanel.vue
@@ -270,10 +270,11 @@ import ColorPicker from '@/components/controls/ColorPicker.vue'
 
 import { presentation } from '@/stores/presentation'
 import { slide, slideIndex, selectSlide } from '@/stores/slide'
-import { activeElements, addTextElement, addMediaElement } from '@/stores/element'
+import { activeElements, focusElementId, addTextElement, addMediaElement } from '@/stores/element'
 
 const activeTab = computed(() => {
 	if (activeElements.value[0]) return activeElements.value[0].type
+	if (focusElementId.value) return 'text'
 	return 'slide'
 })
 

--- a/frontend/src/components/SlideNavigationPanel.vue
+++ b/frontend/src/components/SlideNavigationPanel.vue
@@ -40,13 +40,12 @@
 	</div>
 
 	<!-- Slide Navigator Toggle -->
-	<div v-if="!showNavigator">
-		<div
-			class="top-[calc(50% - 24)px] fixed left-0 z-20 flex h-12 w-4 cursor-pointer items-center justify-center rounded-r-lg border bg-white shadow-xl"
-			@click="toggleNavigator"
-		>
-			<ChevronRight size="14" class="stroke-[1.5]" />
-		</div>
+	<div
+		v-if="!showNavigator"
+		class="top-[calc(50% - 24)px] fixed left-0 z-20 flex h-12 w-4 cursor-pointer items-center justify-center rounded-r-lg border bg-white shadow-xl"
+		@click="toggleNavigator"
+	>
+		<ChevronRight size="14" class="stroke-[1.5]" />
 	</div>
 </template>
 

--- a/frontend/src/components/TextElement.vue
+++ b/frontend/src/components/TextElement.vue
@@ -37,7 +37,7 @@ const textStyle = computed(() => ({
 	opacity: element.value.opacity / 100,
 	lineHeight: element.value.lineHeight,
 	letterSpacing: `${element.value.letterSpacing}px`,
-	wordWrap: 'break-word',
+	wordWrap: element.value.width == 'auto' ? 'normal' : 'break-word',
 	textAlign: element.value.textAlign,
 	color: element.value.color,
 	cursor: focusElementId.value == attrs['data-index'] ? 'text' : '',

--- a/frontend/src/components/TextPropertyTab.vue
+++ b/frontend/src/components/TextPropertyTab.vue
@@ -6,9 +6,7 @@
 				v-for="style in styleProperties"
 				:key="style.property"
 				class="cursor-pointer rounded-sm p-1"
-				:class="
-					activeElements[0][style.property]?.includes(style.value) ? 'bg-gray-200' : ''
-				"
+				:class="element[style.property]?.includes(style.value) ? 'bg-gray-200' : ''"
 				@click="toggleTextProperty(style.property, style.value)"
 			>
 				<component :is="style.icon" size="18" :strokeWidth="1.5" />
@@ -19,8 +17,8 @@
 			<button
 				v-for="textAlign in ['left', 'center', 'right', 'justify']"
 				class="cursor-pointer rounded-sm p-1"
-				:class="activeElements[0].textAlign == textAlign ? 'bg-gray-200' : ''"
-				@click="activeElements[0].textAlign = textAlign"
+				:class="element.textAlign == textAlign ? 'bg-gray-200' : ''"
+				@click="element.textAlign = textAlign"
 			>
 				<AlignLeft v-if="textAlign == 'left'" size="18" class="stroke-[1.5]" />
 				<AlignCenter v-if="textAlign == 'center'" size="18" class="stroke-[1.5]" />
@@ -40,15 +38,15 @@
 			:options="textFonts"
 			size="sm"
 			variant="subtle"
-			:modelValue="activeElements[0].fontFamily"
-			@update:modelValue="(font) => (activeElements[0].fontFamily = font.value)"
+			:modelValue="element.fontFamily"
+			@update:modelValue="(font) => (element.fontFamily = font.value)"
 		/>
 
 		<div class="flex items-center justify-between">
 			<div class="text-sm text-gray-600">Size</div>
 			<div class="h-[30px] w-28">
 				<NumberInput
-					v-model="activeElements[0].fontSize"
+					v-model="element.fontSize"
 					suffix="px"
 					:rangeStart="5"
 					:rangeEnd="100"
@@ -59,7 +57,7 @@
 
 		<div class="flex items-center justify-between">
 			<div class="text-sm text-gray-600">Colour</div>
-			<ColorPicker v-model="activeElements[0].color" />
+			<ColorPicker v-model="element.color" />
 		</div>
 	</div>
 
@@ -71,8 +69,8 @@
 			:rangeStart="0.1"
 			:rangeEnd="5.0"
 			:rangeStep="0.1"
-			:modelValue="parseFloat(activeElements[0].lineHeight)"
-			@update:modelValue="(value) => (activeElements[0].lineHeight = value)"
+			:modelValue="parseFloat(element.lineHeight)"
+			@update:modelValue="(value) => (element.lineHeight = value)"
 		/>
 
 		<SliderInput
@@ -80,13 +78,14 @@
 			:rangeStart="-10"
 			:rangeEnd="50"
 			:rangeStep="0.1"
-			:modelValue="parseFloat(activeElements[0].letterSpacing)"
-			@update:modelValue="(value) => (activeElements[0].letterSpacing = value)"
+			:modelValue="parseFloat(element.letterSpacing)"
+			@update:modelValue="(value) => (element.letterSpacing = value)"
 		/>
 	</div>
 </template>
 
 <script setup>
+import { computed } from 'vue'
 import { FormControl } from 'frappe-ui'
 import {
 	Bold,
@@ -106,10 +105,23 @@ import NumberInput from './controls/NumberInput.vue'
 import ColorPicker from './controls/ColorPicker.vue'
 
 import { slide } from '@/stores/slide'
-import { activeElementIds, activeElements, toggleTextProperty } from '@/stores/element'
+import {
+	activeElementIds,
+	activeElements,
+	focusElementId,
+	toggleTextProperty,
+} from '@/stores/element'
 
 const sectionClasses = 'flex flex-col gap-4 border-b p-4'
 const sectionTitleClasses = 'text-2xs font-semibold uppercase text-gray-700'
+
+const element = computed(() => {
+	if (focusElementId.value) {
+		return slide.value.elements.find((element) => element.id === focusElementId.value)
+	} else {
+		return activeElements.value[0]
+	}
+})
 
 const textFonts = [
 	'Arial',


### PR DESCRIPTION
### Changes

- Show Text Properties in Editable state.
- Don't allow word wrapping when editing a text element with auto width.
- When an element is already selected and scale / translate values change for the slide, update the bounds of the selected div correctly.
- After style changes like Line Height, Letter Spacing etc, correctly update the selected div bounds after the width and height of the div changes.