### PR TITLE
feat: handle range response for video seeking

### DIFF
--- a/frontend/src/components/DropTargetOverlay.vue
+++ b/frontend/src/components/DropTargetOverlay.vue
@@ -42,7 +42,7 @@ const uploadMedia = (file, fileType) => {
 			.upload(file, {
 				doctype: 'Presentation',
 				docname: presentationId.value,
-				private: false,
+				private: true,
 			})
 			.then((fileDoc) => {
 				addMediaElement(fileDoc, fileType)

--- a/frontend/src/components/Toolbar.vue
+++ b/frontend/src/components/Toolbar.vue
@@ -11,7 +11,7 @@
 		<Tooltip text="Media" :hover-delay="0.7" placement="bottom">
 			<FileUploader
 				:fileTypes="ALLOWED_IMAGE_FILETYPES.concat(['video/*'])"
-				:uploadArgs="{ doctype: 'Presentation', docname: presentationId, private: false }"
+				:uploadArgs="{ doctype: 'Presentation', docname: presentationId, private: true }"
 				@success="(file) => handleUploadSuccess(file)"
 			>
 				<template #default="{ openFileSelector }">

--- a/frontend/src/components/VideoElement.vue
+++ b/frontend/src/components/VideoElement.vue
@@ -42,7 +42,7 @@
 					class="bg-white-overlay-900 opacity-30 w-full h-full absolute left-0 top-0"
 				></div>
 				<div
-					class="bg-white-overlay-900 opacity-40 h-full absolute left-0 top-0 transition-width duration-300 ease-linear"
+					class="bg-white-overlay-900 opacity-40 h-full absolute left-0 top-0 transition-width duration-100 ease-linear"
 					:style="{ width: `${progress}%` }"
 				></div>
 			</div>

--- a/frontend/src/components/VideoElement.vue
+++ b/frontend/src/components/VideoElement.vue
@@ -15,7 +15,7 @@
 			@ended="resetProgress"
 			preload="auto"
 		>
-			<source :src="`/api/method/slides.api.get_video?src=${element.src}`" />
+			<source :src="`/api/method/slides.api.get_video_file?src=${element.src}`" />
 		</video>
 		<div
 			class="transition-opacity duration-500 ease-in-out absolute top-0 left-0 w-full h-full"

--- a/frontend/src/components/VideoElement.vue
+++ b/frontend/src/components/VideoElement.vue
@@ -14,6 +14,7 @@
 			<source :src="`/api/method/slides.api.get_video_file?src=${element.src}`" />
 		</video>
 		<div
+			ref="overlay"
 			class="transition-opacity duration-500 ease-in-out absolute top-0 left-0 w-full h-full"
 			:style="gradientOverlayStyles"
 		>
@@ -62,6 +63,7 @@ const element = defineModel('element', {
 })
 
 const el = useTemplateRef('videoElement')
+const overlay = useTemplateRef('overlay')
 
 const isPlaying = ref(false)
 
@@ -91,7 +93,7 @@ const handleVideoClick = (e) => {
 	// in slideshow, always toggle playing on click anywhere
 	// in editor, toggle playing only when center play button is clicked
 
-	if (inSlideShow.value || (isActive && e.target !== el.value)) {
+	if (inSlideShow.value || (isActive && e.target !== overlay.value)) {
 		e.stopPropagation()
 		togglePlaying()
 	}

--- a/frontend/src/components/VideoElement.vue
+++ b/frontend/src/components/VideoElement.vue
@@ -1,9 +1,5 @@
 <template>
-	<div
-		@click="handleVideoClick"
-		@mouseenter="hoveringOverVideo = true"
-		@mouseleave="hoveringOverVideo = false"
-	>
+	<div @click="handleVideoClick" @mouseenter="hoverOver = 'video'" @mouseleave="hoverOver = null">
 		<video
 			ref="videoElement"
 			:style="videoStyle"
@@ -19,7 +15,6 @@
 		</video>
 		<div
 			class="transition-opacity duration-500 ease-in-out absolute top-0 left-0 w-full h-full"
-			:class="{ 'opacity-0': !showProgressBar }"
 			:style="gradientOverlayStyles"
 		>
 			<div
@@ -34,15 +29,18 @@
 			</div>
 			<div
 				v-if="showProgressBar"
-				class="absolute h-[6px] hover:h-2 w-full bottom-0 left-0 cursor-pointer transition-all duration-100 ease-linear"
+				class="absolute w-full bottom-0 left-0 cursor-pointer transition-all duration-100 ease-linear"
+				:class="hoverOver == 'progressBar' ? 'h-2' : 'h-[6px]'"
 				@click.stop="seekTimestamp"
+				@mouseenter="hoverOver = 'progressBar'"
+				@mouseleave="hoverOver = null"
 			>
 				<div
 					ref="progressBar"
 					class="bg-white-overlay-900 opacity-30 w-full h-full absolute left-0 top-0"
 				></div>
 				<div
-					class="bg-white-overlay-900 opacity-40 h-full absolute left-0 top-0 transition-width duration-100 ease-linear"
+					class="bg-white-overlay-900 opacity-70 h-full absolute left-0 top-0 transition-width duration-100 ease-linear"
 					:style="{ width: `${progress}%` }"
 				></div>
 			</div>
@@ -116,14 +114,14 @@ const updateDuration = () => {
 	}
 }
 
-const hoveringOverVideo = ref(false)
+const hoverOver = ref(null)
 
 const showProgressBar = computed(() => {
 	// In editor, show it when video is active
 	const isActive = activeElementIds.value.includes(element.value.id)
 
 	// During slideshow, show it only if user is hovering over video
-	const slideshowHovering = inSlideShow.value && hoveringOverVideo.value
+	const slideshowHovering = inSlideShow.value && hoverOver.value === 'video'
 
 	return isActive || slideshowHovering
 })
@@ -141,6 +139,7 @@ const seekTimestamp = (e) => {
 const gradientOverlayStyles = computed(() => ({
 	background: `radial-gradient(circle at center, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.3) 5%, rgba(0, 0, 0, 0) 100%),
 	linear-gradient(to top, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.1) 15%, rgba(0, 0, 0, 0) 100%)`,
+	opacity: showProgressBar.value ? 1 : 0,
 }))
 
 const resetProgress = () => {

--- a/frontend/src/components/VideoElement.vue
+++ b/frontend/src/components/VideoElement.vue
@@ -20,7 +20,7 @@
 		>
 			<div
 				v-if="activeElementIds.includes(element.id)"
-				class="absolute inset-[calc(50%-16px)] flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg bg-white-overlay-200 opacity-90"
+				class="absolute inset-[calc(50%-16px)] flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg bg-white-overlay-200 opacity-95"
 			>
 				<component
 					size="16"
@@ -41,7 +41,7 @@
 					class="bg-white-overlay-900 opacity-30 w-full h-full absolute left-0 top-0"
 				></div>
 				<div
-					class="bg-white-overlay-900 opacity-70 h-full absolute left-0 top-0 transition-width duration-100 ease-linear"
+					class="bg-white-overlay-900 opacity-80 h-full absolute left-0 top-0 transition-width duration-100 ease-linear"
 					:style="{ width: `${progress}%` }"
 				></div>
 			</div>
@@ -140,8 +140,8 @@ const seekTimestamp = (e) => {
 }
 
 const gradientOverlayStyles = computed(() => ({
-	background: `radial-gradient(circle at center, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.3) 5%, rgba(0, 0, 0, 0) 100%),
-	linear-gradient(to top, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.1) 15%, rgba(0, 0, 0, 0) 100%)`,
+	background: `radial-gradient(circle at center, rgba(0, 0, 0, 0.4) 0%, rgba(0, 0, 0, 0.2) 5%, rgba(0, 0, 0, 0) 100%),
+	linear-gradient(to top, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.2) 20%, rgba(0, 0, 0, 0) 100%)`,
 	opacity: showProgressBar.value ? 1 : 0,
 }))
 

--- a/frontend/src/components/VideoElement.vue
+++ b/frontend/src/components/VideoElement.vue
@@ -24,7 +24,7 @@
 		>
 			<div
 				v-if="activeElementIds.includes(element.id)"
-				class="absolute inset-[calc(50%-16px)] flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg bg-white-overlay-100 opacity-80"
+				class="absolute inset-[calc(50%-16px)] flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg bg-white-overlay-200 opacity-90"
 			>
 				<component
 					size="16"
@@ -139,7 +139,8 @@ const seekTimestamp = (e) => {
 }
 
 const gradientOverlayStyles = computed(() => ({
-	background: `linear-gradient(to top, rgba(0, 0, 0, 0.6) 0%, rgba(0, 0, 0, 0.1) 25%, rgba(0, 0, 0, 0) 100%)`,
+	background: `radial-gradient(circle at center, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.3) 5%, rgba(0, 0, 0, 0) 100%),
+	linear-gradient(to top, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.1) 15%, rgba(0, 0, 0, 0) 100%)`,
 }))
 
 const resetProgress = () => {

--- a/frontend/src/components/VideoElement.vue
+++ b/frontend/src/components/VideoElement.vue
@@ -6,7 +6,6 @@
 	>
 		<video
 			ref="videoElement"
-			:src="element.src"
 			:style="videoStyle"
 			:autoplay="inSlideShow ? element.autoplay : false"
 			:loop="element.loop"
@@ -15,7 +14,9 @@
 			@loadedmetadata="updateDuration"
 			@ended="resetProgress"
 			preload="auto"
-		></video>
+		>
+			<source :src="`/api/method/slides.api.get_video?src=${element.src}`" />
+		</video>
 		<div
 			class="transition-opacity duration-500 ease-in-out absolute top-0 left-0 w-full h-full"
 			:class="{ 'opacity-0': !showProgressBar }"

--- a/slides/api.py
+++ b/slides/api.py
@@ -1,0 +1,58 @@
+import os
+
+import frappe
+from frappe import _
+from werkzeug.wrappers import Response
+
+
+def get_file_size(file_path):
+	return os.path.getsize(file_path)
+
+
+def get_range(range_header, file_size):
+	import re
+
+	range_start, range_end = 0, None
+	match = re.search(r"bytes=(\d+)-(\d*)", range_header)
+
+	if match:
+		range_start = int(match.group(1))
+		if match.group(2):
+			range_end = int(match.group(2))
+
+	range_end = range_end or file_size - 1
+
+	return range_start, range_end
+
+
+@frappe.whitelist()
+def get_video(src):
+	file_path = frappe.get_site_path() + src
+
+	if not os.path.exists(file_path):
+		frappe.throw(_("File {0} does not exist").format(file_path), IOError)
+
+	range_header = frappe.request.headers.get("Range", None)
+	file_size = get_file_size(file_path)
+
+	if range_header:
+		range_start, range_end = get_range(range_header, file_size)
+		content_length = range_end - range_start + 1
+
+		with open(file_path, "rb") as f:
+			f.seek(range_start)
+			data = f.read(content_length)
+
+		response = Response(data, 206, mimetype="video/mp4", direct_passthrough=True)
+		response.headers["Content-Range"] = f"bytes {range_start}-{range_end}/{file_size}"
+		response.headers["Accept-Ranges"] = "bytes"
+		response.headers["Content-Length"] = str(content_length)
+		return response
+
+	with open(file_path, "rb") as f:
+		data = f.read()
+
+	response = Response(data, 200, mimetype="video/mp4", direct_passthrough=True)
+	response.headers["Content-Length"] = str(file_size)
+	response.headers["Accept-Ranges"] = "bytes"
+	return response

--- a/slides/api.py
+++ b/slides/api.py
@@ -7,11 +7,17 @@ from werkzeug.exceptions import Forbidden, NotFound
 from werkzeug.wrappers import Response
 
 
-def get_file_size(file_path):
+def get_file_size(file_path: str) -> int:
+	"""
+	Returns the size of the file at the given path.
+	"""
 	return os.path.getsize(file_path)
 
 
-def get_range(range_header, file_size):
+def get_range(range_header: str, file_size: int) -> tuple[int, int]:
+	"""
+	Extracts the byte range from Range header.
+	"""
 	import re
 
 	range_start, range_end = 0, None
@@ -27,49 +33,71 @@ def get_range(range_header, file_size):
 	return range_start, range_end
 
 
-def get_file_data(file_path, range_start=0, range_end=None):
+def get_file_data(file_path: str, range_start: int = 0, range_end: int = 0) -> bytes:
+	"""
+	Returns specified range of bytes from the file.
+	If range_end is None, returns the full file content.
+	"""
 	with open(file_path, "rb") as f:
 		f.seek(range_start)
-		if range_end is not None:
-			# read the specified range from the file
-			data = f.read(range_end - range_start + 1)
-		else:
+
+		if range_end == 0:
 			# return the full file content in the response
 			data = f.read()
+		else:
+			# read the specified range from the file
+			data = f.read(range_end - range_start + 1)
+
 	return data
 
 
-def get_response(src):
+def get_file_metadata(src: str) -> tuple[str, int, str]:
+	"""
+	Returns file metadata including path, size, and MIME type.
+	"""
 	file_path = frappe.get_site_path() + src
 	file_size = get_file_size(file_path)
 	mimetype = mimetypes.guess_type(file_path)[0] or "video/mp4"
 
-	range_header = frappe.request.headers.get("Range", None)
+	return file_path, file_size, mimetype
 
-	response = None
+
+def get_media_response(src: str) -> Response:
+	"""
+	Processes the range header from browser to return valid response.
+	"""
+	file_path, file_size, mimetype = get_file_metadata(src)
+
+	range_header = frappe.request.headers.get("Range", None)
 
 	# if the request includes a Range header, return a partial content response
 	if range_header:
-		# extract the byte range from the Range header
 		range_start, range_end = get_range(range_header, file_size)
+
 		file_data = get_file_data(file_path, range_start, range_end)
-		response = Response(file_data, 206, mimetype=mimetype, direct_passthrough=True)
-		response.headers["Content-Range"] = f"bytes {range_start}-{range_end}/{file_size}"
+		status_code = 206  # Partial Content
 		content_length = range_end - range_start + 1
 
 	# otherwise, return the full content response
 	else:
 		file_data = get_file_data(file_path)
-		response = Response(file_data, 200, mimetype=mimetype, direct_passthrough=True)
+		status_code = 200  # Full Content
 		content_length = file_size
 
+	response = Response(file_data, status_code, mimetype=mimetype, direct_passthrough=True)
 	response.headers["Content-Length"] = str(content_length)
 	response.headers["Accept-Ranges"] = "bytes"
+
+	if range_start is not None and range_end is not None:
+		response.headers["Content-Range"] = f"bytes {range_start}-{range_end}/{file_size}"
 	return response
 
 
 @frappe.whitelist()
-def get_video_file(src):
+def get_video_file(src: str) -> Response:
+	"""
+	Fetches permitted video file and returns a response.
+	"""
 	file_doc = frappe.get_doc("File", {"file_url": src})
 
 	if not file_doc:
@@ -78,4 +106,4 @@ def get_video_file(src):
 	if not frappe.has_permission("File", "read", file_doc):
 		raise Forbidden(_("You don't have permission to access this file"))
 
-	return get_response(src)
+	return get_media_response(src)

--- a/slides/api.py
+++ b/slides/api.py
@@ -38,7 +38,7 @@ def get_media_response_with_range(range_header, file_path):
 		f.seek(range_start)
 		data = f.read(content_length)
 
-		# return a 206 Partial Content response with the specified range
+	# return a 206 Partial Content response with the specified range
 	response = Response(data, 206, mimetype="video/mp4", direct_passthrough=True)
 	response.headers["Content-Range"] = f"bytes {range_start}-{range_end}/{file_size}"
 	response.headers["Accept-Ranges"] = "bytes"
@@ -52,7 +52,7 @@ def get_media_response(file_path):
 	with open(file_path, "rb") as f:
 		data = f.read()
 
-		# return the full file content in the response
+	# return the full file content in the response
 	response = Response(data, 200, mimetype="video/mp4", direct_passthrough=True)
 	response.headers["Content-Length"] = str(file_size)
 	response.headers["Accept-Ranges"] = "bytes"

--- a/slides/api.py
+++ b/slides/api.py
@@ -1,7 +1,9 @@
+import mimetypes
 import os
 
 import frappe
 from frappe import _
+from werkzeug.exceptions import Forbidden, NotFound
 from werkzeug.wrappers import Response
 
 
@@ -26,6 +28,7 @@ def get_range(range_header, file_size):
 
 
 def get_media_response_with_range(range_header, file_path):
+	mimetype = mimetypes.guess_type(file_path)[0] or "video/mp4"
 	file_size = get_file_size(file_path)
 
 	# extract the byte range from the Range header
@@ -39,7 +42,7 @@ def get_media_response_with_range(range_header, file_path):
 		data = f.read(content_length)
 
 	# return a 206 Partial Content response with the specified range
-	response = Response(data, 206, mimetype="video/mp4", direct_passthrough=True)
+	response = Response(data, 206, mimetype=mimetype, direct_passthrough=True)
 	response.headers["Content-Range"] = f"bytes {range_start}-{range_end}/{file_size}"
 	response.headers["Accept-Ranges"] = "bytes"
 	response.headers["Content-Length"] = str(content_length)
@@ -47,13 +50,14 @@ def get_media_response_with_range(range_header, file_path):
 
 
 def get_media_response(file_path):
+	mimetype = mimetypes.guess_type(file_path)[0] or "video/mp4"
 	file_size = get_file_size(file_path)
 
 	with open(file_path, "rb") as f:
 		data = f.read()
 
 	# return the full file content in the response
-	response = Response(data, 200, mimetype="video/mp4", direct_passthrough=True)
+	response = Response(data, 200, mimetype=mimetype, direct_passthrough=True)
 	response.headers["Content-Length"] = str(file_size)
 	response.headers["Accept-Ranges"] = "bytes"
 	return response
@@ -63,8 +67,13 @@ def get_media_response(file_path):
 def get_video_file(src):
 	file_path = frappe.get_site_path() + src
 
-	if not os.path.exists(file_path):
-		frappe.throw(_("File {0} does not exist").format(file_path), IOError)
+	file_doc = frappe.get_doc("File", {"file_url": src})
+
+	if not file_doc:
+		raise NotFound
+
+	if not frappe.has_permission("File", "read", file_doc):
+		raise Forbidden(_("You don't have permission to access this file"))
 
 	range_header = frappe.request.headers.get("Range", None)
 

--- a/slides/api.py
+++ b/slides/api.py
@@ -72,5 +72,5 @@ def get_video_file(src):
 	if range_header:
 		return get_media_response_with_range(range_header, file_path)
 
-		# otherwise, return the full content response
+	# otherwise, return the full content response
 	return get_media_response(file_path)

--- a/slides/api.py
+++ b/slides/api.py
@@ -25,15 +25,20 @@ def get_range(range_header, file_size):
 	return range_start, range_end
 
 
-def get_range_response(range_header, file_path):
+def get_media_response_with_range(range_header, file_path):
 	file_size = get_file_size(file_path)
+
+	# extract the byte range from the Range header
 	range_start, range_end = get_range(range_header, file_size)
+
 	content_length = range_end - range_start + 1
 
+	# read the specified range from the file
 	with open(file_path, "rb") as f:
 		f.seek(range_start)
 		data = f.read(content_length)
 
+		# return a 206 Partial Content response with the specified range
 	response = Response(data, 206, mimetype="video/mp4", direct_passthrough=True)
 	response.headers["Content-Range"] = f"bytes {range_start}-{range_end}/{file_size}"
 	response.headers["Accept-Ranges"] = "bytes"
@@ -41,11 +46,13 @@ def get_range_response(range_header, file_path):
 	return response
 
 
-def get_response(file_path):
+def get_media_response(file_path):
 	file_size = get_file_size(file_path)
+
 	with open(file_path, "rb") as f:
 		data = f.read()
 
+		# return the full file content in the response
 	response = Response(data, 200, mimetype="video/mp4", direct_passthrough=True)
 	response.headers["Content-Length"] = str(file_size)
 	response.headers["Accept-Ranges"] = "bytes"
@@ -53,7 +60,7 @@ def get_response(file_path):
 
 
 @frappe.whitelist()
-def get_video(src):
+def get_video_file(src):
 	file_path = frappe.get_site_path() + src
 
 	if not os.path.exists(file_path):
@@ -61,7 +68,9 @@ def get_video(src):
 
 	range_header = frappe.request.headers.get("Range", None)
 
+	# if the request includes a Range header, return a partial content response
 	if range_header:
-		return get_range_response(range_header, file_path)
+		return get_media_response_with_range(range_header, file_path)
 
-	return get_response(file_path)
+		# otherwise, return the full content response
+	return get_media_response(file_path)


### PR DESCRIPTION
### Changes

Video seeking only worked previously for short videos since the video is fully loaded in memory instead of loading the content in ranges. 

Added a custom API to handle fetching video files so 206 partial content response can be returned with the requested range. This allows fetching and processing the keyframe content segments correctly so that the browser can seek to the clicked timestamp accurately. 