### PR TITLE
fix: reset zoom before capturing thumbnail + misc

### DIFF
--- a/frontend/src/components/ImageElement.vue
+++ b/frontend/src/components/ImageElement.vue
@@ -8,6 +8,8 @@ import { computed } from 'vue'
 import { setActiveElements } from '@/stores/element'
 import { inSlideShow } from '@/stores/presentation'
 
+const emit = defineEmits(['select'])
+
 const element = defineModel('element', {
 	type: Object,
 	default: null,
@@ -26,6 +28,6 @@ const imageStyle = computed(() => ({
 
 const selectImage = (e) => {
 	if (inSlideShow.value) return
-	setActiveElements([element.value.id])
+	emit('select', e)
 }
 </script>

--- a/frontend/src/components/ImageElement.vue
+++ b/frontend/src/components/ImageElement.vue
@@ -5,9 +5,6 @@
 <script setup>
 import { computed } from 'vue'
 
-import { setActiveElements } from '@/stores/element'
-import { inSlideShow } from '@/stores/presentation'
-
 const emit = defineEmits(['select'])
 
 const element = defineModel('element', {

--- a/frontend/src/components/ImageElement.vue
+++ b/frontend/src/components/ImageElement.vue
@@ -27,7 +27,6 @@ const imageStyle = computed(() => ({
 }))
 
 const selectImage = (e) => {
-	if (inSlideShow.value) return
 	emit('select', e)
 }
 </script>

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -151,7 +151,8 @@ const handleDimensionChange = (dimensions) => {
 }
 
 const handlePositionChange = (position) => {
-	if (position.left == selectionBoxRef.value.getBoxBounds().left + slideBounds.left) {
+	const { left, top } = selectionBoxRef.value.getBoxBounds()
+	if (position.left == left + slideBounds.left && position.top == top + slideBounds.top) {
 		return
 	}
 	selectionBoxRef.value.setBoxBounds({

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -2,7 +2,7 @@
 	<div ref="slideContainer" class="slideContainer flex items-center justify-center w-full h-full">
 		<div ref="target" :style="targetStyles">
 			<div ref="slideRef" :class="slideClasses" :style="slideStyles">
-				<SelectionBox ref="selectionBox" @updateFocus="updateFocus" />
+				<SelectionBox ref="selectionBox" @updateFocus="updateFocus" @click="stopDragging" />
 
 				<AlignmentGuides
 					v-if="showGuides"
@@ -297,6 +297,14 @@ const handleSlideTransform = () => {
 			top: top + slideBounds.top,
 		})
 	})
+}
+
+const stopDragging = (e) => {
+	// stop dragging when the mouse is released within the selection box and not on an element
+	if (isDragging.value && e.target == selectionBoxRef.value.$el) {
+		isDragging.value = false
+		return
+	}
 }
 
 watch(

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -20,12 +20,16 @@
 
 			<!-- Slide Actions -->
 			<div class="fixed -bottom-12 right-0 cursor-pointer p-3 flex items-center gap-4">
-				<Trash size="14" class="text-gray-800 stroke-[1.5]" @click="deleteSlide" />
-				<Copy size="14" class="text-gray-800 stroke-[1.5]" @click="duplicateSlide" />
+				<Trash size="14" class="text-gray-800 stroke-[1.5]" @click="emit('delete')" />
+				<Copy
+					size="14"
+					class="text-gray-800 stroke-[1.5]"
+					@click="(e) => emit('duplicate', e)"
+				/>
 				<SquarePlus
 					size="14"
 					class="text-gray-800 stroke-[1.5]"
-					@click="insertSlide(slideIndex + 1)"
+					@click="emit('insert', slideIndex + 1)"
 				/>
 			</div>
 		</div>
@@ -49,17 +53,7 @@ import AlignmentGuides from '@/components/AlignmentGuides.vue'
 import SelectionBox from './SelectionBox.vue'
 
 import { presentation } from '@/stores/presentation'
-import {
-	slideIndex,
-	slide,
-	insertSlide,
-	deleteSlide,
-	duplicateSlide,
-	loadSlide,
-	selectSlide,
-	getSlideThumbnail,
-	slideBounds,
-} from '@/stores/slide'
+import { slideIndex, slide, loadSlide, selectSlide, slideBounds } from '@/stores/slide'
 import {
 	activePosition,
 	activeDimensions,
@@ -80,6 +74,8 @@ import { usePanAndZoom } from '@/utils/zoom'
 const props = defineProps({
 	highlight: Boolean,
 })
+
+const emit = defineEmits(['insert', 'delete', 'duplicate'])
 
 let recentlySnapped = false
 let snapTimer = null
@@ -274,6 +270,10 @@ useResizeObserver(activeDiv, (entries) => {
 	})
 })
 
+const togglePanZoom = () => {
+	allowPanAndZoom.value = !allowPanAndZoom.value
+}
+
 watch(
 	() => activeElementIds.value,
 	(newVal, oldVal) => {
@@ -322,6 +322,10 @@ onMounted(() => {
 
 provide('slideDiv', slideRef)
 provide('slideContainerDiv', slideContainerRef)
+
+defineExpose({
+	togglePanZoom,
+})
 </script>
 
 <style src="../assets/styles/resizer.css"></style>

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -45,7 +45,7 @@
 <script setup>
 import { ref, computed, watch, useTemplateRef, nextTick, onMounted, provide } from 'vue'
 import { useRouter } from 'vue-router'
-import { useElementBounding, useResizeObserver } from '@vueuse/core'
+import { useResizeObserver } from '@vueuse/core'
 
 import { Trash, Copy, SquarePlus } from 'lucide-vue-next'
 import SlideElement from '@/components/SlideElement.vue'
@@ -53,15 +53,12 @@ import AlignmentGuides from '@/components/AlignmentGuides.vue'
 import SelectionBox from './SelectionBox.vue'
 
 import { presentation } from '@/stores/presentation'
-import { slideIndex, slide, loadSlide, selectSlide, slideBounds } from '@/stores/slide'
+import { slideIndex, slide, selectSlide, slideBounds } from '@/stores/slide'
 import {
 	activePosition,
 	activeDimensions,
 	activeElements,
 	activeElementIds,
-	focusElementId,
-	pairElementId,
-	resetFocus,
 	updateActivePosition,
 	setActivePosition,
 	resizeElement,
@@ -94,8 +91,6 @@ const { isPanningOrZooming, allowPanAndZoom, transform, transformOrigin } = useP
 	slideContainerRef,
 	slideTargetRef,
 )
-
-const delayPositionUpdates = ref(0)
 
 const slideClasses = computed(() => {
 	const classes = ['slide', 'h-[540px]', 'w-[960px]', 'shadow-2xl']

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -344,6 +344,7 @@ onMounted(() => {
 
 provide('slideDiv', slideRef)
 provide('slideContainerDiv', slideContainerRef)
+provide('isDragging', isDragging)
 
 defineExpose({
 	togglePanZoom,

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -325,6 +325,7 @@ provide('slideContainerDiv', slideContainerRef)
 
 defineExpose({
 	togglePanZoom,
+	applyMovement,
 })
 </script>
 

--- a/frontend/src/components/SlideElement.vue
+++ b/frontend/src/components/SlideElement.vue
@@ -1,22 +1,35 @@
 <template>
 	<div :style="elementStyle">
-		<component :is="getDynamicComponent(element.type)" :element="element" />
+		<component
+			:is="getDynamicComponent(element.type)"
+			:element="element"
+			@select="selectElement"
+			@focus="focusOnElement"
+		/>
 	</div>
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, inject, nextTick } from 'vue'
 
 import TextElement from '@/components/TextElement.vue'
 import ImageElement from '@/components/ImageElement.vue'
 import VideoElement from '@/components/VideoElement.vue'
 
-import { activeElementIds, pairElementId, focusElementId } from '@/stores/element'
+import {
+	activeElementIds,
+	pairElementId,
+	focusElementId,
+	setActiveElements,
+	activeElement,
+} from '@/stores/element'
 
 const element = defineModel('element', {
 	type: Object,
 	default: null,
 })
+
+const isDragging = inject('isDragging')
 
 const outline = computed(() => {
 	if (activeElementIds.value.concat([focusElementId.value]).includes(element.value.id))
@@ -44,5 +57,24 @@ const getDynamicComponent = (type) => {
 		default:
 			return TextElement
 	}
+}
+
+const focusOnElement = (e) => {
+	e.stopPropagation()
+	if (focusElementId.value == element.value.id) return
+	setActiveElements([element.value.id], true)
+	nextTick(() => {
+		e.target.focus()
+	})
+}
+
+const selectElement = (e) => {
+	if (isDragging.value) {
+		isDragging.value = false
+		return
+	}
+	if (element.value.type == 'text' && element.value.id == activeElement.value?.id)
+		focusOnElement(e)
+	else setActiveElements([element.value.id])
 }
 </script>

--- a/frontend/src/components/SlideElement.vue
+++ b/frontend/src/components/SlideElement.vue
@@ -29,7 +29,7 @@ const element = defineModel('element', {
 	default: null,
 })
 
-const isDragging = inject('isDragging')
+const isDragging = inject('isDragging', null)
 
 const outline = computed(() => {
 	if (activeElementIds.value.concat([focusElementId.value]).includes(element.value.id))

--- a/frontend/src/components/SlideElement.vue
+++ b/frontend/src/components/SlideElement.vue
@@ -61,7 +61,10 @@ const getDynamicComponent = (type) => {
 
 const focusOnElement = (e) => {
 	e.stopPropagation()
+
+	// avoid re-triggering focus and putting the cursor at end if text element is already in focus
 	if (focusElementId.value == element.value.id) return
+
 	setActiveElements([element.value.id], true)
 	nextTick(() => {
 		e.target.focus()
@@ -69,10 +72,18 @@ const focusOnElement = (e) => {
 }
 
 const selectElement = (e) => {
+	e.stopPropagation()
+
+	// avoid the click event from firing after a drag
 	if (isDragging.value) {
 		isDragging.value = false
 		return
 	}
+
+	// if the text element is in focus, don't select it again
+	if (focusElementId.value == element.value.id) return
+
+	// if the element is already selected and is editable, focus on it
 	if (element.value.type == 'text' && element.value.id == activeElement.value?.id)
 		focusOnElement(e)
 	else setActiveElements([element.value.id])

--- a/frontend/src/components/SlideElementsPanel.vue
+++ b/frontend/src/components/SlideElementsPanel.vue
@@ -28,7 +28,7 @@
 					size="sm"
 					variant="subtle"
 					:modelValue="slide.transition || 'None'"
-					@update:modelValue="(option) => (slide.transition = option.value)"
+					@update:modelValue="(option) => setSlideTransition(option)"
 				/>
 
 				<SliderInput
@@ -363,6 +363,12 @@ const handleUploadFailure = () => {
 const addBorder = (style) => {
 	activeElement.value.borderStyle = style
 	activeElement.value.borderWidth = 1
+}
+
+const setSlideTransition = (option) => {
+	slide.value.transition = option.value
+	if (option.value == 'None') slide.value.transitionDuration = 0
+	else slide.value.transitionDuration = 1
 }
 </script>
 

--- a/frontend/src/components/SlideElementsPanel.vue
+++ b/frontend/src/components/SlideElementsPanel.vue
@@ -90,8 +90,8 @@
 						:rangeStart="0.5"
 						:rangeEnd="2"
 						:rangeStep="0.1"
-						:modelValue="parseFloat(activeElements[0].playbackRate) || 1"
-						@update:modelValue="(value) => (activeElements[0].playbackRate = value)"
+						:modelValue="parseFloat(activeElement.playbackRate) || 1"
+						@update:modelValue="(value) => (activeElement.playbackRate = value)"
 					/>
 				</div>
 			</div>
@@ -107,7 +107,7 @@
 							v-for="(style, index) in ['none', 'solid', 'dashed', 'dotted']"
 							:key="index"
 							class="flex h-4/5 w-1/4 cursor-pointer items-center justify-center rounded-sm"
-							:class="activeElements[0].borderStyle == style ? 'bg-white shadow' : ''"
+							:class="activeElement.borderStyle == style ? 'bg-white shadow' : ''"
 							@click="addBorder(style)"
 						>
 							<Ban v-if="style == 'none'" size="16" class="stroke-[1.5] text-black" />
@@ -119,12 +119,12 @@
 						</div>
 					</div>
 
-					<div v-if="activeElements[0].borderStyle != 'none'" class="flex flex-col gap-4">
+					<div v-if="activeElement.borderStyle != 'none'" class="flex flex-col gap-4">
 						<div class="flex items-center justify-between">
 							<div class="text-sm text-gray-600">Width</div>
 							<div class="h-[30px] w-28">
 								<NumberInput
-									v-model="activeElements[0].borderWidth"
+									v-model="activeElement.borderWidth"
 									suffix="px"
 									:rangeStart="0"
 									:rangeEnd="50"
@@ -136,7 +136,7 @@
 							<div class="text-sm text-gray-600">Radius</div>
 							<div class="h-[30px] w-28">
 								<NumberInput
-									v-model="activeElements[0].borderRadius"
+									v-model="activeElement.borderRadius"
 									suffix="px"
 									:rangeStart="1"
 									:rangeEnd="50"
@@ -146,7 +146,7 @@
 
 						<div class="flex items-center justify-between">
 							<div class="text-sm text-gray-600">Colour</div>
-							<ColorPicker v-model="activeElements[0].borderColor" />
+							<ColorPicker v-model="activeElement.borderColor" />
 						</div>
 					</div>
 				</div>
@@ -158,16 +158,16 @@
 						label="Offset X"
 						:rangeStart="-50"
 						:rangeEnd="50"
-						:modelValue="parseFloat(activeElements[0].shadowOffsetX) || 0"
-						@update:modelValue="(value) => (activeElements[0].shadowOffsetX = value)"
+						:modelValue="parseFloat(activeElement.shadowOffsetX) || 0"
+						@update:modelValue="(value) => (activeElement.shadowOffsetX = value)"
 					/>
 
 					<SliderInput
 						label="Offset Y"
 						:rangeStart="-50"
 						:rangeEnd="50"
-						:modelValue="parseFloat(activeElements[0].shadowOffsetY) || 0"
-						@update:modelValue="(value) => (activeElements[0].shadowOffsetY = value)"
+						:modelValue="parseFloat(activeElement.shadowOffsetY) || 0"
+						@update:modelValue="(value) => (activeElement.shadowOffsetY = value)"
 					/>
 
 					<div class="flex flex-col gap-1">
@@ -177,29 +177,27 @@
 								class="w-4/5"
 								:rangeStart="1"
 								:rangeEnd="500"
-								:modelValue="parseFloat(activeElements[0].shadowSpread) || 50"
-								@update:modelValue="
-									(value) => (activeElements[0].shadowSpread = value)
-								"
+								:modelValue="parseFloat(activeElement.shadowSpread) || 50"
+								@update:modelValue="(value) => (activeElement.shadowSpread = value)"
 								:showInput="false"
 							/>
 							<ColorPicker
 								class="w-10 justify-end"
-								v-model="activeElements[0].shadowColor"
+								v-model="activeElement.shadowColor"
 							/>
 						</div>
 					</div>
 				</div>
 			</div>
 
-			<div v-if="activeElements[0] && activeTab != 'video'" :class="sectionClasses">
+			<div v-if="activeElement && activeTab != 'video'" :class="sectionClasses">
 				<div :class="sectionTitleClasses">Other</div>
 				<SliderInput
 					label="Opacity"
 					:rangeStart="0"
 					:rangeEnd="100"
-					:modelValue="parseFloat(activeElements[0].opacity) || 100"
-					@update:modelValue="(value) => (activeElements[0].opacity = value)"
+					:modelValue="parseFloat(activeElement.opacity) || 100"
+					@update:modelValue="(value) => (activeElement.opacity = value)"
 				/>
 			</div>
 		</div>
@@ -270,11 +268,16 @@ import ColorPicker from '@/components/controls/ColorPicker.vue'
 
 import { presentation } from '@/stores/presentation'
 import { slide, slideIndex, selectSlide } from '@/stores/slide'
-import { activeElements, focusElementId, addTextElement, addMediaElement } from '@/stores/element'
+import {
+	activeElements,
+	activeElement,
+	focusElementId,
+	addTextElement,
+	addMediaElement,
+} from '@/stores/element'
 
 const activeTab = computed(() => {
-	if (activeElements.value[0]) return activeElements.value[0].type
-	if (focusElementId.value) return 'text'
+	if (activeElement.value) return activeElement.value.type
 	return 'slide'
 })
 
@@ -309,8 +312,7 @@ const imageOrientationProperties = [
 ]
 
 const toggleImageOrientation = (direction) => {
-	activeElements.value[0][direction.property] =
-		activeElements.value[0][direction.property] === 1 ? -1 : 1
+	activeElement.value[direction.property] = activeElement.value[direction.property] === 1 ? -1 : 1
 }
 
 const sectionClasses = 'flex flex-col gap-4 p-4 border-b'
@@ -334,20 +336,19 @@ const playbackProperties = [
 const getPlaybackOptionClasses = (option) => {
 	return {
 		'cursor-pointer flex flex-col w-1/2 items-center justify-center gap-1 rounded border p-1': true,
-		'border-gray-800 bg-gray-50':
-			hoverOption.value == option || activeElements.value[0][option],
+		'border-gray-800 bg-gray-50': hoverOption.value == option || activeElement.value[option],
 	}
 }
 
 const getPlaybackTextClasses = (option) => {
 	return {
-		'text-gray-800': hoverOption.value == option || activeElements.value[0][option],
-		'text-gray-600': hoverOption.value != option && !activeElements.value[0][option],
+		'text-gray-800': hoverOption.value == option || activeElement.value[option],
+		'text-gray-600': hoverOption.value != option && !activeElement.value[option],
 	}
 }
 
 const togglePlaybackOption = (option) => {
-	activeElements.value[0][option] = !activeElements.value[0][option]
+	activeElement.value[option] = !activeElement.value[option]
 }
 
 const handleUploadSuccess = (file, type) => {
@@ -360,8 +361,8 @@ const handleUploadFailure = () => {
 }
 
 const addBorder = (style) => {
-	activeElements.value[0].borderStyle = style
-	activeElements.value[0].borderWidth = 1
+	activeElement.value.borderStyle = style
+	activeElement.value.borderWidth = 1
 }
 </script>
 

--- a/frontend/src/components/SlideNavigationPanel.vue
+++ b/frontend/src/components/SlideNavigationPanel.vue
@@ -14,14 +14,14 @@
 						class="my-4 h-20 cursor-pointer rounded bg-center bg-no-repeat bg-cover border"
 						:class="getThumbnailClasses(slide)"
 						:style="getThumbnailStyles(slide)"
-						@click="changeSlide(slide.idx - 1)"
+						@click="emit('changeSlide', slide.idx - 1)"
 					></div>
 				</template>
 			</Draggable>
 
 			<div
 				class="flex h-20 cursor-pointer items-center justify-center rounded border border-dashed border-gray-400 shadow-lg shadow-gray-100 hover:border-blue-400 hover:bg-blue-50"
-				@click="insertSlide(presentation.data.slides.length)"
+				@click="emit('insertSlide', presentation.data.slides.length)"
 			>
 				<Plus size="14" class="stroke-[1.5]" />
 			</div>
@@ -59,12 +59,14 @@ import { Plus, ChevronRight } from 'lucide-vue-next'
 import Draggable from 'vuedraggable'
 
 import { presentation } from '@/stores/presentation'
-import { slide, slideIndex, changeSlide, insertSlide } from '@/stores/slide'
+import { slide, slideIndex } from '@/stores/slide'
 
 const showNavigator = defineModel('showNavigator', {
 	type: Boolean,
 	default: true,
 })
+
+const emit = defineEmits(['changeSlide', 'insertSlide'])
 
 const showCollapseShortcut = ref(false)
 
@@ -85,7 +87,7 @@ const getThumbnailStyles = (s) => {
 
 const handleSortEnd = async (event) => {
 	const data = presentation.data
-	changeSlide(event.newIndex)
+	emit('changeSlide', event.newIndex)
 	data.slides.forEach((slide) => {
 		slide.idx = data.slides.indexOf(slide) + 1
 	})

--- a/frontend/src/components/TextElement.vue
+++ b/frontend/src/components/TextElement.vue
@@ -23,6 +23,8 @@ const element = defineModel('element', {
 	default: null,
 })
 
+const emit = defineEmits(['focus', 'select'])
+
 const textStyle = computed(() => ({
 	content: element.value.content,
 	fontFamily: element.value.fontFamily,
@@ -43,23 +45,17 @@ const textStyle = computed(() => ({
 
 const selectElement = (e) => {
 	if (inSlideShow.value) return
-	handleSingleAndDoubleClick(e, setActiveText, setFocusElement)
+	handleSingleAndDoubleClick(e, setActiveText, setFocusText)
 }
 
 const setActiveText = (e) => {
 	e.stopPropagation()
 	if (focusElementId.value == element.value.id) return
-	if (activeElement.value?.id == element.value.id) setFocusElement(e)
-	else setActiveElements([element.value.id])
+	emit('select', e)
 }
 
-const setFocusElement = (e) => {
-	e.stopPropagation()
-	if (focusElementId.value == element.value.id) return
-	setActiveElements([element.value.id], true)
-	nextTick(() => {
-		e.target.focus()
-	})
+const setFocusText = (e) => {
+	emit('focus', e)
 }
 
 const setCursorPosition = (e) => {

--- a/frontend/src/components/TextElement.vue
+++ b/frontend/src/components/TextElement.vue
@@ -49,8 +49,6 @@ const selectElement = (e) => {
 }
 
 const setActiveText = (e) => {
-	e.stopPropagation()
-	if (focusElementId.value == element.value.id) return
 	emit('select', e)
 }
 

--- a/frontend/src/components/TextElement.vue
+++ b/frontend/src/components/TextElement.vue
@@ -15,7 +15,7 @@
 import { computed, nextTick } from 'vue'
 
 import { inSlideShow } from '@/stores/presentation'
-import { activeElement, focusElementId, setActiveElements } from '@/stores/element'
+import { focusElementId } from '@/stores/element'
 import { handleSingleAndDoubleClick } from '@/utils/helpers'
 
 const element = defineModel('element', {

--- a/frontend/src/components/TextElement.vue
+++ b/frontend/src/components/TextElement.vue
@@ -15,7 +15,7 @@
 import { computed, nextTick } from 'vue'
 
 import { inSlideShow } from '@/stores/presentation'
-import { focusElementId, setActiveElements } from '@/stores/element'
+import { activeElement, focusElementId, setActiveElements } from '@/stores/element'
 import { handleSingleAndDoubleClick } from '@/utils/helpers'
 
 const element = defineModel('element', {
@@ -49,7 +49,8 @@ const selectElement = (e) => {
 const setActiveText = (e) => {
 	e.stopPropagation()
 	if (focusElementId.value == element.value.id) return
-	setActiveElements([element.value.id])
+	if (activeElement.value?.id == element.value.id) setFocusElement(e)
+	else setActiveElements([element.value.id])
 }
 
 const setFocusElement = (e) => {

--- a/frontend/src/components/TextPropertyTab.vue
+++ b/frontend/src/components/TextPropertyTab.vue
@@ -6,7 +6,7 @@
 				v-for="style in styleProperties"
 				:key="style.property"
 				class="cursor-pointer rounded-sm p-1"
-				:class="element[style.property]?.includes(style.value) ? 'bg-gray-200' : ''"
+				:class="activeElement[style.property]?.includes(style.value) ? 'bg-gray-200' : ''"
 				@click="toggleTextProperty(style.property, style.value)"
 			>
 				<component :is="style.icon" size="18" :strokeWidth="1.5" />
@@ -17,8 +17,8 @@
 			<button
 				v-for="textAlign in ['left', 'center', 'right', 'justify']"
 				class="cursor-pointer rounded-sm p-1"
-				:class="element.textAlign == textAlign ? 'bg-gray-200' : ''"
-				@click="element.textAlign = textAlign"
+				:class="activeElement.textAlign == textAlign ? 'bg-gray-200' : ''"
+				@click="activeElement.textAlign = textAlign"
 			>
 				<AlignLeft v-if="textAlign == 'left'" size="18" class="stroke-[1.5]" />
 				<AlignCenter v-if="textAlign == 'center'" size="18" class="stroke-[1.5]" />
@@ -38,15 +38,15 @@
 			:options="textFonts"
 			size="sm"
 			variant="subtle"
-			:modelValue="element.fontFamily"
-			@update:modelValue="(font) => (element.fontFamily = font.value)"
+			:modelValue="activeElement.fontFamily"
+			@update:modelValue="(font) => (activeElement.fontFamily = font.value)"
 		/>
 
 		<div class="flex items-center justify-between">
 			<div class="text-sm text-gray-600">Size</div>
 			<div class="h-[30px] w-28">
 				<NumberInput
-					v-model="element.fontSize"
+					v-model="activeElement.fontSize"
 					suffix="px"
 					:rangeStart="5"
 					:rangeEnd="100"
@@ -57,7 +57,7 @@
 
 		<div class="flex items-center justify-between">
 			<div class="text-sm text-gray-600">Colour</div>
-			<ColorPicker v-model="element.color" />
+			<ColorPicker v-model="activeElement.color" />
 		</div>
 	</div>
 
@@ -69,8 +69,8 @@
 			:rangeStart="0.1"
 			:rangeEnd="5.0"
 			:rangeStep="0.1"
-			:modelValue="parseFloat(element.lineHeight)"
-			@update:modelValue="(value) => (element.lineHeight = value)"
+			:modelValue="parseFloat(activeElement.lineHeight)"
+			@update:modelValue="(value) => (activeElement.lineHeight = value)"
 		/>
 
 		<SliderInput
@@ -78,8 +78,8 @@
 			:rangeStart="-10"
 			:rangeEnd="50"
 			:rangeStep="0.1"
-			:modelValue="parseFloat(element.letterSpacing)"
-			@update:modelValue="(value) => (element.letterSpacing = value)"
+			:modelValue="parseFloat(activeElement.letterSpacing)"
+			@update:modelValue="(value) => (activeElement.letterSpacing = value)"
 		/>
 	</div>
 </template>
@@ -110,18 +110,11 @@ import {
 	activeElements,
 	focusElementId,
 	toggleTextProperty,
+	activeElement,
 } from '@/stores/element'
 
 const sectionClasses = 'flex flex-col gap-4 border-b p-4'
 const sectionTitleClasses = 'text-2xs font-semibold uppercase text-gray-700'
-
-const element = computed(() => {
-	if (focusElementId.value) {
-		return slide.value.elements.find((element) => element.id === focusElementId.value)
-	} else {
-		return activeElements.value[0]
-	}
-})
 
 const textFonts = [
 	'Arial',

--- a/frontend/src/components/VideoElement.vue
+++ b/frontend/src/components/VideoElement.vue
@@ -29,6 +29,8 @@ import { Play, Pause } from 'lucide-vue-next'
 import { inSlideShow } from '@/stores/presentation'
 import { activeElementIds, setActiveElements } from '@/stores/element'
 
+const emit = defineEmits(['select'])
+
 const el = useTemplateRef('videoElement')
 const isPlaying = ref(false)
 
@@ -57,6 +59,8 @@ const handleVideoControls = (e) => {
 			isPlaying.value = false
 			video.pause()
 		}
-	} else setActiveElements([element.value.id])
+	} else {
+		emit('select', e)
+	}
 }
 </script>

--- a/frontend/src/components/VideoElement.vue
+++ b/frontend/src/components/VideoElement.vue
@@ -1,5 +1,5 @@
 <template>
-	<div @click="handleVideoControls">
+	<div @click="handleVideoClick">
 		<video
 			ref="videoElement"
 			:src="element.src"
@@ -27,17 +27,18 @@ import { ref, computed, useTemplateRef } from 'vue'
 import { Play, Pause } from 'lucide-vue-next'
 
 import { inSlideShow } from '@/stores/presentation'
-import { activeElementIds, setActiveElements } from '@/stores/element'
-
-const emit = defineEmits(['select'])
-
-const el = useTemplateRef('videoElement')
-const isPlaying = ref(false)
+import { activeElementIds } from '@/stores/element'
 
 const element = defineModel('element', {
 	type: Object,
 	default: null,
 })
+
+const emit = defineEmits(['select'])
+
+const el = useTemplateRef('videoElement')
+
+const isPlaying = ref(false)
 
 const videoStyle = computed(() => ({
 	borderRadius: `${element.value.borderRadius}px`,
@@ -47,19 +48,30 @@ const videoStyle = computed(() => ({
 	boxShadow: `${element.value.shadowOffsetX}px ${element.value.shadowOffsetY}px ${element.value.shadowSpread}px ${element.value.shadowColor}`,
 }))
 
-const handleVideoControls = (e) => {
+const togglePlaying = () => {
+	const video = el.value
+	if (video.paused) {
+		isPlaying.value = true
+		video.play()
+	} else {
+		isPlaying.value = false
+		video.pause()
+	}
+}
+
+const handleVideoClick = (e) => {
 	e.stopPropagation()
 	const isActive = activeElementIds.value.includes(element.value.id)
+
+	// in slideshow, always toggle playing on click anywhere
+	// in editor, toggle playing only when center play button is clicked
+
 	if (inSlideShow.value || (isActive && e.target !== el.value)) {
-		const video = el.value
-		if (video.paused) {
-			isPlaying.value = true
-			video.play()
-		} else {
-			isPlaying.value = false
-			video.pause()
-		}
-	} else {
+		togglePlaying()
+	}
+
+	// select element if clicked outside play button
+	else {
 		emit('select', e)
 	}
 }

--- a/frontend/src/components/VideoElement.vue
+++ b/frontend/src/components/VideoElement.vue
@@ -60,7 +60,6 @@ const togglePlaying = () => {
 }
 
 const handleVideoClick = (e) => {
-	e.stopPropagation()
 	const isActive = activeElementIds.value.includes(element.value.id)
 
 	// in slideshow, always toggle playing on click anywhere

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -70,6 +70,7 @@ import {
 import {
 	resetFocus,
 	activeElementIds,
+	activeElement,
 	focusElementId,
 	deleteElements,
 	duplicateElements,
@@ -165,7 +166,7 @@ const handleGlobalShortcuts = (e) => {
 			break
 		case 'b':
 			if (e.metaKey) {
-				if (activeElementIds.value.length && activeElements.value[0].type == 'text')
+				if (activeElementIds.value.length && activeElement.value.type == 'text')
 					return toggleTextProperty('fontWeight', 'bold')
 				showNavigator.value = !showNavigator.value
 			}

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -110,7 +110,7 @@ const handleArrowKeys = (key) => {
 	else if (key == 'ArrowUp') dy = -1
 	else if (key == 'ArrowDown') dy = 1
 
-	updateActivePosition({ dx, dy })
+	slideContainerRef.value.applyMovement({ dx, dy })
 }
 
 const handleElementShortcuts = (e) => {

--- a/frontend/src/pages/Slideshow.vue
+++ b/frontend/src/pages/Slideshow.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, useTemplateRef, onMounted, onBeforeUnmount } from 'vue'
+import { ref, computed, watch, useTemplateRef, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import SlideElement from '@/components/SlideElement.vue'
@@ -42,7 +42,7 @@ import {
 	inSlideShow,
 	applyReverseTransition,
 } from '@/stores/presentation'
-import { slide, slideIndex, changeSlide, loadSlide } from '@/stores/slide'
+import { slide, slideIndex, loadSlide } from '@/stores/slide'
 
 const slideContainerRef = useTemplateRef('slideContainer')
 
@@ -183,6 +183,16 @@ const initFullscreenMode = async () => {
 		})
 		inSlideShow.value = true
 	}
+}
+
+const changeSlide = (index) => {
+	if (index < 0 || index >= presentation.data.slides.length) return
+	applyReverseTransition.value = index < slideIndex.value
+
+	nextTick(() => {
+		slideIndex.value = index
+		loadSlide()
+	})
 }
 
 watch(

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -23,6 +23,14 @@ const activeElements = computed(() => {
 	return elements
 })
 
+const activeElement = computed(() => {
+	if (focusElementId.value) {
+		return slide.value.elements.find((element) => element.id === focusElementId.value)
+	} else {
+		return activeElements.value[0]
+	}
+})
+
 const setActiveElements = (ids, focus = false) => {
 	if (ids.length == 1 && focus) {
 		activeElementIds.value = []
@@ -145,7 +153,7 @@ const resetFocus = () => {
 }
 
 const toggleTextProperty = (property, value) => {
-	const oldStyle = activeElements.value[0][property]
+	const oldStyle = activeElement.value[property]
 	let newStyle = ''
 
 	switch (property) {
@@ -167,8 +175,7 @@ const toggleTextProperty = (property, value) => {
 				? oldStyle.replace(value, '')
 				: oldStyle + ' ' + value
 	}
-	let element = slide.value.elements.find((element) => element.id == activeElementIds.value[0])
-	element[property] = newStyle
+	activeElement.value[property] = newStyle
 }
 
 const moveElement = (elementId, movement) => {
@@ -205,6 +212,7 @@ export {
 	focusElementId,
 	pairElementId,
 	activeElements,
+	activeElement,
 	setActiveElements,
 	resetFocus,
 	addTextElement,

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -70,6 +70,7 @@ const addTextElement = () => {
 		element.color = guessTextColorFromBackground(slideColor)
 		element.lineHeight = 1
 		element.letterSpacing = 0
+		element.opacity = 100
 	}
 	slide.value.elements.push(element)
 	nextTick(() => setActiveElements([element.id]))

--- a/frontend/src/utils/drag.js
+++ b/frontend/src/utils/drag.js
@@ -10,7 +10,6 @@ export const useDragAndDrop = () => {
 	const startDragging = (e) => {
 		e.preventDefault()
 		e.stopPropagation()
-		isDragging.value = true
 		mouseX.value = e.clientX
 		mouseY.value = e.clientY
 		window.addEventListener('mousemove', drag)
@@ -19,6 +18,7 @@ export const useDragAndDrop = () => {
 
 	const drag = (e) => {
 		e.preventDefault()
+		isDragging.value = true
 		if (isDragging.value) {
 			const dx = mouseX.value - e.clientX
 			const dy = mouseY.value - e.clientY
@@ -35,7 +35,7 @@ export const useDragAndDrop = () => {
 
 	const stopDragging = (e) => {
 		e.preventDefault()
-		isDragging.value = false
+		e.stopPropagation()
 		window.removeEventListener('mousemove', drag)
 		window.removeEventListener('mouseup', stopDragging)
 	}
@@ -44,9 +44,9 @@ export const useDragAndDrop = () => {
 		() => dragTarget.value,
 		(newVal, oldVal) => {
 			oldVal?.removeEventListener('mousedown', startDragging)
+			oldVal?.removeEventListener('mouseup', stopDragging)
 			newVal?.addEventListener('mousedown', startDragging)
 		},
-		{ immediate: true },
 	)
 
 	return { dragTarget, isDragging, movement }


### PR DESCRIPTION
### Fixes

1. Reset the applied zoom transform when the slide is changed to capture the thumbnail with correct scale.
2. When a Text element is selected, enable editing with just one click.
3. Fix broken movement using keyboard shortcuts.
4. When transition is set or unset automatically set default durations.
5. Reflect position change introduced by left and top resizers on selection box so element can be resized from left correctly.