### PR TITLE
fix: dimension indicator visibility and position

### DIFF
--- a/frontend/src/components/ResizeHandle.vue
+++ b/frontend/src/components/ResizeHandle.vue
@@ -13,6 +13,10 @@ const props = defineProps({
 		type: String,
 		required: true,
 	},
+	currentResizer: {
+		type: String,
+		default: null,
+	},
 })
 
 const emit = defineEmits(['startResize', 'resizeToFitContent'])
@@ -29,11 +33,6 @@ const widthHandleStyles = {
 	height: '14px',
 	cursor: 'ew-resize',
 	top: 'calc(50% - 7px)',
-}
-
-const dimensionHandleStyles = {
-	width: '7px',
-	height: '7px',
 }
 
 const getWidthResizerStyles = () => {
@@ -53,13 +52,15 @@ const getDimensionResizerStyles = () => {
 		'bottom-left': 'nesw-resize',
 		'bottom-right': 'nwse-resize',
 	}
+	const offset = props.currentResizer ? '-5px' : '-4.5px'
 	return {
 		...baseStyles,
-		...dimensionHandleStyles,
-		top: resizer.includes('top') ? '-4.5px' : 'auto',
-		bottom: resizer.includes('bottom') ? '-4.5px' : 'auto',
-		left: resizer.includes('left') ? '-4.5px' : 'auto',
-		right: resizer.includes('right') ? '-4.5px' : 'auto',
+		top: resizer.includes('top') ? offset : 'auto',
+		bottom: resizer.includes('bottom') ? offset : 'auto',
+		left: resizer.includes('left') ? offset : 'auto',
+		right: resizer.includes('right') ? offset : 'auto',
+		width: props.currentResizer ? '10px' : '7px',
+		height: props.currentResizer ? '10px' : '7px',
 		cursor: cursorStyles[resizer],
 	}
 }

--- a/frontend/src/components/ResizeIndicator.vue
+++ b/frontend/src/components/ResizeIndicator.vue
@@ -4,10 +4,10 @@
 		class="backdrop-blur-sm opacity-85 text-black"
 		:class="indicatorClasses"
 	>
-		<i v-if="type === 'text'"> {{ Math.round(selectionBounds.width) }}px </i>
+		<i v-if="type === 'text'"> {{ Math.round(selectionBounds.width) }} </i>
 		<template v-else>
-			<i>{{ Math.round(selectionBounds.width) }}px</i> ×
-			<i>{{ Math.round(selectionBounds.height) }}px</i>
+			<i>{{ Math.round(selectionBounds.width) }}</i> ×
+			<i>{{ Math.round(selectionBounds.height) }}</i>
 		</template>
 	</div>
 </template>

--- a/frontend/src/components/ResizeIndicator.vue
+++ b/frontend/src/components/ResizeIndicator.vue
@@ -42,7 +42,7 @@ const getTextIndicatorPosition = () => {
 
 const getMediaIndicatorPosition = () => {
 	const scale = slideBounds.scale
-	const offset = `${8 / scale}px`
+	const offset = `${12 / scale}px`
 
 	return {
 		left: props.currentResizer.includes('left') ? offset : 'auto',
@@ -64,13 +64,15 @@ const indicatorStyles = computed(() => {
 
 	const scale = slideBounds.scale
 	const positionStyles = getPositionStyles()
+	const paddingX = props.type === 'text' ? 8 / scale : 4 / scale
 
 	return {
 		position: 'absolute',
 		zIndex: 100,
 		fontSize: `${10 / scale}px`,
 		borderRadius: `${6 / scale}px`,
-		padding: `${4 / scale}px`,
+		padding: `${4 / scale}px ${paddingX}px`,
+
 		...positionStyles,
 	}
 })

--- a/frontend/src/components/Resizer.vue
+++ b/frontend/src/components/Resizer.vue
@@ -5,6 +5,7 @@
 			v-show="handleVisibilityMap[resizeHandle]"
 			:key="resizeHandle"
 			:direction="resizeHandle"
+			:currentResizer="currentResizer"
 			:cursor="resizeCursor"
 			@startResize="(e) => startResize(e, resizeHandle)"
 			@resizeToFitContent="resizeToFitContent"

--- a/frontend/src/components/Resizer.vue
+++ b/frontend/src/components/Resizer.vue
@@ -11,6 +11,12 @@
 			@resizeToFitContent="resizeToFitContent"
 		/>
 
+		<div
+			v-show="currentResizer"
+			class="w-full h-full absolute left-0 top-0"
+			:style="overlayStyle"
+		></div>
+
 		<ResizeIndicator
 			v-show="currentResizer"
 			:currentResizer="currentResizer"
@@ -125,5 +131,32 @@ watch(
 	(resizer) => {
 		updateSlideCursor(resizeCursor.value)
 	},
+	{ immediate: true },
 )
+
+const overlayStyle = computed(() => {
+	if (!currentResizer.value || props.elementType == 'text') return {}
+
+	let direction = ''
+	switch (currentResizer.value) {
+		case 'top-left':
+			direction = 'to bottom right'
+			break
+		case 'top-right':
+			direction = 'to bottom left'
+			break
+		case 'bottom-left':
+			direction = 'to top right'
+			break
+		case 'bottom-right':
+			direction = 'to top left'
+			break
+		default:
+			direction = 'to bottom right'
+			break
+	}
+	return {
+		background: `linear-gradient(${direction}, rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.1) 60px, transparent 90px)`,
+	}
+})
 </script>

--- a/frontend/src/components/Resizer.vue
+++ b/frontend/src/components/Resizer.vue
@@ -15,13 +15,9 @@
 			v-show="currentResizer"
 			class="w-full h-full absolute left-0 top-0"
 			:style="overlayStyle"
-		></div>
-
-		<ResizeIndicator
-			v-show="currentResizer"
-			:currentResizer="currentResizer"
-			:type="elementType"
-		/>
+		>
+			<ResizeIndicator :currentResizer="currentResizer" :type="elementType" />
+		</div>
 	</div>
 </template>
 
@@ -71,6 +67,29 @@ const resizeCursor = computed(() => {
 			return 'ew-resize'
 		default:
 			return 'default'
+	}
+})
+
+const overlayStyle = computed(() => {
+	if (!currentResizer.value || props.elementType == 'text') return {}
+
+	let direction = ''
+	switch (currentResizer.value) {
+		case 'top-right':
+			direction = 'to bottom left'
+			break
+		case 'bottom-left':
+			direction = 'to top right'
+			break
+		case 'bottom-right':
+			direction = 'to top left'
+			break
+		default:
+			direction = 'to bottom right'
+			break
+	}
+	return {
+		background: `linear-gradient(${direction}, rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.1) 60px, transparent 90px)`,
 	}
 })
 
@@ -133,30 +152,4 @@ watch(
 	},
 	{ immediate: true },
 )
-
-const overlayStyle = computed(() => {
-	if (!currentResizer.value || props.elementType == 'text') return {}
-
-	let direction = ''
-	switch (currentResizer.value) {
-		case 'top-left':
-			direction = 'to bottom right'
-			break
-		case 'top-right':
-			direction = 'to bottom left'
-			break
-		case 'bottom-left':
-			direction = 'to top right'
-			break
-		case 'bottom-right':
-			direction = 'to top left'
-			break
-		default:
-			direction = 'to bottom right'
-			break
-	}
-	return {
-		background: `linear-gradient(${direction}, rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.1) 60px, transparent 90px)`,
-	}
-})
 </script>


### PR DESCRIPTION
### Fixes

- Whichever side's resizer is currently active, increase it's size a bit.
- Add a gradient behind the indicator in the active corner so it shows up on lighter and darker colors.

