### PR TITLE
fix: keyboard movement and alignment

### DIFF
--- a/frontend/src/components/ResizeIndicator.vue
+++ b/frontend/src/components/ResizeIndicator.vue
@@ -1,13 +1,9 @@
 <template>
-	<div
-		:style="indicatorStyles"
-		class="backdrop-blur-sm opacity-85 text-black"
-		:class="indicatorClasses"
-	>
-		<i v-if="type === 'text'"> {{ Math.round(selectionBounds.width) }}px </i>
+	<div :style="styles" class="backdrop-blur-sm opacity-85 text-black" :class="indicatorClasses">
+		<i v-if="type === 'text'"> {{ Math.round(dimensions.width) }}px </i>
 		<template v-else>
-			<i>{{ Math.round(selectionBounds.width) }}px</i> ×
-			<i>{{ Math.round(selectionBounds.height) }}px</i>
+			<i>{{ Math.round(dimensions.width) }}px</i> ×
+			<i>{{ Math.round(dimensions.height) }}px</i>
 		</template>
 	</div>
 </template>
@@ -15,68 +11,29 @@
 <script setup>
 import { computed } from 'vue'
 
-import { slide, slideBounds, selectionBounds } from '@/stores/slide'
+import { slide } from '@/stores/slide'
 import { isBackgroundColorDark } from '@/utils/color'
 
 const props = defineProps({
-	currentResizer: {
-		type: String,
-		default: null,
-	},
 	type: {
 		type: String,
 		default: null,
 	},
+	dimensions: {
+		type: Object,
+		default: () => ({}),
+	},
+	indicatorStyles: {
+		type: Object,
+		default: () => ({}),
+	},
 })
 
-const getScaledOffset = (offset) => `${offset / slideBounds.scale}px`
-
-const getTextIndicatorPosition = () => {
-	const resizer = props.currentResizer
-	const offsetX = getScaledOffset(selectionBounds.width + 20)
-	const offsetY = getScaledOffset(12)
-
-	return {
-		left: resizer.includes('right') ? offsetX : 'auto',
-		right: resizer.includes('left') ? offsetX : 'auto',
-		top: `calc(50% - ${offsetY})`,
-	}
-}
-
-const getMediaIndicatorPosition = () => {
-	const resizer = props.currentResizer
-	const offset = getScaledOffset(8)
-
-	return {
-		left: resizer.includes('left') ? offset : 'auto',
-		right: resizer.includes('right') ? offset : 'auto',
-		top: resizer.includes('top') ? offset : 'auto',
-		bottom: resizer.includes('bottom') ? offset : 'auto',
-	}
-}
-
-const getPositionStyles = () => {
-	if (props.type === 'text') {
-		return getTextIndicatorPosition()
-	}
-	return getMediaIndicatorPosition()
-}
-
-const indicatorStyles = computed(() => {
-	if (!props.currentResizer) return {}
-
-	const scale = slideBounds.scale
-	const positionStyles = getPositionStyles()
-
-	return {
-		position: 'absolute',
-		zIndex: 100,
-		fontSize: `${10 / scale}px`,
-		borderRadius: `${6 / scale}px`,
-		padding: `${4 / scale}px`,
-		...positionStyles,
-	}
-})
+const styles = computed(() => ({
+	position: 'absolute',
+	zIndex: 100,
+	...props.indicatorStyles,
+}))
 
 const indicatorClasses = computed(() => {
 	const isDark = isBackgroundColorDark(slide.value.background)

--- a/frontend/src/components/ResizeIndicator.vue
+++ b/frontend/src/components/ResizeIndicator.vue
@@ -29,26 +29,29 @@ const props = defineProps({
 	},
 })
 
+const getScaledOffset = (offset) => `${offset / slideBounds.scale}px`
+
 const getTextIndicatorPosition = () => {
-	const scale = slideBounds.scale
-	const offset = `${selectionBounds.width + 20 / scale}px`
+	const resizer = props.currentResizer
+	const offsetX = getScaledOffset(selectionBounds.width + 20)
+	const offsetY = getScaledOffset(12)
 
 	return {
-		left: props.currentResizer.includes('right') ? offset : 'auto',
-		right: props.currentResizer.includes('left') ? offset : 'auto',
-		top: `calc(50% - ${12 / scale}px)`,
+		left: resizer.includes('right') ? offsetX : 'auto',
+		right: resizer.includes('left') ? offsetX : 'auto',
+		top: `calc(50% - ${offsetY})`,
 	}
 }
 
 const getMediaIndicatorPosition = () => {
-	const scale = slideBounds.scale
-	const offset = `${8 / scale}px`
+	const resizer = props.currentResizer
+	const offset = getScaledOffset(8)
 
 	return {
-		left: props.currentResizer.includes('left') ? offset : 'auto',
-		right: props.currentResizer.includes('right') ? offset : 'auto',
-		top: props.currentResizer.includes('top') ? offset : 'auto',
-		bottom: props.currentResizer.includes('bottom') ? offset : 'auto',
+		left: resizer.includes('left') ? offset : 'auto',
+		right: resizer.includes('right') ? offset : 'auto',
+		top: resizer.includes('top') ? offset : 'auto',
+		bottom: resizer.includes('bottom') ? offset : 'auto',
 	}
 }
 

--- a/frontend/src/components/Resizer.vue
+++ b/frontend/src/components/Resizer.vue
@@ -24,7 +24,7 @@ import { computed, inject, watch } from 'vue'
 import ResizeHandle from '@/components/ResizeHandle.vue'
 import ResizeIndicator from '@/components/ResizeIndicator.vue'
 
-import { selectionBounds, slideBounds } from '@/stores/slide'
+import { selectionBounds, slideBounds, updateSelectionBounds } from '@/stores/slide'
 import { useResizer } from '@/utils/resizer'
 
 const props = defineProps({
@@ -93,8 +93,10 @@ const handleDimensionChange = (delta) => {
 	const minWidth = props.elementType === 'text' ? 7 : 50
 	if (delta.width + selectionBounds.width < minWidth) return
 
-	selectionBounds.left += delta.left / slideBounds.scale
-	selectionBounds.top += delta.top / slideBounds.scale
+	updateSelectionBounds({
+		left: selectionBounds.left + delta.left / slideBounds.scale,
+		top: selectionBounds.top + delta.top / slideBounds.scale,
+	})
 
 	emit('updateElementWidth', delta.width / slideBounds.scale || 0)
 }

--- a/frontend/src/components/Resizer.vue
+++ b/frontend/src/components/Resizer.vue
@@ -5,7 +5,6 @@
 			v-show="resizeHandle.isVisible"
 			:key="resizeHandle.direction"
 			:direction="resizeHandle.direction"
-			:cursor="resizeCursor"
 			@startResize="(e) => startResize(e, resizeHandle.direction)"
 			@resizeToFitContent="resizeToFitContent"
 		/>

--- a/frontend/src/components/Resizer.vue
+++ b/frontend/src/components/Resizer.vue
@@ -2,11 +2,11 @@
 	<div>
 		<ResizeHandle
 			v-for="resizeHandle in resizeHandles"
-			v-show="handleVisibilityMap[resizeHandle]"
-			:key="resizeHandle"
-			:direction="resizeHandle"
+			v-show="resizeHandle.isVisible"
+			:key="resizeHandle.direction"
+			:direction="resizeHandle.direction"
 			:cursor="resizeCursor"
-			@startResize="(e) => startResize(e, resizeHandle)"
+			@startResize="(e) => startResize(e, resizeHandle.direction)"
 			@resizeToFitContent="resizeToFitContent"
 		/>
 
@@ -47,42 +47,9 @@ const element = defineModel('element', {
 
 const updateSlideCursor = inject('updateSlideCursor')
 
-const { dimensionDelta, currentResizer, startResize } = useResizer()
-
-const resizeCursor = computed(() => {
-	switch (currentResizer.value) {
-		case 'top-left':
-			return 'nwse-resize'
-		case 'top-right':
-			return 'nesw-resize'
-		case 'bottom-left':
-			return 'nesw-resize'
-		case 'bottom-right':
-			return 'nwse-resize'
-		case 'left':
-		case 'right':
-			return 'ew-resize'
-		default:
-			return 'default'
-	}
-})
-
-const resizeHandles = computed(() => {
-	if (props.elementType === 'text') return ['left', 'right']
-	else return ['top-left', 'top-right', 'bottom-left', 'bottom-right']
-})
-
-const isResizeHandleVisible = (resizer) => {
-	if (!currentResizer.value) return true
-	return currentResizer.value === resizer
-}
-
-const handleVisibilityMap = computed(() => {
-	return resizeHandles.value.reduce((acc, resizer) => {
-		acc[resizer] = isResizeHandleVisible(resizer)
-		return acc
-	}, {})
-})
+const { dimensionDelta, currentResizer, startResize, resizeHandles, resizeCursor } = useResizer(
+	props.elementType,
+)
 
 const handleDimensionChange = (delta) => {
 	if (!delta.width) return

--- a/frontend/src/components/Resizer.vue
+++ b/frontend/src/components/Resizer.vue
@@ -19,7 +19,7 @@
 </template>
 
 <script setup>
-import { computed, inject, watch } from 'vue'
+import { computed, inject } from 'vue'
 
 import ResizeHandle from '@/components/ResizeHandle.vue'
 import ResizeIndicator from '@/components/ResizeIndicator.vue'
@@ -45,10 +45,12 @@ const isResizeHandleVisible = (resizer) => {
 }
 
 const resizeHandles = computed(() => {
-	const directions =
-		props.elementType === 'text'
-			? ['left', 'right']
-			: ['top-left', 'top-right', 'bottom-left', 'bottom-right']
+	let directions = []
+	if (props.elementType === 'text') {
+		directions = ['left', 'right']
+	} else {
+		directions = ['top-left', 'top-right', 'bottom-left', 'bottom-right']
+	}
 
 	return directions.map((direction) => ({
 		direction,

--- a/frontend/src/components/Resizer.vue
+++ b/frontend/src/components/Resizer.vue
@@ -11,8 +11,9 @@
 
 		<ResizeIndicator
 			v-show="currentResizer"
-			:currentResizer="currentResizer"
 			:type="elementType"
+			:dimensions="selectionBounds"
+			:indicatorStyles="indicatorStyles"
 		/>
 	</div>
 </template>
@@ -49,6 +50,52 @@ const updateSlideCursor = inject('updateSlideCursor')
 const { dimensionDelta, currentResizer, startResize, resizeHandles, resizeCursor } = useResizer(
 	props.elementType,
 )
+
+const getScaledValue = (value) => `${value / slideBounds.scale}px`
+
+const getTextIndicatorPosition = () => {
+	const resizer = currentResizer.value
+	const offsetX = getScaledValue(selectionBounds.width + 20)
+	const offsetY = getScaledValue(12)
+
+	return {
+		left: resizer.includes('right') ? offsetX : 'auto',
+		right: resizer.includes('left') ? offsetX : 'auto',
+		top: `calc(50% - ${offsetY})`,
+	}
+}
+
+const getMediaIndicatorPosition = () => {
+	const resizer = currentResizer.value
+	const offset = getScaledValue(8)
+
+	return {
+		left: resizer.includes('left') ? offset : 'auto',
+		right: resizer.includes('right') ? offset : 'auto',
+		top: resizer.includes('top') ? offset : 'auto',
+		bottom: resizer.includes('bottom') ? offset : 'auto',
+	}
+}
+
+const getPositionStyles = () => {
+	if (props.elementType === 'text') {
+		return getTextIndicatorPosition()
+	}
+	return getMediaIndicatorPosition()
+}
+
+const indicatorStyles = computed(() => {
+	if (!currentResizer.value) return {}
+
+	const positionStyles = getPositionStyles()
+
+	return {
+		fontSize: getScaledValue(10),
+		borderRadius: getScaledValue(6),
+		padding: getScaledValue(4),
+		...positionStyles,
+	}
+})
 
 const handleDimensionChange = (delta) => {
 	if (!delta.width) return

--- a/frontend/src/components/Resizer.vue
+++ b/frontend/src/components/Resizer.vue
@@ -85,7 +85,7 @@ const handleVisibilityMap = computed(() => {
 })
 
 const handleDimensionChange = (delta) => {
-	if (!currentResizer.value || !delta.width) return
+	if (!delta.width) return
 
 	const ratio = selectionBounds.width / selectionBounds.height
 	delta.top = (delta.top ?? 0) / ratio
@@ -103,7 +103,7 @@ const handleDimensionChange = (delta) => {
 
 const resizeToFitContent = () => {
 	// create range of the text node within TextElement
-	const target = props.elementDivRef?.value
+	const target = props.elementDivRef
 	const range = document.createRange()
 	const textNode = target.firstChild
 	const originalWidth = target.offsetWidth

--- a/frontend/src/components/SelectionBox.vue
+++ b/frontend/src/components/SelectionBox.vue
@@ -233,14 +233,17 @@ const moveElementsToBox = (elementIds) => {
 	})
 }
 
+const handleSelection = (elementIds) => {
+	if (!elementIds.length) return
+	document.removeEventListener('mouseup', endSelection)
+	cropSelectionToFitContent(elementIds)
+	moveElementsToBox(elementIds)
+}
+
 const handleSelectionChange = (elementIds, oldIds) => {
 	resetSelection(oldIds)
 	moveElementsToSlide(oldIds)
-	if (elementIds.length) {
-		document.removeEventListener('mouseup', endSelection)
-		cropSelectionToFitContent(elementIds)
-		moveElementsToBox(elementIds)
-	}
+	nextTick(() => handleSelection(elementIds))
 }
 
 const selectSlide = (e) => {

--- a/frontend/src/components/SelectionBox.vue
+++ b/frontend/src/components/SelectionBox.vue
@@ -5,7 +5,7 @@
 <script setup>
 import { ref, computed, nextTick, useTemplateRef, onMounted, onBeforeUnmount, inject } from 'vue'
 
-import { slide, slideBounds, selectionBounds } from '@/stores/slide'
+import { slide, slideBounds, selectionBounds, updateSelectionBounds } from '@/stores/slide'
 import {
 	activeElementIds,
 	setActiveElements,
@@ -43,11 +43,12 @@ const initSelection = (e) => {
 		const currentX = (e.clientX - slideBounds.left) / slideBounds.scale
 		const currentY = (e.clientY - slideBounds.top) / slideBounds.scale
 
-		selectionBounds.left = currentX
-		selectionBounds.top = currentY
-
-		selectionBounds.width = 0
-		selectionBounds.height = 0
+		updateSelectionBounds({
+			left: currentX,
+			top: currentY,
+			width: 0,
+			height: 0,
+		})
 
 		startX.value = currentX
 		startY.value = currentY
@@ -60,20 +61,30 @@ const updateSelection = (e) => {
 	const currentX = (e.clientX - slideBounds.left) / slideBounds.scale
 	const currentY = (e.clientY - slideBounds.top) / slideBounds.scale
 
-	selectionBounds.width = Math.abs(currentX - startX.value)
-	selectionBounds.height = Math.abs(currentY - startY.value)
+	const newBounds = {
+		width: Math.abs(currentX - startX.value),
+		height: Math.abs(currentY - startY.value),
+	}
 
-	if (currentX < startX.value) selectionBounds.left = currentX
-	if (currentY < startY.value) selectionBounds.top = currentY
+	if (currentX < startX.value) {
+		newBounds.left = currentX
+	}
+	if (currentY < startY.value) {
+		newBounds.top = currentY
+	}
+
+	updateSelectionBounds(newBounds)
 
 	document.addEventListener('mouseup', endSelection)
 }
 
 const removeSelectionBox = () => {
-	selectionBounds.left = 0
-	selectionBounds.top = 0
-	selectionBounds.width = 0
-	selectionBounds.height = 0
+	updateSelectionBounds({
+		left: 0,
+		top: 0,
+		width: 0,
+		height: 0,
+	})
 }
 
 const getElementsWithinBoxSurface = () => {
@@ -145,15 +156,19 @@ const cropSelectionToFitContent = (elementIds) => {
 		if (elementBottom > b) b = elementBottom
 	})
 
-	selectionBounds.left = l
-	selectionBounds.top = t
-	selectionBounds.width = r - l + 1
-	selectionBounds.height = b - t + 1
+	updateSelectionBounds({
+		left: l,
+		top: t,
+		width: r - l + 1,
+		height: b - t + 1,
+	})
 }
 
 const resetSelection = (oldVal) => {
-	selectionBounds.width = 0
-	selectionBounds.height = 0
+	updateSelectionBounds({
+		width: 0,
+		height: 0,
+	})
 }
 
 const handleMouseDown = (e) => {

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -35,7 +35,7 @@ import SelectionBox from '@/components/SelectionBox.vue'
 import SlideElement from '@/components/SlideElement.vue'
 
 import { presentation } from '@/stores/presentation'
-import { slide, slideBounds, selectionBounds } from '@/stores/slide'
+import { slide, slideBounds, selectionBounds, updateSelectionBounds } from '@/stores/slide'
 import {
 	activeElementIds,
 	handleCopy,
@@ -194,8 +194,10 @@ useResizeObserver(activeDiv, (entries) => {
 	// case:
 	// when element dimensions are changed not by resizer
 	// but by other updates on properties - font size, line height, letter spacing etc.
-	selectionBounds.width = width
-	selectionBounds.height = height
+	updateSelectionBounds({
+		width: width,
+		height: height,
+	})
 })
 
 const togglePanZoom = () => {
@@ -216,8 +218,10 @@ const handlePositionChange = (delta) => {
 
 	if (!disableMovement.value) {
 		const totalDelta = getTotalPositionDelta(delta)
-		selectionBounds.left += totalDelta.left / scale.value
-		selectionBounds.top += totalDelta.top / scale.value
+		updateSelectionBounds({
+			left: selectionBounds.left + totalDelta.left / scale.value,
+			top: selectionBounds.top + totalDelta.top / scale.value,
+		})
 	}
 }
 

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -73,12 +73,6 @@ const { allowPanAndZoom, transform, transformOrigin } = usePanAndZoom(
 	slideTargetRef,
 )
 
-const slideCursor = ref('default')
-
-const updateSlideCursor = (cursor) => {
-	slideCursor.value = cursor
-}
-
 const slideClasses = computed(() => {
 	const classes = ['slide', 'h-[540px]', 'w-[960px]', 'shadow-2xl']
 
@@ -96,7 +90,7 @@ const targetStyles = computed(() => ({
 const slideStyles = computed(() => ({
 	backgroundColor: slide.value.background || 'white',
 	'--showEdgeOverlay': !activeElementIds.value.length ? 'block' : 'none',
-	cursor: isDragging.value ? 'move' : slideCursor.value || 'default',
+	cursor: isDragging.value ? 'move' : resizeCursor.value || 'default',
 }))
 
 const getElementOutline = (element) => {
@@ -288,13 +282,6 @@ watch(
 	() => dimensionDelta.value,
 	(delta) => {
 		handleDimensionChange(delta)
-	},
-)
-
-watch(
-	() => currentResizer.value,
-	(resizer) => {
-		updateSlideCursor(resizeCursor.value)
 	},
 )
 

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -117,7 +117,7 @@ const clearTimeouts = () => {
 }
 
 const triggerSelection = (e, id) => {
-	if (id && !focusElementId.value) {
+	if (id && !focusElementId.value && !activeElementIds.value.includes(id)) {
 		activeElementIds.value = [id]
 	}
 }

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -74,19 +74,13 @@ const updateSlideCursor = (cursor) => {
 	slideCursor.value = cursor
 }
 
-const cursorClass = computed(() => {
-	const cursor = isDragging.value ? 'move' : slideCursor.value || 'default'
-	return `cursor-${cursor}`
-})
-
 const slideClasses = computed(() => {
 	const classes = ['slide', 'h-[540px]', 'w-[960px]', 'shadow-2xl']
 
 	const outlineClasses = props.highlight ? ['outline', 'outline-2', 'outline-blue-400'] : []
 	const shadowClasses = activeElementIds.value.length ? ['shadow-gray-200'] : ['shadow-gray-400']
-	const cursorClasses = [cursorClass.value]
 
-	return [...classes, outlineClasses, shadowClasses, cursorClasses]
+	return [...classes, outlineClasses, shadowClasses]
 })
 
 const targetStyles = computed(() => ({
@@ -97,6 +91,7 @@ const targetStyles = computed(() => ({
 const slideStyles = computed(() => ({
 	backgroundColor: slide.value.background || 'white',
 	'--showEdgeOverlay': !activeElementIds.value.length ? 'block' : 'none',
+	cursor: isDragging.value ? 'move' : slideCursor.value || 'default',
 }))
 
 const getElementOutline = (element) => {

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -219,6 +219,31 @@ const handlePositionChange = (delta) => {
 	}
 }
 
+const applyAspectRatio = (offset) => {
+	if (!offset) return 0
+	const ratio = selectionBounds.width / selectionBounds.height
+	return (offset ?? 0) / ratio
+}
+
+const validateMinWidth = (width) => {
+	const minWidth = activeElement.value.type === 'text' ? 7 : 50
+	return width + selectionBounds.width > minWidth
+}
+
+const handleDimensionChange = (delta) => {
+	if (!delta.width || !validateMinWidth(delta.width)) return
+
+	delta.top = applyAspectRatio(delta.top)
+
+	updateSelectionBounds({
+		left: selectionBounds.left + delta.left / slideBounds.scale,
+		top: selectionBounds.top + delta.top / slideBounds.scale,
+	})
+
+	const newWidth = delta.width / slideBounds.scale || 0
+	updateElementWidth(newWidth)
+}
+
 const updateSlideBounds = () => {
 	const slideRect = slideRef.value.getBoundingClientRect()
 
@@ -258,6 +283,13 @@ watch(
 	},
 )
 
+watch(
+	() => dimensionDelta.value,
+	(delta) => {
+		handleDimensionChange(delta)
+	},
+)
+
 onMounted(() => {
 	if (!slideRef.value) return
 
@@ -277,32 +309,6 @@ provide('resizer', {
 defineExpose({
 	togglePanZoom,
 })
-
-watch(
-	() => dimensionDelta.value,
-	(delta) => {
-		handleDimensionChange(delta)
-	},
-)
-
-const handleDimensionChange = (delta) => {
-	if (!delta.width) return
-
-	const ratio = selectionBounds.width / selectionBounds.height
-	delta.top = (delta.top ?? 0) / ratio
-
-	const minWidth = props.elementType === 'text' ? 7 : 50
-	if (delta.width + selectionBounds.width < minWidth) return
-
-	updateSelectionBounds({
-		left: selectionBounds.left + delta.left / slideBounds.scale,
-		top: selectionBounds.top + delta.top / slideBounds.scale,
-	})
-
-	const newWidth = delta.width / slideBounds.scale || 0
-
-	updateElementWidth(newWidth)
-}
 </script>
 
 <style src="../assets/styles/overlay.css"></style>

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -17,6 +17,7 @@
 					:key="element.id"
 					:element="element"
 					:outline="getElementOutline(element)"
+					:isDragging="isDragging"
 					:data-index="element.id"
 					@mousedown="(e) => handleMouseDown(e, element)"
 					@dblclick="(e) => handleDoubleClick(e, element)"

--- a/frontend/src/components/SlideElement.vue
+++ b/frontend/src/components/SlideElement.vue
@@ -19,7 +19,7 @@ import ImageElement from '@/components/ImageElement.vue'
 import VideoElement from '@/components/VideoElement.vue'
 import Resizer from '@/components/Resizer.vue'
 
-import { activeElementIds } from '@/stores/element'
+import { activeElement, activeElementIds } from '@/stores/element'
 
 const props = defineProps({
 	outline: {
@@ -68,8 +68,8 @@ const getDynamicComponent = (type) => {
 }
 
 const isElementActive = computed(() => {
-	if (!activeElementIds.value.length) return false
-	return activeElementIds.value[0] == element.value.id
+	if (!activeElement.value) return false
+	return activeElement.value.id == element.value.id
 })
 
 const updateElementWidth = (deltaWidth) => {

--- a/frontend/src/components/SlideElement.vue
+++ b/frontend/src/components/SlideElement.vue
@@ -3,7 +3,7 @@
 		<component :is="getDynamicComponent(element.type)" :element="element" />
 
 		<Resizer
-			v-if="isElementActive"
+			v-if="showResizers"
 			:elementType="element.type"
 			:dimensions="selectionBounds"
 			@resizeToFitContent="resizeToFitContent"
@@ -27,6 +27,10 @@ const props = defineProps({
 	outline: {
 		type: String,
 		default: 'none',
+	},
+	isDragging: {
+		type: Boolean,
+		default: false,
 	},
 })
 
@@ -69,9 +73,9 @@ const getDynamicComponent = (type) => {
 	}
 }
 
-const isElementActive = computed(() => {
+const showResizers = computed(() => {
 	if (!activeElement.value) return false
-	return activeElement.value.id == element.value.id
+	return activeElement.value.id == element.value.id && !props.isDragging
 })
 
 const resizeToFitContent = () => {

--- a/frontend/src/components/SlideElement.vue
+++ b/frontend/src/components/SlideElement.vue
@@ -5,8 +5,8 @@
 		<Resizer
 			v-if="isElementActive"
 			:elementType="element.type"
-			:elementDivRef="elementDivRef"
-			@updateElementWidth="updateElementWidth"
+			:dimensions="selectionBounds"
+			@resizeToFitContent="resizeToFitContent"
 		/>
 	</div>
 </template>
@@ -19,7 +19,9 @@ import ImageElement from '@/components/ImageElement.vue'
 import VideoElement from '@/components/VideoElement.vue'
 import Resizer from '@/components/Resizer.vue'
 
-import { activeElement, activeElementIds } from '@/stores/element'
+import { activeElement, activeElementIds, updateElementWidth } from '@/stores/element'
+
+import { selectionBounds, slideBounds } from '@/stores/slide'
 
 const props = defineProps({
 	outline: {
@@ -72,14 +74,19 @@ const isElementActive = computed(() => {
 	return activeElement.value.id == element.value.id
 })
 
-const updateElementWidth = (deltaWidth) => {
-	if (element.value.width) {
-		element.value.width += deltaWidth
-	} else {
-		const elementDiv = elementDivRef.value
-		const width = elementDiv.getBoundingClientRect().width
+const resizeToFitContent = () => {
+	// create range of the text node within TextElement
+	const target = elementDivRef.value
+	const range = document.createRange()
+	const textNode = target.firstChild
+	const originalWidth = target.offsetWidth
+	range.selectNodeContents(textNode)
 
-		element.value.width = width + deltaWidth
-	}
+	// find out width of text content
+	const textWidth = range.getBoundingClientRect().width
+
+	const newWidth = textWidth - originalWidth + 5 / slideBounds.scale
+
+	updateElementWidth(newWidth)
 }
 </script>

--- a/frontend/src/components/SnapGuides.vue
+++ b/frontend/src/components/SnapGuides.vue
@@ -59,17 +59,16 @@ const getElementBounds = (div) => {
 const getVerticalStyles = (direction) => {
 	if (!pairElementId.value || !props.visibilityMap[direction]) return ''
 
-	const activeBounds = selectionBounds
 	const pairedBounds = getElementBounds(pairedDiv.value)
 
 	const left =
 		direction == 'left'
-			? activeBounds.left - 1
-			: activeBounds.left + activeBounds.width * slideBounds.scale
-	const top = Math.min(activeBounds.top, pairedBounds.top)
+			? selectionBounds.left - 1
+			: selectionBounds.left + selectionBounds.width
+	const top = Math.min(selectionBounds.top, pairedBounds.top)
 	const lastElementHeight =
-		pairedBounds.top < activeBounds.top ? activeBounds.height : pairedBounds.height
-	const height = Math.abs(pairedBounds.top - activeBounds.top) + lastElementHeight
+		pairedBounds.top < selectionBounds.top ? selectionBounds.height : pairedBounds.height
+	const height = Math.abs(pairedBounds.top - selectionBounds.top) + lastElementHeight
 
 	return {
 		position: 'fixed',
@@ -85,18 +84,15 @@ const getVerticalStyles = (direction) => {
 const getHorizontalStyles = (direction) => {
 	if (!pairElementId.value || !props.visibilityMap[direction]) return ''
 
-	const activeBounds = selectionBounds
 	const pairedBounds = getElementBounds(pairedDiv.value)
 
 	const top =
-		direction == 'top'
-			? activeBounds.top - 1
-			: activeBounds.top + activeBounds.height * slideBounds.scale
-	const left = Math.min(activeBounds.left, pairedBounds.left)
+		direction == 'top' ? selectionBounds.top - 1 : selectionBounds.top + selectionBounds.height
+	const left = Math.min(selectionBounds.left, pairedBounds.left)
 
 	const lastElementWidth =
-		pairedBounds.left < activeBounds.left ? activeBounds.width : pairedBounds.width
-	const width = Math.abs(pairedBounds.left - activeBounds.left) + lastElementWidth
+		pairedBounds.left < selectionBounds.left ? selectionBounds.width : pairedBounds.width
+	const width = Math.abs(pairedBounds.left - selectionBounds.left) + lastElementWidth
 
 	return {
 		position: 'fixed',

--- a/frontend/src/components/VideoElement.vue
+++ b/frontend/src/components/VideoElement.vue
@@ -68,6 +68,7 @@ const isPlaying = ref(false)
 
 const videoStyle = computed(() => ({
 	width: '100%',
+	opacity: element.value.opacity / 100,
 	borderRadius: `${element.value.borderRadius}px`,
 	borderStyle: element.value.borderStyle || 'none',
 	borderColor: element.value.borderColor,

--- a/frontend/src/components/controls/CollapsibleSection.vue
+++ b/frontend/src/components/controls/CollapsibleSection.vue
@@ -1,11 +1,11 @@
 <template>
-	<div class="flex flex-col gap-4">
+	<div class="flex flex-col gap-4 cursor-pointer">
 		<div class="flex justify-between items-center" @click="showContent = !showContent">
 			<div :class="titleClasses">{{ title }}</div>
 			<component
 				:is="showContent ? ChevronUp : ChevronDown"
 				size="16"
-				class="stroke-[1.5] text-gray-700 cursor-pointer"
+				class="stroke-[1.5] text-gray-700"
 			/>
 		</div>
 

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -104,8 +104,10 @@ const handleArrowKeys = (key) => {
 	else if (key == 'ArrowUp') dy = -1
 	else if (key == 'ArrowDown') dy = 1
 
-	selectionBounds.left += dx
-	selectionBounds.top += dy
+	updateSelectionBounds({
+		left: selectionBounds.left + dx,
+		top: selectionBounds.top + dy,
+	})
 }
 
 const saveSlide = (e) => {

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -54,7 +54,14 @@ import DropTargetOverlay from '@/components/DropTargetOverlay.vue'
 import Toolbar from '@/components/Toolbar.vue'
 
 import { presentationId, presentation } from '@/stores/presentation'
-import { slide, slideIndex, saveChanges, loadSlide, selectionBounds } from '@/stores/slide'
+import {
+	slide,
+	slideIndex,
+	saveChanges,
+	loadSlide,
+	selectionBounds,
+	updateSelectionBounds,
+} from '@/stores/slide'
 import {
 	resetFocus,
 	activeElementIds,

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -54,7 +54,7 @@ import DropTargetOverlay from '@/components/DropTargetOverlay.vue'
 import Toolbar from '@/components/Toolbar.vue'
 
 import { presentationId, presentation, loadPresentation } from '@/stores/presentation'
-import { slide, slideIndex, saveChanges, loadSlide } from '@/stores/slide'
+import { slide, slideIndex, saveChanges, loadSlide, updateSlideThumbnail } from '@/stores/slide'
 import {
 	resetFocus,
 	activeElementIds,

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -54,7 +54,15 @@ import DropTargetOverlay from '@/components/DropTargetOverlay.vue'
 import Toolbar from '@/components/Toolbar.vue'
 
 import { presentationId, presentation, loadPresentation } from '@/stores/presentation'
-import { slide, slideIndex, saveChanges, loadSlide, updateSlideThumbnail } from '@/stores/slide'
+import {
+	slide,
+	slideIndex,
+	saveChanges,
+	loadSlide,
+	selectionBounds,
+	updateSelectionBounds,
+	updateSlideThumbnail,
+} from '@/stores/slide'
 import {
 	resetFocus,
 	activeElementIds,

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -54,7 +54,7 @@ import DropTargetOverlay from '@/components/DropTargetOverlay.vue'
 import Toolbar from '@/components/Toolbar.vue'
 
 import { presentationId, presentation } from '@/stores/presentation'
-import { slide, slideIndex, saveChanges, loadSlide } from '@/stores/slide'
+import { slide, slideIndex, saveChanges, loadSlide, selectionBounds } from '@/stores/slide'
 import {
 	resetFocus,
 	activeElementIds,
@@ -104,7 +104,8 @@ const handleArrowKeys = (key) => {
 	else if (key == 'ArrowUp') dy = -1
 	else if (key == 'ArrowDown') dy = 1
 
-	// slideContainerRef.value.applyMovement({ dx, dy })
+	selectionBounds.left += dx
+	selectionBounds.top += dy
 }
 
 const saveSlide = (e) => {

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -23,7 +23,7 @@ const activeElements = computed(() => {
 const activeElement = computed(() => {
 	if (focusElementId.value) {
 		return slide.value.elements.find((element) => element.id === focusElementId.value)
-	} else {
+	} else if (activeElementIds.value.length == 1) {
 		return activeElements.value[0]
 	}
 })

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -238,6 +238,19 @@ const handlePaste = (e) => {
 	}
 }
 
+const updateElementWidth = (deltaWidth) => {
+	const element = activeElement.value
+
+	if (element.width) {
+		element.width += deltaWidth
+	} else {
+		const elementDiv = document.querySelector(`[data-index="${element.id}"]`)
+		const width = elementDiv.getBoundingClientRect().width
+
+		element.width = width + deltaWidth
+	}
+}
+
 export {
 	activeElementIds,
 	focusElementId,
@@ -255,4 +268,5 @@ export {
 	getElementPosition,
 	handleCopy,
 	handlePaste,
+	updateElementWidth,
 }

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -104,4 +104,17 @@ const saveChanges = async () => {
 
 const slideBounds = reactive({})
 
-export { slideIndex, slide, slideBounds, selectionBounds, loadSlide, updateSlideState, saveChanges }
+const updateSelectionBounds = (newBounds) => {
+	Object.assign(selectionBounds, newBounds)
+}
+
+export {
+	slideIndex,
+	slide,
+	slideBounds,
+	selectionBounds,
+	loadSlide,
+	updateSlideState,
+	saveChanges,
+	updateSelectionBounds,
+}

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -125,4 +125,5 @@ export {
 	updateSlideState,
 	saveChanges,
 	updateSelectionBounds,
+	updateSlideThumbnail,
 }

--- a/frontend/src/utils/resizer.js
+++ b/frontend/src/utils/resizer.js
@@ -1,6 +1,6 @@
 import { ref, computed } from 'vue'
 
-export const useResizer = (elementType) => {
+export const useResizer = () => {
 	const isResizing = ref(false)
 	const currentResizer = ref(null)
 
@@ -14,23 +14,6 @@ export const useResizer = (elementType) => {
 	}
 
 	const resizeCursor = computed(() => cursorMap[currentResizer.value] ?? 'default')
-
-	const isResizeHandleVisible = (resizer) => {
-		if (!currentResizer.value) return true
-		return currentResizer.value === resizer
-	}
-
-	const resizeHandles = computed(() => {
-		const directions =
-			elementType === 'text'
-				? ['left', 'right']
-				: ['top-left', 'top-right', 'bottom-left', 'bottom-right']
-
-		return directions.map((direction) => ({
-			direction,
-			isVisible: isResizeHandleVisible(direction),
-		}))
-	})
 
 	let prevX = 0
 	let prevY = 0
@@ -109,5 +92,5 @@ export const useResizer = (elementType) => {
 		window.removeEventListener('mouseup', stopResize)
 	}
 
-	return { dimensionDelta, currentResizer, startResize, resizeHandles, resizeCursor }
+	return { dimensionDelta, currentResizer, startResize, resizeCursor }
 }

--- a/frontend/src/utils/resizer.js
+++ b/frontend/src/utils/resizer.js
@@ -1,8 +1,36 @@
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 
-export const useResizer = () => {
+export const useResizer = (elementType) => {
 	const isResizing = ref(false)
 	const currentResizer = ref(null)
+
+	const cursorMap = {
+		'top-left': 'nwse-resize',
+		'top-right': 'nesw-resize',
+		'bottom-left': 'nesw-resize',
+		'bottom-right': 'nwse-resize',
+		left: 'ew-resize',
+		right: 'ew-resize',
+	}
+
+	const resizeCursor = computed(() => cursorMap[currentResizer.value] ?? 'default')
+
+	const isResizeHandleVisible = (resizer) => {
+		if (!currentResizer.value) return true
+		return currentResizer.value === resizer
+	}
+
+	const resizeHandles = computed(() => {
+		const directions =
+			elementType === 'text'
+				? ['left', 'right']
+				: ['top-left', 'top-right', 'bottom-left', 'bottom-right']
+
+		return directions.map((direction) => ({
+			direction,
+			isVisible: isResizeHandleVisible(direction),
+		}))
+	})
 
 	let prevX = 0
 	let prevY = 0
@@ -81,5 +109,5 @@ export const useResizer = () => {
 		window.removeEventListener('mouseup', stopResize)
 	}
 
-	return { dimensionDelta, currentResizer, startResize }
+	return { dimensionDelta, currentResizer, startResize, resizeHandles, resizeCursor }
 }

--- a/frontend/src/utils/snap.js
+++ b/frontend/src/utils/snap.js
@@ -3,7 +3,8 @@ import { selectionBounds, slide, slideBounds } from '../stores/slide'
 import { activeElementIds, pairElementId } from '../stores/element'
 
 export const useSnapping = (target, parent) => {
-	const PROXIMITY_THRESHOLD = 30
+	const CENTER_PROXIMITY_THRESHOLD = 15
+	const PROXIMITY_THRESHOLD = 10
 
 	const snapMovement = ref({ x: 0, y: 0 })
 
@@ -139,10 +140,18 @@ export const useSnapping = (target, parent) => {
 		const diff = diffs[axis]
 		const prevDiff = prevDiffs[axis]
 
+		let threshold, margin
+		if (['horizontal', 'vertical'].includes(axis)) {
+			threshold = CENTER_PROXIMITY_THRESHOLD
+			margin = 3
+		} else {
+			threshold = PROXIMITY_THRESHOLD
+			margin = 5
+		}
+
 		let offset = 0
 
-		const canSnap =
-			Math.abs(diff + PROXIMITY_THRESHOLD) < 3 || Math.abs(diff - PROXIMITY_THRESHOLD) < 3
+		const canSnap = Math.abs(diff + threshold) < margin || Math.abs(diff - threshold) < margin
 		const movingAway = Math.abs(diff) > Math.abs(prevDiff)
 
 		if (canSnap && !movingAway) {

--- a/frontend/src/utils/snap.js
+++ b/frontend/src/utils/snap.js
@@ -1,5 +1,5 @@
 import { ref, reactive, computed } from 'vue'
-import { slide, slideBounds } from '../stores/slide'
+import { selectionBounds, slide, slideBounds } from '../stores/slide'
 import { activeElementIds, pairElementId } from '../stores/element'
 
 export const useSnapping = (target, parent) => {
@@ -64,11 +64,11 @@ export const useSnapping = (target, parent) => {
 		const activeBounds = getElementBounds(target.value.$el)
 
 		if (axis == 'X') {
-			slideCenter = slideBounds.left + slideBounds.width / 2
-			elementCenter = activeBounds.left + activeBounds.width / 2
+			slideCenter = slideBounds.width / 2
+			elementCenter = selectionBounds.left + selectionBounds.width / 2
 		} else {
-			slideCenter = slideBounds.top + slideBounds.height / 2
-			elementCenter = activeBounds.top + activeBounds.height / 2
+			slideCenter = slideBounds.height / 2
+			elementCenter = selectionBounds.top + selectionBounds.height / 2
 		}
 
 		return slideCenter - elementCenter
@@ -90,7 +90,7 @@ export const useSnapping = (target, parent) => {
 			const elementDiv = document.querySelector(`[data-index="${element.id}"]`)
 			if (!elementDiv || !target.value) return
 
-			const activeBounds = getElementBounds(target.value.$el)
+			const activeBounds = selectionBounds
 			const elementBounds = getElementBounds(elementDiv)
 
 			const diffLeft = activeBounds.left - elementBounds.left

--- a/frontend/src/utils/snap.js
+++ b/frontend/src/utils/snap.js
@@ -94,9 +94,9 @@ export const useSnapping = (target, parent) => {
 			const elementBounds = getElementBounds(elementDiv)
 
 			const diffLeft = activeBounds.left - elementBounds.left
-			const diffRight = activeBounds.right - elementBounds.right
+			const diffRight = activeBounds.left + activeBounds.width - elementBounds.right
 			const diffTop = activeBounds.top - elementBounds.top
-			const diffBottom = activeBounds.bottom - elementBounds.bottom
+			const diffBottom = activeBounds.top + activeBounds.height - elementBounds.bottom
 
 			const canPair = canElementPair(diffLeft, diffRight, diffTop, diffBottom)
 			const isPaired = pairElementId.value == element.id

--- a/frontend/src/utils/snap.js
+++ b/frontend/src/utils/snap.js
@@ -62,14 +62,18 @@ export const useSnapping = (target, parent) => {
 		if (!target.value) return
 		let slideCenter, elementCenter
 
-		const activeBounds = getElementBounds(target.value.$el)
-
 		if (axis == 'X') {
-			slideCenter = slideBounds.width / 2
-			elementCenter = selectionBounds.left + selectionBounds.width / 2
+			const elementLeft = selectionBounds.left * slideBounds.scale + slideBounds.left
+			const elementWidth = selectionBounds.width * slideBounds.scale
+
+			slideCenter = slideBounds.left + slideBounds.width / 2
+			elementCenter = elementLeft + elementWidth / 2
 		} else {
-			slideCenter = slideBounds.height / 2
-			elementCenter = selectionBounds.top + selectionBounds.height / 2
+			const elementTop = selectionBounds.top * slideBounds.scale + slideBounds.top
+			const elementHeight = selectionBounds.height * slideBounds.scale
+
+			slideCenter = slideBounds.top + slideBounds.height / 2
+			elementCenter = elementTop + elementHeight / 2
 		}
 
 		return slideCenter - elementCenter


### PR DESCRIPTION
### Changes

- Re-enable movement using up, down, left, right arrow keys.
- Use separate thresholds and margins for proximity and center alignment guides.
- The resize cursor now properly overrides the slide cursor so it will be shown uniformly even if the mouse leaves the element bounds.
- First element of selection showed up with resizers previously due to incorrect condition.
- Breakdown and move the dimension change affect logic to the container instead of inside the resizer utility.