### PR TITLE
fix: panel and slideshow sizes for larger screens

### DIFF
--- a/frontend/src/components/DropTargetOverlay.vue
+++ b/frontend/src/components/DropTargetOverlay.vue
@@ -1,6 +1,5 @@
 <template>
 	<div
-		v-show="isMediaDragOver"
 		ref="overlay"
 		class="bg-blue-400 opacity-10 z-15 w-full h-full fixed top-0 left-0"
 		@dragleave.prevent="handleDragLeave"
@@ -18,20 +17,13 @@ import { FileUploadHandler } from 'frappe-ui'
 import { presentationId } from '@/stores/presentation'
 import { addMediaElement } from '@/stores/element'
 
+const emit = defineEmits(['hideOverlay'])
+
 const overlayRef = useTemplateRef('overlay')
-
-const isMediaDragOver = ref(false)
-
-const handleDragEnter = (e) => {
-	e.preventDefault()
-	isMediaDragOver.value = true
-}
 
 const handleDragLeave = (e) => {
 	e.preventDefault()
-	if (!overlayRef.value.contains(e.relatedTarget)) {
-		isMediaDragOver.value = false
-	}
+	emit('hideOverlay', false)
 }
 
 const fileUploadHandler = new FileUploadHandler()
@@ -72,13 +64,8 @@ const uploadFiles = (files) => {
 
 const handleMediaDrop = async (e) => {
 	e.preventDefault()
-	isMediaDragOver.value = false
+	emit('hideOverlay', false)
 	const files = e.dataTransfer.files
 	uploadFiles(files)
 }
-
-defineExpose({
-	isMediaDragOver,
-	handleDragEnter,
-})
 </script>

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -1,5 +1,8 @@
 <template>
-	<div class="z-10 flex items-center justify-between bg-white p-2 border-b" @wheel.prevent>
+	<div
+		class="z-10 flex items-center justify-between bg-white p-2 border-b h-[2.5rem]"
+		@wheel.prevent
+	>
 		<router-link class="flex items-center gap-2" :to="{ name: 'Home' }">
 			<img src="../icons/slides.svg" class="h-7" />
 			<div class="text-base font-semibold">Slides</div>

--- a/frontend/src/components/NavigationPanel.vue
+++ b/frontend/src/components/NavigationPanel.vue
@@ -7,7 +7,11 @@
 		@mouseleave="showCollapseShortcut = false"
 		@wheel="handleWheelEvent"
 	>
-		<div class="flex flex-col h-full px-4 pb-12 overflow-y-auto" :style="scrollbarStyles">
+		<div
+			v-if="presentation.data"
+			class="flex flex-col h-full px-4 pb-12 overflow-y-auto"
+			:style="scrollbarStyles"
+		>
 			<Draggable v-model="presentation.data.slides" item-key="name" @end="handleSortEnd">
 				<template #item="{ element: slide }">
 					<div

--- a/frontend/src/components/NavigationPanel.vue
+++ b/frontend/src/components/NavigationPanel.vue
@@ -1,7 +1,7 @@
 <template>
 	<!-- Slide Navigation Panel -->
 	<div
-		class="fixed z-20 h-[94.27%] w-48 border-r bg-white transition-all duration-300 ease-in-out"
+		class="fixed z-20 h-full top-[2.5rem] w-48 border-r bg-white transition-all duration-300 ease-in-out"
 		:class="showNavigator ? 'left-0' : '-left-48'"
 		@mouseenter="showCollapseShortcut = true"
 		@mouseleave="showCollapseShortcut = false"

--- a/frontend/src/components/PropertiesPanel.vue
+++ b/frontend/src/components/PropertiesPanel.vue
@@ -1,5 +1,6 @@
 <template>
 	<div
+		v-if="presentation.data"
 		class="fixed right-0 z-20 flex flex-col h-full top-[2.5rem] w-64 bg-white border-l"
 		@wheel.prevent
 	>

--- a/frontend/src/components/PropertiesPanel.vue
+++ b/frontend/src/components/PropertiesPanel.vue
@@ -1,5 +1,8 @@
 <template>
-	<div class="fixed right-0 z-20 flex flex-col h-[94.35%] w-64 bg-white border-l" @wheel.prevent>
+	<div
+		class="fixed right-0 z-20 flex flex-col h-full top-[2.5rem] w-64 bg-white border-l"
+		@wheel.prevent
+	>
 		<component :is="activeProperties" />
 
 		<div v-if="activeElement" :class="sectionClasses">

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -1,5 +1,5 @@
 <template>
-	<div ref="slideContainer" class="flex w-full h-full">
+	<div ref="slideContainer" class="flex w-full h-full" @dragenter="showOverlay">
 		<!-- when mounting place slide directly in the center of the visible container -->
 		<!-- 1/2 width of viewport + 1/2 width of offset caused due to thinner navigation panel -->
 		<div
@@ -25,6 +25,8 @@
 			</div>
 		</div>
 	</div>
+
+	<DropTargetOverlay v-show="mediaDragOver" @hideOverlay="hideOverlay" />
 </template>
 
 <script setup>
@@ -77,7 +79,8 @@ const { allowPanAndZoom, transform, transformOrigin } = usePanAndZoom(
 const slideClasses = computed(() => {
 	const classes = ['slide', 'h-[540px]', 'w-[960px]', 'shadow-2xl']
 
-	const outlineClasses = props.highlight ? ['outline', 'outline-2', 'outline-blue-400'] : []
+	const outlineClasses =
+		props.highlight || mediaDragOver.value ? ['outline', 'outline-2', 'outline-blue-400'] : []
 	const shadowClasses = activeElementIds.value.length ? ['shadow-gray-200'] : ['shadow-gray-400']
 
 	return [...classes, outlineClasses, shadowClasses]
@@ -102,6 +105,17 @@ const getElementOutline = (element) => {
 	} else {
 		return 'none'
 	}
+}
+
+const mediaDragOver = ref(false)
+
+const showOverlay = (e) => {
+	e.preventDefault()
+	mediaDragOver.value = true
+}
+
+const hideOverlay = () => {
+	mediaDragOver.value = false
 }
 
 let dragTimeout, clickTimeout

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -25,8 +25,6 @@
 
 			<DropTargetOverlay ref="dropTarget" />
 
-			<PropertiesPanel />
-
 			<Toolbar
 				@setHighlight="setHighlight"
 				@insert="insertSlide"
@@ -34,6 +32,8 @@
 				@delete="deleteSlide"
 			/>
 		</div>
+
+		<PropertiesPanel />
 	</div>
 </template>
 

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		ref="mediaDropContainer"
-		class="fixed flex h-screen w-screen flex-col select-none"
+		class="fixed h-screen w-screen flex flex-col select-none"
 		:class="!activeElementIds.length ? 'bg-gray-300' : 'bg-gray-100'"
 	>
 		<Navbar :primaryButton="primaryButtonProps">
@@ -10,13 +10,13 @@
 			</template>
 		</Navbar>
 
-		<div v-if="presentation.data?.slides" class="flex h-full items-center justify-center">
-			<NavigationPanel
-				:showNavigator="showNavigator"
-				@changeSlide="changeSlide"
-				@insertSlide="insertSlide"
-			/>
+		<NavigationPanel
+			:showNavigator="showNavigator"
+			@changeSlide="changeSlide"
+			@insertSlide="insertSlide"
+		/>
 
+		<div v-if="presentation.data?.slides" class="flex h-full items-center justify-center">
 			<SlideContainer
 				ref="slideContainer"
 				:highlight="highlightSlide"

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -1,6 +1,5 @@
 <template>
 	<div
-		ref="mediaDropContainer"
 		class="fixed h-screen w-screen flex flex-col select-none"
 		:class="!activeElementIds.length ? 'bg-gray-300' : 'bg-gray-100'"
 	>
@@ -16,22 +15,14 @@
 			@insertSlide="insertSlide"
 		/>
 
-		<div v-if="presentation.data?.slides" class="flex h-full items-center justify-center">
-			<SlideContainer
-				ref="slideContainer"
-				:highlight="highlightSlide"
-				@dragenter="handleMediaDragEnter"
-			/>
+		<SlideContainer ref="slideContainer" :highlight="slideHighlight" />
 
-			<DropTargetOverlay ref="dropTarget" />
-
-			<Toolbar
-				@setHighlight="setHighlight"
-				@insert="insertSlide"
-				@duplicate="duplicateSlide"
-				@delete="deleteSlide"
-			/>
-		</div>
+		<Toolbar
+			@setHighlight="setHighlight"
+			@insert="insertSlide"
+			@duplicate="duplicateSlide"
+			@delete="deleteSlide"
+		/>
 
 		<PropertiesPanel />
 	</div>
@@ -93,14 +84,10 @@ const slideContainerRef = useTemplateRef('slideContainer')
 const dropTargetRef = useTemplateRef('dropTarget')
 
 const showNavigator = ref(true)
-const showHighlight = ref(false)
-
-const highlightSlide = computed(() => {
-	return dropTargetRef.value?.isMediaDragOver || showHighlight.value
-})
+const slideHighlight = ref(false)
 
 const setHighlight = (value) => {
-	showHighlight.value = value
+	slideHighlight.value = value
 }
 
 const handleArrowKeys = (key) => {
@@ -306,11 +293,6 @@ const resetAndSave = () => {
 	nextTick(() => {
 		saveChanges()
 	})
-}
-
-const handleMediaDragEnter = (e) => {
-	e.preventDefault()
-	dropTargetRef.value.handleDragEnter(e)
 }
 
 const resetSlideState = () => {

--- a/frontend/src/pages/Slideshow.vue
+++ b/frontend/src/pages/Slideshow.vue
@@ -4,7 +4,7 @@
 			ref="slideContainer"
 			class="flex items-center justify-center w-full h-screen"
 			:style="{
-				clipPath: 'inset(45px 0 45px 0)',
+				clipPath: clipPath,
 			}"
 		>
 			<Transition
@@ -53,6 +53,7 @@ const router = useRouter()
 const transition = ref('none')
 const transform = ref('')
 const opacity = ref(1)
+const clipPath = ref('')
 
 const slideCursor = ref('none')
 
@@ -170,6 +171,17 @@ const handleKeyDown = (e) => {
 	}
 }
 
+const setClipPath = () => {
+	const screenHeight = window.screen.height
+	const scale = window.screen.width / 960
+	const containerHeight = 540 * scale
+
+	// divide remaining height by 2 to set inset on top and bottom
+	const inset = (screenHeight - containerHeight) / 2
+
+	clipPath.value = `inset(${inset}px 0px ${inset}px 0px)`
+}
+
 const initFullscreenMode = async () => {
 	const container = slideContainerRef.value
 	if (!container) return
@@ -188,6 +200,8 @@ const initFullscreenMode = async () => {
 			router.replace({ name: 'PresentationEditor' })
 		})
 		inSlideShow.value = true
+
+		setClipPath()
 	}
 }
 

--- a/frontend/src/pages/Slideshow.vue
+++ b/frontend/src/pages/Slideshow.vue
@@ -57,12 +57,16 @@ const opacity = ref(1)
 const slideCursor = ref('none')
 
 const slideStyles = computed(() => {
+	// scale slide to fit current screen size while maintaining 16:9 aspect ratio
+	const screenWidth = window.screen.width
+	const widthScale = screenWidth / 960
+
 	return {
 		width: '960px',
 		height: '540px',
 		backgroundColor: slide.value.background || 'white',
 		cursor: slideCursor.value,
-		transform: `${transform.value} scale(1.5)`,
+		transform: `${transform.value} scale(${widthScale})`,
 		transition: transition.value,
 		opacity: opacity.value,
 	}


### PR DESCRIPTION
### Changes

- Fixed the issue where some components did not span full screen height for larger screens.
- For the Slideshow, how much the slide scaled depended on an arbitrary factor and the aspect ratio of **16:9**. Although the ratio was correct, the arbitrary factor was set considering the effective screen size of **1440 x 900** as the default. Changed to be dynamic depending on the current screen size.
- The `clipPath` value that hides any overflowing elements also used a fixed inset value leading to inconsistencies when the scaled size of the slide increased because of the second change, so fixed that.
- Simplified the logic and events emitted for the functionality of the overlay shown while dropping media.

