### PR TITLE
feat: copy pasting across slides

### DIFF
--- a/frontend/src/components/DropTargetOverlay.vue
+++ b/frontend/src/components/DropTargetOverlay.vue
@@ -35,23 +35,33 @@ const handleDragLeave = (e) => {
 
 const fileUploadHandler = new FileUploadHandler()
 
+const uploadMedia = (file, fileType) => {
+	return new Promise((resolve, reject) => {
+		fileUploadHandler
+			.upload(file, { private: false })
+			.then((fileDoc) => {
+				addMediaElement(fileDoc, fileType)
+				resolve(fileDoc)
+			})
+			.catch((error) => {
+				reject(error)
+			})
+	})
+}
+
 const uploadFiles = (files) => {
 	files.forEach((file, index) => {
 		const fileType = file.type.split('/')[0]
 		if (!['image', 'video'].includes(fileType)) return
 
-		setTimeout(() => {
-			toast.promise(
-				fileUploadHandler.upload(file, { private: false }).then((fileDoc) => {
-					addMediaElement(fileDoc, fileType)
-				}),
-				{
-					loading: `Uploading (${index + 1}/${files.length}): ${file.name}`,
-					success: (data) => `Uploaded: ${file.name}`,
-					error: (data) => 'Upload failed. Please try again.',
-				},
-			)
-		}, 100)
+		const toastProps = {
+			loading: `Uploading (${index + 1}/${files.length}): ${file.name}`,
+			success: (data) => `Uploaded: ${file.name}`,
+			error: (data) => 'Upload failed. Please try again.',
+		}
+
+		// run after current call stack so toast's expand animation works
+		setTimeout(() => toast.promise(uploadMedia(file, fileType), toastProps), 0)
 	})
 }
 

--- a/frontend/src/components/DropTargetOverlay.vue
+++ b/frontend/src/components/DropTargetOverlay.vue
@@ -1,0 +1,69 @@
+<template>
+	<div
+		v-show="isMediaDragOver"
+		ref="overlay"
+		class="bg-blue-400 opacity-10 z-15 w-full h-full fixed top-0 left-0"
+		@dragleave.prevent="handleDragLeave"
+		@dragover.prevent
+		@drop="handleMediaDrop"
+	></div>
+</template>
+
+<script setup>
+import { ref, useTemplateRef } from 'vue'
+import { toast } from 'vue-sonner'
+
+import { FileUploadHandler } from 'frappe-ui'
+
+import { addMediaElement } from '@/stores/element'
+
+const overlayRef = useTemplateRef('overlay')
+
+const isMediaDragOver = ref(false)
+
+const handleDragEnter = (e) => {
+	e.preventDefault()
+	isMediaDragOver.value = true
+}
+
+const handleDragLeave = (e) => {
+	e.preventDefault()
+	if (!overlayRef.value.contains(e.relatedTarget)) {
+		isMediaDragOver.value = false
+	}
+}
+
+const fileUploadHandler = new FileUploadHandler()
+
+const uploadFiles = (files) => {
+	files.forEach((file, index) => {
+		const fileType = file.type.split('/')[0]
+		if (!['image', 'video'].includes(fileType)) return
+
+		setTimeout(() => {
+			toast.promise(
+				fileUploadHandler.upload(file, { private: false }).then((fileDoc) => {
+					addMediaElement(fileDoc, fileType)
+				}),
+				{
+					loading: `Uploading (${index + 1}/${files.length}): ${file.name}`,
+					success: (data) => `Uploaded: ${file.name}`,
+					error: (data) => 'Upload failed. Please try again.',
+				},
+			)
+		}, 100)
+	})
+}
+
+const handleMediaDrop = async (e) => {
+	e.preventDefault()
+	isMediaDragOver.value = false
+	const files = e.dataTransfer.files
+	uploadFiles(files)
+}
+
+defineExpose({
+	isMediaDragOver,
+	handleDragEnter,
+})
+</script>

--- a/frontend/src/components/SelectionBox.vue
+++ b/frontend/src/components/SelectionBox.vue
@@ -22,6 +22,7 @@ import {
 	activeElementIds,
 	setActiveElements,
 	moveElement,
+	getElementPosition,
 } from '@/stores/element'
 
 const emit = defineEmits(['updateFocus'])
@@ -105,14 +106,12 @@ const getElementsWithinBoxSurface = () => {
 	const boxBottom = bounds.top + bounds.height
 
 	slide.value.elements.forEach((element) => {
-		const elementRect = document
-			.querySelector(`[data-index="${element.id}"]`)
-			.getBoundingClientRect()
-
-		const elementLeft = (elementRect.left - slideBounds.left) / slideBounds.scale
-		const elementTop = (elementRect.top - slideBounds.top) / slideBounds.scale
-		const elementRight = elementLeft + elementRect.width / slideBounds.scale
-		const elementBottom = elementTop + elementRect.height / slideBounds.scale
+		const {
+			left: elementLeft,
+			top: elementTop,
+			right: elementRight,
+			bottom: elementBottom,
+		} = getElementPosition(element.id)
 
 		const withinWidth =
 			(boxRight >= elementLeft && boxLeft <= elementLeft) ||
@@ -154,12 +153,12 @@ const cropSelectionToFitContent = (elementIds) => {
 
 	// crop selection to selected element edges
 	elementIds.forEach((id) => {
-		const elementRect = document.querySelector(`[data-index="${id}"]`).getBoundingClientRect()
-
-		const elementLeft = (elementRect.left - slideBounds.left) / slideBounds.scale
-		const elementTop = (elementRect.top - slideBounds.top) / slideBounds.scale
-		const elementRight = elementLeft + elementRect.width / slideBounds.scale
-		const elementBottom = elementTop + elementRect.height / slideBounds.scale
+		const {
+			left: elementLeft,
+			top: elementTop,
+			right: elementRight,
+			bottom: elementBottom,
+		} = getElementPosition(id)
 
 		if (elementLeft < l) l = elementLeft
 		if (elementTop < t) t = elementTop

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -34,12 +34,6 @@
 			</div>
 		</div>
 	</div>
-
-	<!-- Media Drag Overlay -->
-	<div
-		v-show="highlight"
-		class="bg-blue-400 opacity-10 z-15 w-full h-full fixed top-0 left-0"
-	></div>
 </template>
 
 <script setup>

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -62,6 +62,8 @@ import {
 	updateActivePosition,
 	setActivePosition,
 	resizeElement,
+	copyElements,
+	pasteElements,
 } from '@/stores/element'
 
 import { useDragAndDrop } from '@/utils/drag'
@@ -344,6 +346,8 @@ watch(
 onMounted(() => {
 	if (!slideRef.value) return
 	updateSlideBounds()
+	document.addEventListener('copy', copyElements)
+	document.addEventListener('paste', pasteElements)
 })
 
 provide('slideDiv', slideRef)

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -201,7 +201,10 @@ const changeSlide = async (index, updateCurrent = true) => {
 
 	nextTick(async () => {
 		// update the current slide along with thumbnail
-		if (updateCurrent) slideIndex.value = index
+		if (updateCurrent) {
+			await saveChanges()
+		}
+		slideIndex.value = index
 		loadSlide()
 
 		// re-enable pan and zoom

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -111,7 +111,7 @@ const handleElementShortcuts = (e) => {
 			deleteElements(e)
 			break
 		case 'd':
-			if (e.metaKey) duplicateElements(e)
+			if (e.metaKey) duplicateElements(e, activeElements.value)
 			break
 		case 'i':
 			if (e.metaKey) toggleTextProperty('fontStyle', 'italic')

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -104,11 +104,11 @@ const addMediaElement = (file, type) => {
 	nextTick(() => setActiveElements([element.id]))
 }
 
-const duplicateElements = async (e) => {
+const duplicateElements = async (e, elements) => {
 	e.preventDefault()
 
 	let newSelection = []
-	const oldElements = activeElements.value
+	const oldElements = elements
 	activeElementIds.value = []
 
 	await nextTick()
@@ -206,6 +206,43 @@ const updateActivePosition = (positionChange) => {
 	})
 }
 
+const getElementPosition = (elementId) => {
+	const elementRect = document
+		.querySelector(`[data-index="${elementId}"]`)
+		.getBoundingClientRect()
+
+	const elementLeft = (elementRect.left - slideBounds.left) / slideBounds.scale
+	const elementTop = (elementRect.top - slideBounds.top) / slideBounds.scale
+	const elementRight = elementLeft + elementRect.width / slideBounds.scale
+	const elementBottom = elementTop + elementRect.height / slideBounds.scale
+
+	return {
+		left: elementLeft,
+		top: elementTop,
+		right: elementRight,
+		bottom: elementBottom,
+	}
+}
+
+const copyElements = (e) => {
+	e.preventDefault()
+	const elements = JSON.parse(JSON.stringify(activeElements.value))
+	elements.forEach((element) => {
+		const { left, top } = getElementPosition(element.id)
+		element.left = left
+		element.top = top
+	})
+	const clipboardText = JSON.stringify(elements)
+	e.clipboardData.setData('text/plain', clipboardText)
+}
+
+const pasteElements = (e) => {
+	e.preventDefault()
+	const clipboardText = e.clipboardData.getData('text/plain')
+	const elements = JSON.parse(clipboardText)
+	duplicateElements(e, elements)
+}
+
 export {
 	activePosition,
 	activeDimensions,
@@ -226,4 +263,7 @@ export {
 	resizeElement,
 	setActivePosition,
 	updateActivePosition,
+	getElementPosition,
+	copyElements,
+	pasteElements,
 }


### PR DESCRIPTION
### Description
Apart from duplicating elements directly onto the current slide, allow copying multiple selected elements onto the clipboard and paste them across slides.

#### Screen Recording
https://github.com/user-attachments/assets/f092d1b2-aedd-4b83-b0c4-64a54a3e3bc3

<br>

----

<br>

### Fix

When reordering slides, the overlay that shows up when a media element is dragged over the slide showed up incorrectly due to the dragenter event getting triggered from the navigation panel. Now, the handler for dragenter only runs when the dragging file is hovering over the slide container except the side panels.

<details>
<summary>Before</summary>

<br>

https://github.com/user-attachments/assets/0268c07c-93ad-4114-b029-2afb8e91b92e
</details>

<br>

<details>
<summary>After</summary>

<br>

https://github.com/user-attachments/assets/cc13fa5a-1f80-4b07-8526-b4b096e39724
</details>


