### PR TITLE
fix: cleanup slide state before leaving editor + new slide thumbnail

### DIFF
--- a/frontend/src/components/PresentationList.vue
+++ b/frontend/src/components/PresentationList.vue
@@ -48,7 +48,7 @@ const emit = defineEmits(['setPreview'])
 
 const getCardStyles = (presentation) => {
 	return {
-		backgroundImage: `url(${presentation.slides[0].thumbnail})`,
+		backgroundImage: `url(${presentation.thumbnail || ''})`,
 		backgroundSize: 'cover',
 		backgroundPosition: 'center',
 	}

--- a/frontend/src/components/PresentationPreview.vue
+++ b/frontend/src/components/PresentationPreview.vue
@@ -87,18 +87,21 @@ let interval = null
 const previewSlide = ref(0)
 
 const slideThumbnails = createResource({
-	url: 'slides.slides.doctype.presentation.presentation.get_thumbnails',
+	url: 'slides.slides.doctype.presentation.presentation.get_slide_thumbnails',
 	method: 'GET',
 	makeParams: () => ({
 		presentation: props.presentation.name,
 	}),
 })
 
-const previewStyles = computed(() => ({
-	backgroundImage: `url(${slideThumbnails.data?.[previewSlide.value].thumbnail || props.presentation.thumbnail})`,
-	backgroundSize: 'cover',
-	backgroundPosition: 'center',
-}))
+const previewStyles = computed(() => {
+	const thumbnail = slideThumbnails.data?.[previewSlide.value] || props.presentation.thumbnail
+	return {
+		backgroundImage: `url(${thumbnail})`,
+		backgroundSize: 'cover',
+		backgroundPosition: 'center',
+	}
+})
 
 const previewDetails = computed(() => {
 	if (!props.presentation) return {}

--- a/frontend/src/components/PresentationPreview.vue
+++ b/frontend/src/components/PresentationPreview.vue
@@ -67,9 +67,9 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, onBeforeUnmount } from 'vue'
+import { ref, computed, watch, onBeforeUnmount, onMounted } from 'vue'
 
-import { Tooltip } from 'frappe-ui'
+import { Tooltip, createResource } from 'frappe-ui'
 
 import { Presentation, Copy, PenLine, Trash } from 'lucide-vue-next'
 
@@ -77,6 +77,7 @@ import dayjs from '@/utils/dayjs'
 
 const props = defineProps({
 	presentation: Object,
+	required: true,
 })
 
 const emit = defineEmits(['setPreview', 'openDialog', 'navigate'])
@@ -85,8 +86,16 @@ let interval = null
 
 const previewSlide = ref(0)
 
+const slideThumbnails = createResource({
+	url: 'slides.slides.doctype.presentation.presentation.get_thumbnails',
+	method: 'GET',
+	makeParams: () => ({
+		presentation: props.presentation.name,
+	}),
+})
+
 const previewStyles = computed(() => ({
-	backgroundImage: `url(${props.presentation?.slides[previewSlide.value]?.thumbnail})`,
+	backgroundImage: `url(${slideThumbnails.data?.[previewSlide.value].thumbnail || props.presentation.thumbnail})`,
 	backgroundSize: 'cover',
 	backgroundPosition: 'center',
 }))
@@ -94,14 +103,14 @@ const previewStyles = computed(() => ({
 const previewDetails = computed(() => {
 	if (!props.presentation) return {}
 
-	const { title, slides, creation, modified } = props.presentation
+	const { title, creation, modified } = props.presentation
 	return [
 		{
 			Title: title,
 			Modified: dayjs(modified).fromNow(),
 		},
 		{
-			'Total Slides': slides.length,
+			'Total Slides': slideThumbnails.data?.length,
 			Created: dayjs(creation).fromNow(),
 		},
 	]
@@ -130,10 +139,14 @@ const presentationActions = [
 	},
 ]
 
-const initPreview = () => {
-	interval = setInterval(() => {
-		previewSlide.value = (previewSlide.value + 1) % props.presentation.slides.length
-	}, 2000)
+const updateCurrentThumbnail = () => {
+	// cycle through the thumbnails for preview
+	previewSlide.value = (previewSlide.value + 1) % slideThumbnails.data.length
+}
+
+const initPreview = async () => {
+	await slideThumbnails.fetch()
+	interval = setInterval(updateCurrentThumbnail, 2000)
 }
 
 const clearPreview = () => {
@@ -147,14 +160,7 @@ const hidePreview = () => {
 	clearPreview()
 }
 
-watch(
-	() => props.presentation,
-	(val) => {
-		val ? initPreview() : clearPreview()
-	},
-)
+onMounted(() => initPreview())
 
-onBeforeUnmount(() => {
-	clearPreview()
-})
+onBeforeUnmount(() => clearPreview())
 </script>

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -15,6 +15,7 @@
 		/>
 
 		<PresentationPreview
+			v-if="previewPresentation"
 			:presentation="previewPresentation"
 			@setPreview="setPreview"
 			@openDialog="openDialog"

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -53,7 +53,7 @@ import SlideContainer from '@/components/SlideContainer.vue'
 import DropTargetOverlay from '@/components/DropTargetOverlay.vue'
 import Toolbar from '@/components/Toolbar.vue'
 
-import { presentationId, presentation } from '@/stores/presentation'
+import { presentationId, presentation, loadPresentation } from '@/stores/presentation'
 import { slide, slideIndex, saveChanges, loadSlide } from '@/stores/slide'
 import {
 	resetFocus,
@@ -301,7 +301,7 @@ watch(
 	() => route.params.presentationId,
 	(id) => {
 		if (!id) return
-		presentationId.value = id
+		loadPresentation(id)
 	},
 	{ immediate: true },
 )

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -39,7 +39,7 @@
 
 <script setup>
 import { ref, watch, computed, useTemplateRef, onMounted, onBeforeUnmount, nextTick } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { useRoute, useRouter, onBeforeRouteLeave } from 'vue-router'
 
 import { call } from 'frappe-ui'
 
@@ -323,9 +323,15 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
-	resetSlideState()
 	clearInterval(autosaveInterval)
 	resetFocus()
 	document.removeEventListener('keydown', handleKeyDown)
+})
+
+onBeforeRouteLeave((to, from, next) => {
+	if (to.name !== 'Slideshow') {
+		resetSlideState()
+	}
+	next()
 })
 </script>

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -54,7 +54,7 @@ import DropTargetOverlay from '@/components/DropTargetOverlay.vue'
 import Toolbar from '@/components/Toolbar.vue'
 
 import { presentationId, presentation, loadPresentation } from '@/stores/presentation'
-import { slide, slideIndex, saveChanges, loadSlide } from '@/stores/slide'
+import { slide, slideIndex, saveChanges, loadSlide, updateSlideThumbnail } from '@/stores/slide'
 import {
 	resetFocus,
 	activeElementIds,
@@ -211,7 +211,7 @@ const changeSlide = async (index, updateCurrent = true) => {
 	// reset the pan and zoom to capture thumbnail
 	slideContainerRef.value.togglePanZoom()
 
-	nextTick(async () => {
+	await nextTick(async () => {
 		// update the current slide along with thumbnail
 		if (updateCurrent) {
 			await saveChanges()
@@ -257,8 +257,13 @@ const performSlideAction = async (action, index) => {
 
 const insertSlide = async (index) => {
 	if (!index) index = slideIndex.value
+	const previousBackground = slide.value.background
 	await performSlideAction('insert', index)
-	changeSlide(index + 1)
+	await changeSlide(index + 1)
+	slide.value.background = previousBackground
+	nextTick(() => {
+		updateSlideThumbnail()
+	})
 }
 
 const deleteSlide = async () => {

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -297,6 +297,17 @@ const handleMediaDragEnter = (e) => {
 	dropTargetRef.value.handleDragEnter(e)
 }
 
+const resetSlideState = () => {
+	slideIndex.value = 0
+	slide.value = {
+		thumbnail: '',
+		elements: [],
+		background: '',
+		transition: '',
+		transitionDuration: 0,
+	}
+}
+
 watch(
 	() => route.params.presentationId,
 	(id) => {
@@ -312,6 +323,7 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
+	resetSlideState()
 	clearInterval(autosaveInterval)
 	resetFocus()
 	document.removeEventListener('keydown', handleKeyDown)

--- a/frontend/src/pages/Slideshow.vue
+++ b/frontend/src/pages/Slideshow.vue
@@ -197,15 +197,6 @@ const changeSlide = (index) => {
 	})
 }
 
-watch(
-	() => route.params.presentationId,
-	(id) => {
-		if (!id) return
-		presentationId.value = id
-	},
-	{ immediate: true },
-)
-
 onMounted(async () => {
 	await initFullscreenMode()
 	document.addEventListener('keydown', handleKeyDown)

--- a/frontend/src/stores/presentation.js
+++ b/frontend/src/stores/presentation.js
@@ -13,12 +13,10 @@ const inSlideShow = ref(false)
 
 const applyReverseTransition = ref(false)
 
-watch(
-	() => presentationId.value,
-	async () => {
-		await presentation.fetch()
-		loadSlide()
-	},
-)
+const loadPresentation = async (id) => {
+	presentationId.value = id
+	await presentation.fetch()
+	loadSlide()
+}
 
-export { presentationId, presentation, inSlideShow, applyReverseTransition }
+export { presentationId, presentation, inSlideShow, applyReverseTransition, loadPresentation }

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -63,7 +63,7 @@ const getSlideThumbnail = async () => {
 }
 
 const updateSlideState = async () => {
-	const { elements, transition, transitionDuration, background, thumbnail } = slide.value
+	const { elements, transition, transitionDuration, background } = slide.value
 	presentation.data.slides[slideIndex.value] = {
 		...presentation.data.slides[slideIndex.value],
 		background,
@@ -72,6 +72,14 @@ const updateSlideState = async () => {
 		transition_duration: transitionDuration,
 		thumbnail: await getSlideThumbnail(),
 	}
+}
+
+const updateSlideThumbnail = async () => {
+	if (!presentation.data || !slide.value) return
+
+	const thumbnail = await getSlideThumbnail()
+	slide.value.thumbnail = thumbnail
+	presentation.data.slides[slideIndex.value].thumbnail = thumbnail
 }
 
 const loadSlide = () => {
@@ -104,4 +112,13 @@ const saveChanges = async () => {
 
 const slideBounds = reactive({})
 
-export { slideIndex, slide, slideBounds, selectionBounds, loadSlide, updateSlideState, saveChanges }
+export {
+	slideIndex,
+	slide,
+	slideBounds,
+	selectionBounds,
+	loadSlide,
+	updateSlideState,
+	updateSlideThumbnail,
+	saveChanges,
+}

--- a/slides/slides/doctype/presentation/presentation.py
+++ b/slides/slides/doctype/presentation/presentation.py
@@ -38,6 +38,16 @@ def get_all_presentations():
 
 
 @frappe.whitelist()
+def get_thumbnails(presentation):
+	return frappe.get_all(
+		"Slide",
+		fields=["thumbnail"],
+		filters={"parent": presentation},
+		order_by="idx",
+	)
+
+
+@frappe.whitelist()
 def get_presentation(name):
 	return frappe.get_doc("Presentation", name)
 

--- a/slides/slides/doctype/presentation/presentation.py
+++ b/slides/slides/doctype/presentation/presentation.py
@@ -58,7 +58,7 @@ def get_slide_thumbnails(presentation: str) -> list[str]:
 
 
 @frappe.whitelist()
-def get_presentation(name):
+def get_presentation(name: str) -> Document:
 	return frappe.get_doc("Presentation", name)
 
 
@@ -70,7 +70,6 @@ def insert_slide(name, index):
 	new_slide.parentfield = "slides"
 	new_slide.parenttype = "Presentation"
 	new_slide.idx = index + 1
-	new_slide.background = presentation.slides[index].background
 	new_slide.save()
 	presentation.slides = presentation.slides[: index + 1] + [new_slide] + presentation.slides[index + 1 :]
 	for i in range(index + 1, len(presentation.slides)):

--- a/slides/slides/doctype/presentation/presentation.py
+++ b/slides/slides/doctype/presentation/presentation.py
@@ -14,15 +14,27 @@ def slug(text):
 	return text.lower().replace(" ", "-")
 
 
+def get_presentation_thumbnail(presentation_name):
+	return frappe.get_value(
+		"Slide",
+		{"parent": presentation_name, "idx": 1},
+		"thumbnail",
+	)
+
+
 @frappe.whitelist()
 def get_all_presentations():
-	presentations = frappe.get_all(
-		"Presentation", fields=["name"], filters={"owner": frappe.session.user}, order_by="modified desc"
+	presentations = frappe.get_list(
+		"Presentation",
+		fields=["name", "title", "creation", "modified"],
+		filters={"owner": frappe.session.user},
+		order_by="modified desc",
 	)
-	all_presentations = [
-		frappe.get_doc("Presentation", presentation.name).as_dict() for presentation in presentations
-	]
-	return all_presentations
+
+	for p in presentations:
+		p["thumbnail"] = get_presentation_thumbnail(p["name"])
+
+	return presentations
 
 
 @frappe.whitelist()

--- a/slides/slides/doctype/presentation/presentation.py
+++ b/slides/slides/doctype/presentation/presentation.py
@@ -10,11 +10,12 @@ class Presentation(Document):
 		self.name = slug(self.title)
 
 
-def slug(text):
+def slug(text: str) -> str:
 	return text.lower().replace(" ", "-")
 
 
-def get_presentation_thumbnail(presentation_name):
+def get_presentation_thumbnail(presentation_name: str) -> str:
+	"""Returns the thumbnail of the first slide in a presentation"""
 	return frappe.get_value(
 		"Slide",
 		{"parent": presentation_name, "idx": 1},
@@ -23,7 +24,11 @@ def get_presentation_thumbnail(presentation_name):
 
 
 @frappe.whitelist()
-def get_all_presentations():
+def get_all_presentations() -> list[dict]:
+	"""
+	Returns a list of presentation details
+	- name, title, creation date, modified date, and first thumbnail
+	"""
 	presentations = frappe.get_list(
 		"Presentation",
 		fields=["name", "title", "creation", "modified"],
@@ -31,20 +36,25 @@ def get_all_presentations():
 		order_by="modified desc",
 	)
 
-	for p in presentations:
-		p["thumbnail"] = get_presentation_thumbnail(p["name"])
+	for presentation in presentations:
+		presentation["thumbnail"] = get_presentation_thumbnail(presentation["name"])
 
 	return presentations
 
 
 @frappe.whitelist()
-def get_thumbnails(presentation):
-	return frappe.get_all(
+def get_slide_thumbnails(presentation: str) -> list[str]:
+	"""
+	Returns a list of thumbnails for all slides in a presentation
+	"""
+	slides = frappe.get_all(
 		"Slide",
-		fields=["thumbnail"],
+		fields=["name", "thumbnail"],
 		filters={"parent": presentation},
 		order_by="idx",
 	)
+
+	return [slide["thumbnail"] for slide in slides]
 
 
 @frappe.whitelist()


### PR DESCRIPTION
### Fixes

- Update the background color of a newly inserted slide based on the previous one on the client side instead of server side so dirty state is maintained correctly. After a new slide is inserted, run the method to update the thumbnail once so the initial state doesn't appear empty in the thumbnail even though the background is updated to match that of previous slide.

  <details>
  <summary> Before </summary>
  
  <br>
  
  
  https://github.com/user-attachments/assets/1f8ea841-a7f7-4dd2-8d2c-5c0f6a8d35bb
  
  
  </details>

  <details>
  <summary>After </summary>
  
  <br>

   https://github.com/user-attachments/assets/62679bd0-7a9a-43e1-aa8e-1bb6569835c4

  </details>

- Previously the index that is used to maintain active slide was not reset, so leaving the editor and switching to another presentation opened the same index in that presentation. When leaving the Editor, cleanup the slide state if the next route is not the Slideshow page in order to reset the active slideIndex and the slide object when a new presentation is opened. Didn't opt for mounting the editor directly with a default empty state for the slide since switches between slideshow mode and editor take place often and the same slide needs to be reloaded again. 

  <details>
  <summary>Before</summary>
  
  <br>

   https://github.com/user-attachments/assets/aed12999-c47c-46bd-be16-776be1d57200

  </details>
  
  <details>
  <summary>After</summary>

  <br>

   https://github.com/user-attachments/assets/3e3ab64e-65a2-474f-80c7-7b0872380be2

  </details>

- The query for fetching all presentations seemed a little slow so now the Home page only fetches the first thumbnail for all presentations to show in the grid layout and only when a presentation is previewed, the rest of the slide thumbnails are fetched (divided that bit into another call).
