### PR TITLE
feat: apply default background 

### DIFF
--- a/frontend/src/components/PresentationHeader.vue
+++ b/frontend/src/components/PresentationHeader.vue
@@ -14,7 +14,6 @@
 			@click="makeTitleEditable"
 		>
 			<div>{{ presentation.data?.title }}</div>
-			<div class="text-gray-400 text-xs" v-if="slideDirty">*</div>
 		</div>
 	</div>
 </template>
@@ -26,7 +25,6 @@ import { useRoute, useRouter } from 'vue-router'
 import { call } from 'frappe-ui'
 
 import { presentation } from '@/stores/presentation'
-import { slideDirty } from '@/stores/slide'
 
 const route = useRoute()
 const router = useRouter()

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -29,7 +29,7 @@
 				<SquarePlus
 					size="14"
 					class="text-gray-800 stroke-[1.5]"
-					@click="emit('insert', slideIndex + 1)"
+					@click="emit('insert', slideIndex)"
 				/>
 			</div>
 		</div>

--- a/frontend/src/components/SlideElementsPanel.vue
+++ b/frontend/src/components/SlideElementsPanel.vue
@@ -21,24 +21,30 @@
 			</div>
 
 			<div :class="sectionClasses">
-				<div :class="sectionTitleClasses">Transition</div>
-				<FormControl
-					type="autocomplete"
-					:options="['Slide In', 'Fade', 'None']"
-					size="sm"
-					variant="subtle"
-					:modelValue="slide.transition || 'None'"
-					@update:modelValue="(option) => setSlideTransition(option)"
-				/>
+				<CollapsibleSection :title="'Transition'" :titleClasses="sectionTitleClasses">
+					<template #default>
+						<div class="flex flex-col gap-4">
+							<FormControl
+								type="autocomplete"
+								:options="['Slide In', 'Fade', 'None']"
+								size="sm"
+								variant="subtle"
+								:modelValue="slide.transition || 'None'"
+								@update:modelValue="(option) => setSlideTransition(option)"
+							/>
 
-				<SliderInput
-					label="Duration"
-					:rangeStart="0"
-					:rangeEnd="4"
-					:rangeStep="0.1"
-					:modelValue="parseFloat(slide.transitionDuration) || 0"
-					@update:modelValue="(value) => (slide.transitionDuration = value)"
-				/>
+							<SliderInput
+								v-show="slide.transition && slide.transition != 'None'"
+								label="Duration"
+								:rangeStart="0"
+								:rangeEnd="4"
+								:rangeStep="0.1"
+								:modelValue="parseFloat(slide.transitionDuration) || 0"
+								@update:modelValue="(value) => (slide.transitionDuration = value)"
+							/>
+						</div>
+					</template>
+				</CollapsibleSection>
 			</div>
 		</div>
 
@@ -275,6 +281,7 @@ import {
 	addTextElement,
 	addMediaElement,
 } from '@/stores/element'
+import CollapsibleSection from './controls/CollapsibleSection.vue'
 
 const activeTab = computed(() => {
 	if (activeElement.value) return activeElement.value.type

--- a/frontend/src/components/SlideNavigationPanel.vue
+++ b/frontend/src/components/SlideNavigationPanel.vue
@@ -7,11 +7,11 @@
 		@mouseleave="showCollapseShortcut = false"
 		@wheel="handleWheelEvent"
 	>
-		<div class="flex flex-col h-full ps-4 pe-3 overflow-y-auto" :style="scrollbarStyles">
+		<div class="flex flex-col h-full ps-4 pe-3 pb-12 overflow-y-auto" :style="scrollbarStyles">
 			<Draggable v-model="presentation.data.slides" item-key="name" @end="handleSortEnd">
 				<template #item="{ element: slide }">
 					<div
-						class="my-4 h-20 cursor-pointer rounded bg-center bg-no-repeat bg-cover border"
+						class="my-4 w-full aspect-video cursor-pointer rounded bg-center bg-no-repeat bg-cover border"
 						:class="getThumbnailClasses(slide)"
 						:style="getThumbnailStyles(slide)"
 						@click="emit('changeSlide', slide.idx - 1)"
@@ -20,7 +20,7 @@
 			</Draggable>
 
 			<div
-				class="flex h-20 cursor-pointer items-center justify-center rounded border border-dashed border-gray-400 shadow-lg shadow-gray-100 hover:border-blue-400 hover:bg-blue-50"
+				class="flex w-full aspect-video cursor-pointer items-center justify-center rounded border border-dashed border-gray-400 shadow-lg shadow-gray-100 hover:border-blue-400 hover:bg-blue-50"
 				@click="emit('insertSlide', presentation.data.slides.length - 1)"
 			>
 				<Plus size="14" class="stroke-[1.5]" />
@@ -32,7 +32,7 @@
 			class="fixed -left-0.4 bottom-0 z-20 flex h-10 w-44 cursor-pointer items-center justify-between border-t bg-white p-4"
 			@click="toggleNavigator"
 		>
-			<div class="text-2xs text-gray-500">Toggle Navigator</div>
+			<div class="text-2xs text-gray-500">Toggle Sidebar</div>
 			<div class="flex h-5 w-1/3 items-center justify-center rounded-sm border bg-gray-100">
 				<div class="text-xs text-gray-500">⌘ + B</div>
 			</div>

--- a/frontend/src/components/SlideNavigationPanel.vue
+++ b/frontend/src/components/SlideNavigationPanel.vue
@@ -21,7 +21,7 @@
 
 			<div
 				class="flex h-20 cursor-pointer items-center justify-center rounded border border-dashed border-gray-400 shadow-lg shadow-gray-100 hover:border-blue-400 hover:bg-blue-50"
-				@click="emit('insertSlide', presentation.data.slides.length)"
+				@click="emit('insertSlide', presentation.data.slides.length - 1)"
 			>
 				<Plus size="14" class="stroke-[1.5]" />
 			</div>

--- a/frontend/src/components/controls/CollapsibleSection.vue
+++ b/frontend/src/components/controls/CollapsibleSection.vue
@@ -1,0 +1,46 @@
+<template>
+	<div class="flex flex-col gap-4">
+		<div class="flex justify-between items-center">
+			<div :class="titleClasses">{{ title }}</div>
+			<component
+				@click="showContent = !showContent"
+				:is="showContent ? ChevronUp : ChevronDown"
+				size="16"
+				class="stroke-[1.5] text-gray-700 cursor-pointer"
+			/>
+		</div>
+
+		<transition name="slide-fade">
+			<div v-if="showContent">
+				<slot />
+			</div>
+		</transition>
+	</div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { ChevronDown, ChevronUp } from 'lucide-vue-next'
+
+const props = defineProps({
+	title: String,
+	titleClasses: {
+		type: String,
+		default: 'text-base text-gray-700',
+	},
+})
+
+const showContent = ref(false)
+</script>
+
+<style>
+.slide-fade-enter-active {
+	transition: all 0.1s ease-out;
+}
+
+.slide-fade-enter-from,
+.slide-fade-leave-to {
+	transform: translateY(-10px);
+	opacity: 0;
+}
+</style>

--- a/frontend/src/components/controls/ColorPicker.vue
+++ b/frontend/src/components/controls/ColorPicker.vue
@@ -2,7 +2,7 @@
 	<Popover>
 		<template #target="{ togglePopover }">
 			<div
-				class="my-2 h-4 w-4 cursor-pointer rounded-sm border ring-[1px] ring-gray-800 ring-offset-1"
+				class="my-2 h-4 w-4 cursor-pointer rounded-sm border border-gray-500"
 				:style="{ backgroundColor: currentColor }"
 				@click="togglePopover"
 			></div>

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -249,13 +249,14 @@ const changeSlide = async (index, updateCurrent = true) => {
 }
 
 const insertSlide = async (index) => {
+	resetFocus()
 	await saveChanges()
 	await call('slides.slides.doctype.presentation.presentation.insert_slide', {
 		name: presentationId.value,
 		index: index,
 	})
 	await presentation.reload()
-	await changeSlide(index)
+	await changeSlide(index + 1)
 }
 
 const deleteSlide = async () => {

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -260,6 +260,7 @@ const insertSlide = async (index) => {
 }
 
 const deleteSlide = async () => {
+	resetFocus()
 	await saveChanges()
 	await call('slides.slides.doctype.presentation.presentation.delete_slide', {
 		name: presentationId.value,
@@ -268,10 +269,12 @@ const deleteSlide = async () => {
 	await presentation.reload()
 	if (slideIndex.value == presentation.data.slides.length)
 		await changeSlide(slideIndex.value - 1, false)
+	else loadSlide()
 }
 
 const duplicateSlide = async (e) => {
 	e.preventDefault()
+	resetFocus()
 	await saveChanges()
 	await call('slides.slides.doctype.presentation.presentation.duplicate_slide', {
 		name: presentationId.value,

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -12,14 +12,6 @@
 			<template #default>
 				<PresentationHeader />
 			</template>
-
-			<template #actions>
-				<Button :loading="saving" :disabled="!slideDirty" @click="saveChanges">
-					<template #icon>
-						<Save size="14" class="stroke-[1.5]" />
-					</template>
-				</Button>
-			</template>
 		</Navbar>
 
 		<div v-if="presentation.data?.slides" class="flex h-full items-center justify-center">
@@ -58,15 +50,7 @@ import SlideElementsPanel from '@/components/SlideElementsPanel.vue'
 import SlideContainer from '@/components/SlideContainer.vue'
 
 import { presentationId, presentation, applyReverseTransition } from '@/stores/presentation'
-import {
-	slide,
-	slideIndex,
-	slideDirty,
-	saving,
-	saveChanges,
-	updateSlideState,
-	loadSlide,
-} from '@/stores/slide'
+import { slide, slideIndex, saving, saveChanges, updateSlideState, loadSlide } from '@/stores/slide'
 import {
 	resetFocus,
 	activeElementIds,
@@ -226,6 +210,7 @@ const handleMediaDrop = async (e) => {
 }
 
 const startSlideShow = async () => {
+	resetFocus()
 	await saveChanges()
 	await presentation.reload()
 	router.replace({
@@ -248,26 +233,14 @@ const handleAutoSave = () => {
 	saveChanges()
 }
 
-const getSlideThumbnail = async () => {
-	const slideRef = document.querySelector('.slide')
-	const scale = slideRef.getBoundingClientRect().width / 960
-	if (scale !== 1) {
-		return slide.value.thumbnail
-	}
-	const canvas = await html2canvas(slideRef)
-	return canvas.toDataURL('image/png')
-}
-
 const changeSlide = async (index, updateCurrent = true) => {
 	if (index < 0 || index >= presentation.data.slides.length) return
-	resetFocus()
 	slideContainerRef.value.togglePanZoom()
-	applyReverseTransition.value = index < slideIndex.value
 
 	nextTick(async () => {
 		if (updateCurrent) {
-			slide.value.thumbnail = await getSlideThumbnail()
-			await updateSlideState()
+			resetFocus()
+			await saveChanges()
 		}
 		slideIndex.value = index
 		loadSlide()

--- a/slides/slides/doctype/presentation/presentation.py
+++ b/slides/slides/doctype/presentation/presentation.py
@@ -36,6 +36,7 @@ def insert_slide(name, index):
 	new_slide.parentfield = "slides"
 	new_slide.parenttype = "Presentation"
 	new_slide.idx = index + 1
+	new_slide.background = presentation.slides[index - 1].background
 	new_slide.save()
 	presentation.slides = presentation.slides[: index + 1] + [new_slide] + presentation.slides[index + 1 :]
 	for i in range(index + 1, len(presentation.slides)):


### PR DESCRIPTION
### Changes
- When inserting a new slide, apply the previous background to the newly added slide automatically.
- Add collapsible section for Transition in Slide Properties so it can be hidden by default.
- While autosaving, check for updated thumbnail and update slide state accordingly.