### PR TITLE
fix(ColorPicker): hue cursor initial position + misc

### DIFF
--- a/frontend/src/components/controls/ColorPicker.vue
+++ b/frontend/src/components/controls/ColorPicker.vue
@@ -1,5 +1,5 @@
 <template>
-	<Popover>
+	<Popover @open="handlePopoverOpen">
 		<template #target="{ togglePopover }">
 			<div
 				class="my-2 h-4 w-4 cursor-pointer rounded-sm ring-1 ring-gray-400"
@@ -77,6 +77,7 @@ const shadeStyles = computed(() => {
 
 const colorStyles = computed(() => {
 	return {
+		width: '125px',
 		background: `linear-gradient(to right, rgb(255, 0, 0), rgb(255, 0, 255), rgb(0, 0, 255), rgb(0, 255, 255), rgb(0, 255, 0), rgb(255, 255, 0), rgb(255, 0, 0))`,
 	}
 })
@@ -90,8 +91,8 @@ let colorRect = useElementBounding(colorSlider)
 let shadeRect = useElementBounding(shadeSlider)
 
 const currentColor = defineModel()
-const currentHue = ref('hsl(0, 100%, 50%)')
-const hueCursorLeft = ref('calc(0% - 6px)')
+const currentHue = ref('')
+const hueCursorLeft = ref('')
 
 const currentOpacity = ref(1)
 const opacityCursorLeft = ref('calc(100% - 6px)')
@@ -198,5 +199,11 @@ const updateOpacity = (e) => {
 
 const endUpdateOpacity = (e) => {
 	window.removeEventListener('mousemove', updateOpacity)
+}
+
+const handlePopoverOpen = () => {
+	hue = tinycolor(currentColor.value).toHsl().h
+	currentHue.value = tinycolor('hsl ' + hue + ' 1 .5').toHslString()
+	hueCursorLeft.value = 125 - (hue / 360) * 125 - 6 + 'px'
 }
 </script>

--- a/frontend/src/components/controls/ColorPicker.vue
+++ b/frontend/src/components/controls/ColorPicker.vue
@@ -8,11 +8,11 @@
 			></div>
 		</template>
 		<template #body-main>
-			<div class="rounded p-2 shadow-2xl" :style="{ width: '192px', height: '200px' }">
-				<div class="flex h-full w-full flex-col">
+			<div class="rounded p-3" :style="{ width: '192px', height: '200px' }">
+				<div class="flex h-full w-full flex-col gap-3">
 					<div
 						ref="shadeSlider"
-						class="h-[150px] cursor-pointer rounded-t"
+						class="h-full cursor-pointer rounded-t"
 						:style="shadeStyles"
 						@mousedown="handleUpdateShade"
 					>
@@ -25,15 +25,15 @@
 							}"
 						></div>
 					</div>
-					<div class="flex h-[50px] justify-between gap-3 p-3">
+					<div class="flex h-[20%] justify-between p-1">
 						<div
-							class="h-full w-8 rounded-sm ring-[1.5px] ring-gray-200"
+							class="h-full w-6 rounded-sm ring-[1.5px] ring-gray-200"
 							:style="{ backgroundColor: currentColor }"
 						></div>
-						<div class="flex w-full flex-col gap-4">
+						<div class="flex flex-col justify-between">
 							<div
 								ref="colorSlider"
-								class="h-1/5 rounded"
+								class="h-1/5 rounded cursor-pointer"
 								:style="colorStyles"
 								@mousedown="handleUpdateHue"
 							>
@@ -44,7 +44,7 @@
 							</div>
 							<div
 								ref="opacitySlider"
-								class="h-1/5 rounded"
+								class="h-1/5 rounded cursor-pointer"
 								:style="opacityStyles"
 								@mousedown="handleUpdateOpacity"
 							>

--- a/frontend/src/components/controls/ColorPicker.vue
+++ b/frontend/src/components/controls/ColorPicker.vue
@@ -2,7 +2,7 @@
 	<Popover @open="handlePopoverOpen">
 		<template #target="{ togglePopover }">
 			<div
-				class="my-2 h-4 w-4 cursor-pointer rounded-sm ring-1 ring-gray-400"
+				class="my-2 h-4 w-4 cursor-pointer rounded-sm ring-1 ring-offset-1 ring-gray-200"
 				:style="{ backgroundColor: currentColor }"
 				@click="togglePopover"
 			></div>
@@ -12,18 +12,21 @@
 				<div class="flex flex-col gap-3">
 					<div
 						ref="shadeSlider"
-						class="cursor-pointer rounded-t"
+						class="cursor-pointer rounded-t shadow-xl"
 						:style="shadeStyles"
 						@mousedown="handleUpdateShade"
 					>
-						<div class="relative h-3 w-3 rounded border" :style="shadeRectStyles"></div>
-					</div>
-					<div class="flex h-8 justify-between p-1">
 						<div
-							class="h-full w-6 rounded-sm ring-[1.5px] ring-gray-200"
+							class="relative h-3 w-3 rounded border shadow-md"
+							:style="shadeRectStyles"
+						></div>
+					</div>
+					<div class="flex h-8 justify-between py-1">
+						<div
+							class="h-full w-6 rounded-sm ring-1 ring-offset-1 ring-gray-100"
 							:style="{ backgroundColor: currentColor }"
 						></div>
-						<div class="flex flex-col justify-between">
+						<div class="flex flex-col justify-between px-1">
 							<div
 								ref="colorSlider"
 								:class="sliderClasses"
@@ -73,7 +76,8 @@ const SHADE_RECT_WIDTH = 170
 const SHADE_RECT_HEIGHT = 130
 
 const sliderClasses = 'h-1/5 rounded cursor-pointer'
-const sliderCursorClasses = 'relative h-[0.8rem] w-[0.8rem] rounded border border-gray-700 bg-white'
+const sliderCursorClasses =
+	'relative h-[0.8rem] w-[0.8rem] rounded shadow border border-gray-200 bg-white'
 
 const currentColor = defineModel()
 

--- a/frontend/src/components/controls/ColorPicker.vue
+++ b/frontend/src/components/controls/ColorPicker.vue
@@ -2,7 +2,7 @@
 	<Popover>
 		<template #target="{ togglePopover }">
 			<div
-				class="my-2 h-4 w-4 cursor-pointer rounded-sm border border-gray-500"
+				class="my-2 h-4 w-4 cursor-pointer rounded-sm ring-1 ring-gray-400"
 				:style="{ backgroundColor: currentColor }"
 				@click="togglePopover"
 			></div>

--- a/frontend/src/components/controls/ColorPicker.vue
+++ b/frontend/src/components/controls/ColorPicker.vue
@@ -79,7 +79,7 @@ const shadeStyles = computed(() => {
 
 const colorStyles = computed(() => {
 	return {
-		width: '125px',
+		width: `${SLIDER_WIDTH}px`,
 		background: `linear-gradient(to right, rgb(255, 0, 0), rgb(255, 0, 255), rgb(0, 0, 255), rgb(0, 255, 255), rgb(0, 255, 0), rgb(255, 255, 0), rgb(255, 0, 0))`,
 	}
 })
@@ -91,6 +91,10 @@ const colorSlider = useTemplateRef('colorSlider')
 
 let colorRect = useElementBounding(colorSlider)
 let shadeRect = useElementBounding(shadeSlider)
+
+const SLIDER_WIDTH = 125
+const SHADE_RECT_WIDTH = 170
+const SHADE_RECT_HEIGHT = 130
 
 const currentColor = defineModel()
 const currentHue = ref('')
@@ -146,21 +150,21 @@ const updateShade = (e) => {
 	var x = e.pageX - unref(shadeRect.left)
 	var y = e.pageY - unref(shadeRect.top)
 
-	if (x > unref(shadeRect.width)) {
-		x = unref(shadeRect.width)
+	if (x > SHADE_RECT_WIDTH) {
+		x = SHADE_RECT_WIDTH
 	}
 	if (x < 0) {
 		x = 0
 	}
-	if (y > unref(shadeRect.height)) {
-		y = unref(shadeRect.height)
+	if (y > unref(SHADE_RECT_HEIGHT)) {
+		y = unref(SHADE_RECT_HEIGHT)
 	}
 	if (y < 0) {
 		y = 0.1
 	}
 
-	var xRatio = (x / unref(shadeRect.width)) * 100
-	var yRatio = (y / unref(shadeRect.height)) * 100
+	var xRatio = (x / SHADE_RECT_WIDTH) * 100
+	var yRatio = (y / unref(SHADE_RECT_HEIGHT)) * 100
 	var hsvValue = 1 - yRatio / 100
 	var hsvSaturation = xRatio / 100
 	lightness = (hsvValue / 2) * (2 - hsvSaturation)
@@ -211,12 +215,12 @@ const handlePopoverOpen = () => {
 	lightness = initialHsl.l
 
 	currentOpacity.value = initialHsl.a
-	opacityCursorLeft.value = `${currentOpacity.value * 125 - 6}px`
+	opacityCursorLeft.value = `${currentOpacity.value * SLIDER_WIDTH - 6}px`
 
 	currentHue.value = tinycolor('hsl ' + hue + ' 1 .5').toHslString()
-	hueCursorLeft.value = `${125 - (hue / 360) * 125 - 6}px`
+	hueCursorLeft.value = `${SLIDER_WIDTH - (hue / 360) * SLIDER_WIDTH - 6}px`
 
-	shadeCursorLeft.value = `${saturation * 170 - 6}px`
-	shadeCursorTop.value = `${(100 - lightness * 100) * (130 / 100) - 6}px`
+	shadeCursorLeft.value = `${saturation * SHADE_RECT_WIDTH - 6}px`
+	shadeCursorTop.value = `${(100 - lightness * 100) * (SHADE_RECT_HEIGHT / 100) - 6}px`
 }
 </script>

--- a/frontend/src/components/controls/ColorPicker.vue
+++ b/frontend/src/components/controls/ColorPicker.vue
@@ -8,11 +8,11 @@
 			></div>
 		</template>
 		<template #body-main>
-			<div class="rounded p-3" :style="{ width: '192px', height: '200px' }">
-				<div class="flex h-full w-full flex-col gap-3">
+			<div class="rounded p-3">
+				<div class="flex flex-col gap-3">
 					<div
 						ref="shadeSlider"
-						class="h-full cursor-pointer rounded-t"
+						class="cursor-pointer rounded-t"
 						:style="shadeStyles"
 						@mousedown="handleUpdateShade"
 					>
@@ -25,7 +25,7 @@
 							}"
 						></div>
 					</div>
-					<div class="flex h-[20%] justify-between p-1">
+					<div class="flex h-8 justify-between p-1">
 						<div
 							class="h-full w-6 rounded-sm ring-[1.5px] ring-gray-200"
 							:style="{ backgroundColor: currentColor }"
@@ -72,6 +72,8 @@ import tinycolor from 'tinycolor2'
 const shadeStyles = computed(() => {
 	return {
 		background: `linear-gradient(transparent, black), linear-gradient(to right, white, ${currentHue.value})`,
+		width: '170px',
+		height: '130px',
 	}
 })
 
@@ -97,8 +99,8 @@ const hueCursorLeft = ref('')
 const currentOpacity = ref()
 const opacityCursorLeft = ref('')
 
-const shadeCursorLeft = ref('calc(0% - 6px)')
-const shadeCursorTop = ref('calc(100% - 6px)')
+const shadeCursorLeft = ref('')
+const shadeCursorTop = ref('')
 
 let hue = 0
 let saturation = 1
@@ -205,11 +207,16 @@ const handlePopoverOpen = () => {
 	const initialHsl = tinycolor(currentColor.value).toHsl()
 
 	hue = initialHsl.h
+	saturation = initialHsl.s
+	lightness = initialHsl.l
 
 	currentOpacity.value = initialHsl.a
 	opacityCursorLeft.value = `${currentOpacity.value * 125 - 6}px`
 
 	currentHue.value = tinycolor('hsl ' + hue + ' 1 .5').toHslString()
 	hueCursorLeft.value = `${125 - (hue / 360) * 125 - 6}px`
+
+	shadeCursorLeft.value = `${saturation * 170 - 6}px`
+	shadeCursorTop.value = `${(100 - lightness * 100) * (130 / 100) - 6}px`
 }
 </script>

--- a/frontend/src/components/controls/ColorPicker.vue
+++ b/frontend/src/components/controls/ColorPicker.vue
@@ -121,13 +121,13 @@ const handleUpdateHue = (e) => {
 const updateHue = (e) => {
 	e.preventDefault()
 	var x = e.pageX - unref(colorRect.left)
-	if (x > unref(colorRect.width)) {
-		x = unref(colorRect.width)
+	if (x > SLIDER_WIDTH) {
+		x = SLIDER_WIDTH
 	}
 	if (x < 0) {
 		x = 0
 	}
-	var percent = x / unref(colorRect.width)
+	var percent = x / SLIDER_WIDTH
 	hue = 360 - 360 * percent
 	hueCursorLeft.value = `${x - 6}px`
 	var color = tinycolor('hsl ' + hue + ' ' + saturation + ' ' + lightness)
@@ -193,13 +193,13 @@ const handleUpdateOpacity = (e) => {
 const updateOpacity = (e) => {
 	e.preventDefault()
 	var x = e.pageX - unref(colorRect.left)
-	if (x > unref(colorRect.width)) {
-		x = unref(colorRect.width)
+	if (x > SLIDER_WIDTH) {
+		x = SLIDER_WIDTH
 	}
 	if (x < 0) {
 		x = 0
 	}
-	var percent = x / unref(colorRect.width)
+	var percent = x / SLIDER_WIDTH
 	currentOpacity.value = percent
 	currentColor.value = tinycolor(currentColor.value).setAlpha(percent).toHslString()
 	opacityCursorLeft.value = `${x - 6}px`

--- a/frontend/src/components/controls/ColorPicker.vue
+++ b/frontend/src/components/controls/ColorPicker.vue
@@ -16,14 +16,7 @@
 						:style="shadeStyles"
 						@mousedown="handleUpdateShade"
 					>
-						<div
-							class="relative h-3 w-3 rounded border"
-							:style="{
-								backgroundColor: currentColor,
-								left: shadeCursorLeft,
-								top: shadeCursorTop,
-							}"
-						></div>
+						<div class="relative h-3 w-3 rounded border" :style="shadeRectStyles"></div>
 					</div>
 					<div class="flex h-8 justify-between p-1">
 						<div
@@ -33,23 +26,23 @@
 						<div class="flex flex-col justify-between">
 							<div
 								ref="colorSlider"
-								class="h-1/5 rounded cursor-pointer"
-								:style="colorStyles"
+								:class="sliderClasses"
+								:style="colorSliderStyles"
 								@mousedown="handleUpdateHue"
 							>
 								<div
-									class="relative h-[0.8rem] w-[0.8rem] rounded border border-gray-700 bg-white"
+									:class="sliderCursorClasses"
 									:style="{ left: hueCursorLeft, top: '-0.25rem' }"
 								></div>
 							</div>
 							<div
 								ref="opacitySlider"
-								class="h-1/5 rounded cursor-pointer"
-								:style="opacityStyles"
+								:class="sliderClasses"
+								:style="opacitySliderStyles"
 								@mousedown="handleUpdateOpacity"
 							>
 								<div
-									class="relative h-[0.8rem] w-[0.8rem] rounded border border-gray-700 bg-white"
+									:class="sliderCursorClasses"
 									:style="{ left: opacityCursorLeft, top: '-0.25rem' }"
 								></div>
 							</div>
@@ -77,14 +70,20 @@ const shadeStyles = computed(() => {
 	}
 })
 
-const colorStyles = computed(() => {
+const colorSliderStyles = computed(() => {
 	return {
 		width: `${SLIDER_WIDTH}px`,
 		background: `linear-gradient(to right, rgb(255, 0, 0), rgb(255, 0, 255), rgb(0, 0, 255), rgb(0, 255, 255), rgb(0, 255, 0), rgb(255, 255, 0), rgb(255, 0, 0))`,
 	}
 })
 
-const opacityStyles = `background: linear-gradient(to right, rgba(0, 0, 0, 0), rgba(0, 0, 0, 1))`
+const opacitySliderStyles = `background: linear-gradient(to right, rgba(0, 0, 0, 0), rgba(0, 0, 0, 1))`
+
+const shadeRectStyles = computed(() => ({
+	backgroundColor: currentColor.value,
+	left: shadeCursorLeft.value,
+	top: shadeCursorTop.value,
+}))
 
 const shadeSlider = useTemplateRef('shadeSlider')
 const colorSlider = useTemplateRef('colorSlider')
@@ -95,6 +94,9 @@ let shadeRect = useElementBounding(shadeSlider)
 const SLIDER_WIDTH = 125
 const SHADE_RECT_WIDTH = 170
 const SHADE_RECT_HEIGHT = 130
+
+const sliderClasses = 'h-1/5 rounded cursor-pointer'
+const sliderCursorClasses = 'relative h-[0.8rem] w-[0.8rem] rounded border border-gray-700 bg-white'
 
 const currentColor = defineModel()
 const currentHue = ref('')

--- a/frontend/src/components/controls/ColorPicker.vue
+++ b/frontend/src/components/controls/ColorPicker.vue
@@ -94,8 +94,8 @@ const currentColor = defineModel()
 const currentHue = ref('')
 const hueCursorLeft = ref('')
 
-const currentOpacity = ref(1)
-const opacityCursorLeft = ref('calc(100% - 6px)')
+const currentOpacity = ref()
+const opacityCursorLeft = ref('')
 
 const shadeCursorLeft = ref('calc(0% - 6px)')
 const shadeCursorTop = ref('calc(100% - 6px)')
@@ -202,8 +202,14 @@ const endUpdateOpacity = (e) => {
 }
 
 const handlePopoverOpen = () => {
-	hue = tinycolor(currentColor.value).toHsl().h
+	const initialHsl = tinycolor(currentColor.value).toHsl()
+
+	hue = initialHsl.h
+
+	currentOpacity.value = initialHsl.a
+	opacityCursorLeft.value = `${currentOpacity.value * 125 - 6}px`
+
 	currentHue.value = tinycolor('hsl ' + hue + ' 1 .5').toHslString()
-	hueCursorLeft.value = 125 - (hue / 360) * 125 - 6 + 'px'
+	hueCursorLeft.value = `${125 - (hue / 360) * 125 - 6}px`
 }
 </script>


### PR DESCRIPTION
### Changes

- Fix the initial position for the hue and opacity cursors to match that of the stored value. Before a default hue of red was set when the colorpicker opened up.
- Show cursor-pointer throughout the opacity and hue sliders.
- Cleanup HSL value calculation for the currentColor. Although the code needs more cleanup, stuck to mostly converting normal states to computed properties or reactive states for better reactivity.
- Fix alignment and padding issues.

<br>

### Before


https://github.com/user-attachments/assets/ad2f0974-e89b-46c6-b00f-61b2c87abdda

<br>

### After


https://github.com/user-attachments/assets/4f5f574c-5740-4c66-b740-5dee09bbd364




