### PR TITLE
feat: create text element for pasted plain text

### DIFF
--- a/frontend/src/components/SelectionBox.vue
+++ b/frontend/src/components/SelectionBox.vue
@@ -168,8 +168,8 @@ const cropSelectionToFitContent = (elementIds) => {
 
 	bounds.left = l
 	bounds.top = t
-	bounds.width = r - l
-	bounds.height = b - t
+	bounds.width = r - l + 1
+	bounds.height = b - t + 1
 }
 
 const resetSelection = (oldVal) => {

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -46,8 +46,8 @@ import {
 	updateActivePosition,
 	setActivePosition,
 	resizeElement,
-	copyElements,
-	pasteElements,
+	handleCopy,
+	handlePaste,
 } from '@/stores/element'
 
 import { useDragAndDrop } from '@/utils/drag'
@@ -328,8 +328,8 @@ watch(
 onMounted(() => {
 	if (!slideRef.value) return
 	updateSlideBounds()
-	document.addEventListener('copy', copyElements)
-	document.addEventListener('paste', pasteElements)
+	document.addEventListener('copy', handleCopy)
+	document.addEventListener('paste', handlePaste)
 })
 
 provide('slideDiv', slideRef)

--- a/frontend/src/components/SlideElement.vue
+++ b/frontend/src/components/SlideElement.vue
@@ -23,6 +23,7 @@ import {
 	setActiveElements,
 	activeElement,
 } from '@/stores/element'
+import { inSlideShow } from '@/stores/presentation'
 
 const element = defineModel('element', {
 	type: Object,
@@ -72,6 +73,8 @@ const focusOnElement = (e) => {
 }
 
 const selectElement = (e) => {
+	if (inSlideShow.value) return
+
 	e.stopPropagation()
 
 	// avoid the click event from firing after a drag

--- a/frontend/src/components/VideoElement.vue
+++ b/frontend/src/components/VideoElement.vue
@@ -66,6 +66,7 @@ const handleVideoClick = (e) => {
 	// in editor, toggle playing only when center play button is clicked
 
 	if (inSlideShow.value || (isActive && e.target !== el.value)) {
+		e.stopPropagation()
 		togglePlaying()
 	}
 

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -42,14 +42,14 @@ const setActiveElements = (ids, focus = false) => {
 	}
 }
 
-const addTextElement = () => {
+const addTextElement = (text) => {
 	const lastTextElement = slide.value.elements.reverse().find((element) => element.type == 'text')
 
 	const element = {
 		id: generateUniqueId(),
 		left: 100,
 		top: 100,
-		content: 'Text',
+		content: text || 'Text',
 		type: 'text',
 		textAlign: 'center',
 	}
@@ -243,6 +243,8 @@ const handleCopy = (e) => {
 const pasteText = (clipboardText) => {
 	if (activeElement.value) {
 		document.execCommand('insertText', false, clipboardText)
+	} else {
+		addTextElement(clipboardText)
 	}
 }
 

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -241,9 +241,10 @@ const handleCopy = (e) => {
 }
 
 const pasteText = (clipboardText) => {
-	if (activeElement.value) {
+	if (focusElementId.value) {
 		document.execCommand('insertText', false, clipboardText)
 	} else {
+		resetFocus()
 		addTextElement(clipboardText)
 	}
 }

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -224,23 +224,45 @@ const getElementPosition = (elementId) => {
 	}
 }
 
-const copyElements = (e) => {
-	e.preventDefault()
-	const elements = JSON.parse(JSON.stringify(activeElements.value))
-	elements.forEach((element) => {
+const getCopiedJSON = () => {
+	const elementsCopy = JSON.parse(JSON.stringify(activeElements.value))
+	elementsCopy.forEach((element) => {
 		const { left, top } = getElementPosition(element.id)
 		element.left = left
 		element.top = top
 	})
-	const clipboardText = JSON.stringify(elements)
-	e.clipboardData.setData('text/plain', clipboardText)
+	return JSON.stringify(elementsCopy)
 }
 
-const pasteElements = (e) => {
+const handleCopy = (e) => {
 	e.preventDefault()
-	const clipboardText = e.clipboardData.getData('text/plain')
-	const elements = JSON.parse(clipboardText)
+	const clipboardJSON = getCopiedJSON()
+	e.clipboardData.setData('application/json', clipboardJSON)
+}
+
+const pasteText = (clipboardText) => {
+	if (activeElement.value) {
+		document.execCommand('insertText', false, clipboardText)
+	}
+}
+
+const pasteElements = (e, clipboardJSON) => {
+	const elements = JSON.parse(clipboardJSON)
 	duplicateElements(e, elements)
+}
+
+const handlePaste = (e) => {
+	e.preventDefault()
+
+	const clipboardText = e.clipboardData.getData('text/plain')
+	if (clipboardText) {
+		return pasteText(clipboardText)
+	}
+
+	const clipboardJSON = e.clipboardData.getData('application/json')
+	if (clipboardJSON) {
+		return pasteElements(e, clipboardJSON)
+	}
 }
 
 export {
@@ -264,6 +286,6 @@ export {
 	setActivePosition,
 	updateActivePosition,
 	getElementPosition,
-	copyElements,
-	pasteElements,
+	handleCopy,
+	handlePaste,
 }


### PR DESCRIPTION
### Description
Allow directly pasting plain text content from clipboard as a new Text Element. 
- If a Text Element is already getting edited, insert the text normally without changing current styles. 
- Otherwise, create a new Text Element with the pasted text.

<br>

https://github.com/user-attachments/assets/c4ca8e34-f83d-4a65-ab6c-7d3ea206cbdf



<br>

### Tiny Fixes
- Toggling Video controls broke due to incorrect event propagation leading to the slide changing instead of the video playing so fixed that.
- For extremely fitted content, when the selection box was cropped, fixed overflow issue.