### PR TITLE
fix: cases for selection and dragging behaviour + misc

### DIFF
--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="z-10 flex items-center justify-between bg-white p-2 shadow-xl" @wheel.prevent>
+	<div class="z-10 flex items-center justify-between bg-white p-2 border-b" @wheel.prevent>
 		<router-link class="flex items-center gap-2" :to="{ name: 'Home' }">
 			<img src="../icons/slides.svg" class="h-7" />
 			<div class="text-base font-semibold">Slides</div>

--- a/frontend/src/components/NavigationPanel.vue
+++ b/frontend/src/components/NavigationPanel.vue
@@ -20,7 +20,7 @@
 			</Draggable>
 
 			<div
-				class="flex w-full aspect-video cursor-pointer items-center justify-center rounded border border-dashed border-gray-400 shadow-lg shadow-gray-100 hover:border-blue-400 hover:bg-blue-50"
+				class="flex w-full aspect-video cursor-pointer items-center justify-center rounded border border-dashed border-gray-400 hover:border-blue-400 hover:bg-blue-50"
 				@click="emit('insertSlide', presentation.data.slides.length - 1)"
 			>
 				<LucidePlus class="h-3.5 w-3.5" />

--- a/frontend/src/components/NavigationPanel.vue
+++ b/frontend/src/components/NavigationPanel.vue
@@ -1,7 +1,7 @@
 <template>
 	<!-- Slide Navigation Panel -->
 	<div
-		class="fixed z-20 h-[94.27%] w-48 border-r bg-white shadow-2xl shadow-gray-300 transition-all duration-300 ease-in-out"
+		class="fixed z-20 h-[94.27%] w-48 border-r bg-white transition-all duration-300 ease-in-out"
 		:class="showNavigator ? 'left-0' : '-left-48'"
 		@mouseenter="showCollapseShortcut = true"
 		@mouseleave="showCollapseShortcut = false"

--- a/frontend/src/components/PropertiesPanel.vue
+++ b/frontend/src/components/PropertiesPanel.vue
@@ -1,8 +1,5 @@
 <template>
-	<div
-		class="fixed right-0 z-20 flex flex-col h-[94.35%] w-64 bg-white border-l shadow-[0_10px_24px_-3px_rgba(199,199,199,0.6)]"
-		@wheel.prevent
-	>
+	<div class="fixed right-0 z-20 flex flex-col h-[94.35%] w-64 bg-white border-l" @wheel.prevent>
 		<component :is="activeProperties" />
 
 		<div v-if="activeElement" :class="sectionClasses">

--- a/frontend/src/components/SelectionBox.vue
+++ b/frontend/src/components/SelectionBox.vue
@@ -6,9 +6,12 @@
 import { ref, computed, nextTick, useTemplateRef, onMounted, onBeforeUnmount, inject } from 'vue'
 
 import { slide, slideBounds, selectionBounds } from '@/stores/slide'
-import { activeElementIds, setActiveElements, getElementPosition } from '@/stores/element'
-
-const emit = defineEmits(['updateFocus'])
+import {
+	activeElementIds,
+	setActiveElements,
+	getElementPosition,
+	resetFocus,
+} from '@/stores/element'
 
 const slideDiv = inject('slideDiv')
 const slideContainerDiv = inject('slideContainerDiv')
@@ -179,7 +182,7 @@ const handleMouseLeave = () => {
 
 const handleMouseUp = (e) => {
 	if (new Date().getTime() < mousedownStart + longpressDuration) {
-		emit('updateFocus', e)
+		selectSlide(e)
 		clearTimeout(mousedownTimer)
 	} else {
 		mousedownStart = 0
@@ -223,6 +226,12 @@ const handleSelectionChange = (elementIds, oldIds) => {
 		cropSelectionToFitContent(elementIds)
 		moveElementsToBox(elementIds)
 	}
+}
+
+const selectSlide = (e) => {
+	e.preventDefault()
+	e.stopPropagation()
+	resetFocus()
 }
 
 onMounted(() => {

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -126,11 +126,13 @@ const handleMouseUp = (e, id) => {
 }
 
 const triggerDrag = (e, id) => {
-	if (id && focusElementId.value !== id) {
+	if ((id && focusElementId.value !== id) || activeElementIds.value.length > 1) {
 		startDragging(e)
 
-		activeElementIds.value = [id]
-		focusElementId.value = null
+		if (id && activeElementIds.value.length < 2) {
+			activeElementIds.value = [id]
+			focusElementId.value = null
+		}
 	}
 }
 

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -126,12 +126,12 @@ const handleMouseUp = (e, id) => {
 }
 
 const triggerDrag = (e, id) => {
-	if (id && !activeElementIds.value.includes(id) && focusElementId.value !== id) {
+	if (id && focusElementId.value !== id) {
+		startDragging(e)
+
 		activeElementIds.value = [id]
 		focusElementId.value = null
 	}
-
-	startDragging(e)
 }
 
 const handleMouseDown = (e, element) => {

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -125,7 +125,7 @@ const triggerDrag = (e, id) => {
 	if ((id && focusElementId.value !== id) || activeElementIds.value.length > 1) {
 		startDragging(e)
 
-		if (id && activeElementIds.value.length < 2) {
+		if (id && activeElementIds.value.length < 2 && activeElementIds.value[0] !== id) {
 			activeElementIds.value = [id]
 			focusElementId.value = null
 		}

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -118,7 +118,7 @@ const handleMouseUp = (e, id) => {
 
 	pairElementId.value = null
 
-	clickTimeout = setTimeout(() => triggerSelection(e, id), 100)
+	if (!isDragging.value) clickTimeout = setTimeout(() => triggerSelection(e, id), 100)
 }
 
 const triggerDrag = (e, id) => {

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -8,11 +8,7 @@
 			class="fixed top-[calc(50%-270px)] left-[calc(50%-512px)]"
 		>
 			<div ref="slideRef" :class="slideClasses" :style="slideStyles">
-				<SelectionBox
-					ref="selectionBox"
-					@mousedown="(e) => handleMouseDown(e)"
-					@updateFocus="updateFocus"
-				/>
+				<SelectionBox ref="selectionBox" @mousedown="(e) => handleMouseDown(e)" />
 
 				<SnapGuides v-if="isDragging" :visibilityMap="visibilityMap" />
 
@@ -39,7 +35,7 @@ import SelectionBox from '@/components/SelectionBox.vue'
 import SlideElement from '@/components/SlideElement.vue'
 
 import { presentation } from '@/stores/presentation'
-import { slide, selectSlide, slideBounds, selectionBounds } from '@/stores/slide'
+import { slide, slideBounds, selectionBounds } from '@/stores/slide'
 import {
 	activeElement,
 	activeElementIds,
@@ -176,14 +172,6 @@ const scale = computed(() => {
 	if (!matrix) return 1
 	return parseFloat(matrix[1].split(', ')[0])
 })
-
-const updateFocus = (e) => {
-	if (isResizing.value) {
-		isResizing.value = false
-		return
-	}
-	selectSlide(e)
-}
 
 const updateResizeHandler = (index) => {
 	const targetElement = document.querySelector(`[data-index="${index}"]`)

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -142,6 +142,7 @@ const handleMouseDown = (e, element) => {
 	// resume normal behavior if element is being edited
 	if (id === focusElementId.value) return
 
+	e.stopPropagation()
 	e.preventDefault()
 
 	// wait for click to be registered

--- a/frontend/src/components/Toolbar.vue
+++ b/frontend/src/components/Toolbar.vue
@@ -1,6 +1,6 @@
 <template>
 	<div
-		class="bg-white w-48 rounded-lg h-10 fixed bottom-10 left-[calc(50%-128px)] shadow-2xl flex items-center gap-1 p-1 justify-center"
+		class="bg-white w-48 rounded-lg h-10 fixed bottom-10 left-[calc(50%-128px)] shadow-xl flex items-center gap-1 p-1 justify-center"
 	>
 		<Tooltip text="Text" :hover-delay="0.7" placement="bottom">
 			<div class="p-2 rounded hover:bg-gray-100 cursor-pointer" @click="addTextElement(null)">

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -262,6 +262,17 @@ const insertSlide = async (index) => {
 }
 
 const deleteSlide = async () => {
+	if (presentation.data.slides.length == 1) {
+		slide.value = {
+			...slide.value,
+			thumbnail: '',
+			elements: [],
+			background: '',
+			transition: '',
+			transitionDuration: 0,
+		}
+		return
+	}
 	await performSlideAction('delete', slideIndex.value)
 	if (slideIndex.value == presentation.data.slides.length)
 		changeSlide(slideIndex.value - 1, false)

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -2,7 +2,7 @@
 	<div
 		ref="mediaDropContainer"
 		class="fixed flex h-screen w-screen flex-col select-none"
-		:class="!activeElementIds.length ? 'bg-gray-200' : 'bg-gray-50'"
+		:class="!activeElementIds.length ? 'bg-gray-300' : 'bg-gray-100'"
 	>
 		<Navbar :primaryButton="primaryButtonProps">
 			<template #default>

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -131,7 +131,7 @@ const handleElementShortcuts = (e) => {
 			deleteElements(e)
 			break
 		case 'd':
-			if (e.metaKey) duplicateElements(e, activeElements.value)
+			if (e.metaKey) duplicateElements(e, activeElements.value, 40)
 			break
 		case 'i':
 			if (e.metaKey) toggleTextProperty('fontStyle', 'italic')

--- a/frontend/src/pages/Slideshow.vue
+++ b/frontend/src/pages/Slideshow.vue
@@ -23,6 +23,7 @@
 						:key="element.id"
 						:element="element"
 						:data-index="element.id"
+						@click.stop
 					/>
 				</div>
 			</Transition>

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -101,7 +101,7 @@ const addMediaElement = (file, type) => {
 	nextTick(() => setActiveElements([element.id]))
 }
 
-const duplicateElements = async (e, elements) => {
+const duplicateElements = async (e, elements, displaceByPx = 0) => {
 	e.preventDefault()
 
 	let newSelection = []
@@ -113,8 +113,8 @@ const duplicateElements = async (e, elements) => {
 	oldElements.forEach((element) => {
 		let newElement = JSON.parse(JSON.stringify(element))
 		newElement.id = generateUniqueId()
-		newElement.top += 40
-		newElement.left += 40
+		newElement.top += displaceByPx
+		newElement.left += displaceByPx
 		slide.value.elements.push(newElement)
 		newSelection.push(newElement.id)
 	})

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -2,7 +2,7 @@ import { ref, computed, nextTick, reactive } from 'vue'
 import { call } from 'frappe-ui'
 
 import { presentationId, presentation, inSlideShow } from './presentation'
-import { activeElementIds, resetFocus } from './element'
+import { activeElementIds } from './element'
 
 import { isEqual } from 'lodash'
 import html2canvas from 'html2canvas'
@@ -102,21 +102,6 @@ const saveChanges = async () => {
 	await presentation.reload()
 }
 
-const selectSlide = (e) => {
-	e.preventDefault()
-	e.stopPropagation()
-	resetFocus()
-}
-
 const slideBounds = reactive({})
 
-export {
-	slideIndex,
-	slide,
-	slideBounds,
-	selectionBounds,
-	loadSlide,
-	updateSlideState,
-	saveChanges,
-	selectSlide,
-}
+export { slideIndex, slide, slideBounds, selectionBounds, loadSlide, updateSlideState, saveChanges }

--- a/frontend/src/utils/resizer.js
+++ b/frontend/src/utils/resizer.js
@@ -26,6 +26,8 @@ export const useResizer = () => {
 		e.preventDefault()
 		e.stopImmediatePropagation()
 
+		isResizing.value = true
+
 		currentResizer.value = e.target.classList[1]
 		isResizing.value = true
 
@@ -81,6 +83,8 @@ export const useResizer = () => {
 	const stopResize = (e) => {
 		e.preventDefault()
 		e.stopImmediatePropagation()
+
+		isResizing.value = false
 
 		window.removeEventListener('mousemove', resize)
 		window.removeEventListener('mouseup', stopResize)

--- a/frontend/src/utils/snap.js
+++ b/frontend/src/utils/snap.js
@@ -62,7 +62,6 @@ export const useSnapping = (target, parent) => {
 		let slideCenter, elementCenter
 
 		const activeBounds = getElementBounds(target.value.$el)
-		const slideBounds = getElementBounds(parent.value)
 
 		if (axis == 'X') {
 			slideCenter = slideBounds.left + slideBounds.width / 2

--- a/frontend/src/utils/snap.js
+++ b/frontend/src/utils/snap.js
@@ -29,6 +29,7 @@ export const useSnapping = (target, parent) => {
 	})
 
 	const visibilityMap = computed(() => {
+		if (!target.value) return
 		return {
 			vertical: Math.abs(diffs.vertical) < PROXIMITY_THRESHOLD,
 			horizontal: Math.abs(diffs.horizontal) < PROXIMITY_THRESHOLD,

--- a/frontend/src/utils/snap.js
+++ b/frontend/src/utils/snap.js
@@ -29,8 +29,6 @@ export const useSnapping = (target, parent) => {
 	})
 
 	const visibilityMap = computed(() => {
-		if (!target.value?.$el) return { vertical: false, horizontal: false }
-
 		return {
 			vertical: Math.abs(diffs.vertical) < PROXIMITY_THRESHOLD,
 			horizontal: Math.abs(diffs.horizontal) < PROXIMITY_THRESHOLD,


### PR DESCRIPTION
### Description 
Fixed a few cases where the selection, editing and drag behaviour was affected due to recent changes. 
1. Fixed the bug where a drag is triggered unnecessarily for currently editing element. Also fixed the incorrect initial values for visibilityMap because the center guides show up in that split second. In the clip below, the element is only clicked and moved so dragging should not occur without explicitly holding the mouse down.

   <details>

   <summary>Before</summary>

   <br>

   https://github.com/user-attachments/assets/bf5b8e0f-65c3-4274-88c3-e6e6efc8344c

   </details>

   <details>
   <summary>After</summary>
  
    <br>

    https://github.com/user-attachments/assets/0fc424af-d73c-47c6-9871-d46f2d147d5e

   </details>


2. When the selection box encloses multiple elements, if the initial position of the drag is on an element outside the box -> override the selection. If it's from an element within the selection box -> don't override the selection.

    <details>
    <summary>Before</summary>
   
      <br>
  
      https://github.com/user-attachments/assets/ce57e1be-5406-408c-8e52-5f70e52602cb
    </details>
  
    <details>
    
    <summary>After</summary>
      
      <br>
      
      https://github.com/user-attachments/assets/de8c87e0-0596-41f4-b21d-16a0715101e0
    
    </details>


3. The play toggle button used in Video Element, triggers drag so avoid event propagation from the button to the selection box.

    <details>
    <summary>Before</summary>
   
    <br>

    https://github.com/user-attachments/assets/b1e75972-883d-40ff-9459-9f12f520f2a2

    </details>
    
    <details>
    <summary>After</summary>
    
    <br>

    https://github.com/user-attachments/assets/3f75f78a-e7a0-445c-914b-a01c610357b8

    </details>


<br>

### Other

- Removed the shadow from the Editor component.
- When a set of elements is pasted on a new slide, don't displace it by a few pixels to the bottom-right like duplicated elements. The standard behaviour for pasted elements is on the same position and for duplicated ones is to the bottom-right.
- Remove hacky way to handle refocusing on slide after a resize is done.