### PR TITLE
fix: minimum resizable width

### DIFF
--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -135,8 +135,8 @@ const handlePositionChange = (position) => {
 		return
 	}
 	selectionBoxRef.value.setBoxBounds({
-		left: position.left - slideBounds.left,
-		top: position.top - slideBounds.top,
+		left: (position.left - slideBounds.left) / slideBounds.scale,
+		top: (position.top - slideBounds.top) / slideBounds.scale,
 	})
 }
 

--- a/frontend/src/components/TextElement.vue
+++ b/frontend/src/components/TextElement.vue
@@ -15,7 +15,7 @@
 import { computed, nextTick } from 'vue'
 
 import { inSlideShow } from '@/stores/presentation'
-import { focusElementId } from '@/stores/element'
+import { focusElementId, deleteElements } from '@/stores/element'
 import { handleSingleAndDoubleClick } from '@/utils/helpers'
 
 const element = defineModel('element', {
@@ -69,6 +69,9 @@ const setCursorPosition = (e) => {
 }
 
 const handleBlur = (e) => {
+	if (element.value.content.trim() === '') {
+		deleteElements()
+	}
 	element.value.content = e.target.innerText
 }
 </script>

--- a/frontend/src/components/Toolbar.vue
+++ b/frontend/src/components/Toolbar.vue
@@ -3,7 +3,7 @@
 		class="bg-white w-48 rounded-lg h-10 fixed bottom-10 left-[calc(50%-128px)] shadow-2xl flex items-center gap-1 p-1 justify-center"
 	>
 		<Tooltip text="Text" :hover-delay="0.7" placement="bottom">
-			<div class="p-2 rounded hover:bg-gray-100 cursor-pointer" @click="addTextElement">
+			<div class="p-2 rounded hover:bg-gray-100 cursor-pointer" @click="addTextElement(null)">
 				<Type size="16" class="stroke-[1.5]" />
 			</div>
 		</Tooltip>

--- a/frontend/src/components/VideoElement.vue
+++ b/frontend/src/components/VideoElement.vue
@@ -4,7 +4,7 @@
 			ref="videoElement"
 			:src="element.src"
 			:style="videoStyle"
-			:autoplay="inSlideShow ? element.autoPlay : false"
+			:autoplay="inSlideShow ? element.autoplay : false"
 			:loop="element.loop"
 			:playbackRate="element.playbackRate"
 		/>

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -96,7 +96,7 @@ const addMediaElement = (file, type) => {
 		shadowColor: '#000000',
 	}
 	if (type == 'video') {
-		element.autoPlay = false
+		element.autoplay = false
 		element.loop = false
 		element.playbackRate = 1
 	}

--- a/frontend/src/utils/resizer.js
+++ b/frontend/src/utils/resizer.js
@@ -92,7 +92,9 @@ export const useResizer = (position, resizeDimensions) => {
 				break
 		}
 
-		if (resizeMode.value == 'both' && newWidth > 75 * slideBounds.scale) {
+		const widthLimit = resizeMode.value == 'width' ? 20 : 75
+
+		if (newWidth > widthLimit * slideBounds.scale) {
 			resizeDimensions.value = { width: newWidth }
 			position.value = { left: newLeft, top: newTop }
 		}

--- a/frontend/src/utils/resizer.js
+++ b/frontend/src/utils/resizer.js
@@ -1,4 +1,5 @@
 import { watch, ref, computed } from 'vue'
+import { slideBounds } from '../stores/slide'
 
 export const useResizer = (position, resizeDimensions) => {
 	const resizeTarget = ref(null)
@@ -91,8 +92,10 @@ export const useResizer = (position, resizeDimensions) => {
 				break
 		}
 
-		resizeDimensions.value = { width: newWidth }
-		position.value = { left: newLeft, top: newTop }
+		if (resizeMode.value == 'both' && newWidth > 75 * slideBounds.scale) {
+			resizeDimensions.value = { width: newWidth }
+			position.value = { left: newLeft, top: newTop }
+		}
 
 		prevX = e.clientX
 		prevY = e.clientY

--- a/frontend/src/utils/resizer.js
+++ b/frontend/src/utils/resizer.js
@@ -1,5 +1,4 @@
 import { watch, ref, computed } from 'vue'
-import { handleSingleAndDoubleClick } from './helpers'
 
 export const useResizer = (position, resizeDimensions) => {
 	const resizeTarget = ref(null)
@@ -119,19 +118,16 @@ export const useResizer = (position, resizeDimensions) => {
 		resizeDimensions.value = { width: textWidth + 10 }
 	}
 
-	const handleDoubleClick = (e) => {
-		e.stopImmediatePropagation()
-		handleSingleAndDoubleClick(e, startResize, resizeToFitContent)
-	}
-
 	const addResizers = (el) => {
 		resizeHandles.value.forEach((handle) => {
 			const resizer = document.createElement('div')
 			resizer.classList.add(`resizer-${resizeMode.value}`, `resizer-${handle}`)
 
 			// add double click event to fit content based on type of element
-			const mousedownHandler = resizeMode.value == 'width' ? handleDoubleClick : startResize
-			resizer.addEventListener('mousedown', mousedownHandler)
+			if (resizeMode.value == 'width') {
+				resizer.addEventListener('dblclick', resizeToFitContent)
+			}
+			resizer.addEventListener('mousedown', startResize)
 
 			el.appendChild(resizer)
 		})


### PR DESCRIPTION
Elements like empty text elements and extremely small media elements stay invisible and interfere with the movement and other interactions in the slide.

Any text elements with no content are removed and width and a set minimum width for media elements is checked for.