### PR TITLE
fix: media attachment issue for copied elements

### DIFF
--- a/frontend/src/components/ImageProperties.vue
+++ b/frontend/src/components/ImageProperties.vue
@@ -18,7 +18,7 @@
 <script setup>
 import { FlipHorizontal, FlipVertical } from 'lucide-vue-next'
 
-import MediaProperties from './MediaProperties.vue'
+import MediaProperties from '@/components/MediaProperties.vue'
 
 import { activeElement } from '@/stores/element'
 import { sectionClasses, sectionTitleClasses } from '@/utils/constants'

--- a/frontend/src/components/MediaProperties.vue
+++ b/frontend/src/components/MediaProperties.vue
@@ -30,6 +30,7 @@
 						suffix="px"
 						:rangeStart="0"
 						:rangeEnd="50"
+						:rangeStep="0.5"
 					/>
 				</div>
 			</div>
@@ -56,11 +57,16 @@
 	<div :class="sectionClasses">
 		<div :class="sectionTitleClasses">Shadow</div>
 
+		<div class="flex items-center justify-between">
+			<div class="text-sm text-gray-600">Color</div>
+			<ColorPicker class="pe-[0.2px]" v-model="activeElement.shadowColor" />
+		</div>
+
 		<SliderInput
 			label="Offset X"
 			:rangeStart="-50"
 			:rangeEnd="50"
-			:modelValue="parseFloat(activeElement.shadowOffsetX) || 0"
+			:modelValue="parseFloat(activeElement.shadowOffsetX) || 5"
 			@update:modelValue="(value) => (activeElement.shadowOffsetX = value)"
 		/>
 
@@ -68,24 +74,17 @@
 			label="Offset Y"
 			:rangeStart="-50"
 			:rangeEnd="50"
-			:modelValue="parseFloat(activeElement.shadowOffsetY) || 0"
+			:modelValue="parseFloat(activeElement.shadowOffsetY) || 5"
 			@update:modelValue="(value) => (activeElement.shadowOffsetY = value)"
 		/>
 
-		<div class="flex flex-col gap-1">
-			<div class="text-sm text-gray-600">Spread</div>
-			<div class="flex items-center justify-between">
-				<SliderInput
-					class="w-4/5"
-					:rangeStart="1"
-					:rangeEnd="500"
-					:modelValue="parseFloat(activeElement.shadowSpread) || 50"
-					@update:modelValue="(value) => (activeElement.shadowSpread = value)"
-					:showInput="false"
-				/>
-				<ColorPicker class="w-10 justify-end" v-model="activeElement.shadowColor" />
-			</div>
-		</div>
+		<SliderInput
+			label="Spread"
+			:rangeStart="1"
+			:rangeEnd="500"
+			:modelValue="parseFloat(activeElement.shadowSpread) || 50"
+			@update:modelValue="(value) => (activeElement.shadowSpread = value)"
+		/>
 	</div>
 </template>
 
@@ -101,6 +100,14 @@ const borderStyles = ['none', 'solid', 'dashed', 'dotted']
 
 const addBorder = (style) => {
 	activeElement.value.borderStyle = style
-	if (style != 'none') activeElement.value.borderWidth = 1
+	if (style != 'none') {
+		activeElement.value.borderWidth = 0.5
+		activeElement.value.borderColor = 'hsla(0, 0%, 0%, 0.2)'
+		activeElement.value.borderRadius = 20
+	} else {
+		activeElement.value.borderWidth = 0
+		activeElement.value.borderColor = ''
+		activeElement.value.borderRadius = 0
+	}
 }
 </script>

--- a/frontend/src/components/MediaProperties.vue
+++ b/frontend/src/components/MediaProperties.vue
@@ -47,7 +47,7 @@
 			</div>
 
 			<div class="flex items-center justify-between">
-				<div class="text-sm text-gray-600">Colour</div>
+				<div class="text-sm text-gray-600">Color</div>
 				<ColorPicker v-model="activeElement.borderColor" />
 			</div>
 		</div>

--- a/frontend/src/components/NavigationPanel.vue
+++ b/frontend/src/components/NavigationPanel.vue
@@ -46,7 +46,7 @@
 	<!-- Slide Navigator Toggle -->
 	<div
 		v-if="!showNavigator"
-		class="top-[calc(50% - 24)px] fixed left-0 z-20 flex h-12 w-4 cursor-pointer items-center justify-center rounded-r-lg border bg-white shadow-xl"
+		class="absolute top-1/2 transform -transform-y-1/2 z-20 flex h-12 w-4 cursor-pointer items-center justify-center rounded-r-lg border bg-white shadow-xl"
 		@click="toggleNavigator"
 	>
 		<LucideChevronRight class="h-3.5 w-3.5" />

--- a/frontend/src/components/SlideProperties.vue
+++ b/frontend/src/components/SlideProperties.vue
@@ -8,7 +8,7 @@
 		</div>
 
 		<div class="flex items-center justify-between">
-			<div class="text-sm text-gray-600">Background</div>
+			<div class="text-sm text-gray-600">Background Color</div>
 			<ColorPicker v-model="slide.background" />
 		</div>
 	</div>
@@ -50,7 +50,7 @@ import { sectionClasses, sectionTitleClasses } from '@/utils/constants'
 
 import SliderInput from '@/components/controls/SliderInput.vue'
 import ColorPicker from '@/components/controls/ColorPicker.vue'
-import CollapsibleSection from './controls/CollapsibleSection.vue'
+import CollapsibleSection from '@/components/controls/CollapsibleSection.vue'
 
 const setSlideTransition = (option) => {
 	slide.value.transition = option.value

--- a/frontend/src/components/TextProperties.vue
+++ b/frontend/src/components/TextProperties.vue
@@ -63,7 +63,7 @@
 		</div>
 
 		<div class="flex items-center justify-between">
-			<div class="text-sm text-gray-600">Colour</div>
+			<div class="text-sm text-gray-600">Color</div>
 			<ColorPicker v-model="activeElement.color" />
 		</div>
 	</div>

--- a/frontend/src/components/TextProperties.vue
+++ b/frontend/src/components/TextProperties.vue
@@ -107,9 +107,9 @@ import {
 	AlignJustify,
 } from 'lucide-vue-next'
 
-import SliderInput from './controls/SliderInput.vue'
-import NumberInput from './controls/NumberInput.vue'
-import ColorPicker from './controls/ColorPicker.vue'
+import SliderInput from '@/components/controls/SliderInput.vue'
+import NumberInput from '@/components/controls/NumberInput.vue'
+import ColorPicker from '@/components/controls/ColorPicker.vue'
 
 import { slide } from '@/stores/slide'
 import {

--- a/frontend/src/components/VideoProperties.vue
+++ b/frontend/src/components/VideoProperties.vue
@@ -41,8 +41,8 @@ import { ref } from 'vue'
 
 import { Repeat2, TvMinimalPlay } from 'lucide-vue-next'
 
-import MediaProperties from './MediaProperties.vue'
-import SliderInput from './controls/SliderInput.vue'
+import MediaProperties from '@/components/MediaProperties.vue'
+import SliderInput from '@/components/controls/SliderInput.vue'
 
 import { activeElement } from '@/stores/element'
 import { sectionClasses, sectionTitleClasses } from '@/utils/constants'

--- a/frontend/src/components/controls/ColorPicker.vue
+++ b/frontend/src/components/controls/ColorPicker.vue
@@ -17,7 +17,7 @@
 						@mousedown="handleUpdateShade"
 					>
 						<div
-							class="relative h-3 w-3 rounded border shadow-md"
+							class="relative h-3 w-3 rounded border shadow-md hover:scale-[1.2] transition-transform duration-200 ease-in-out"
 							:style="shadeRectStyles"
 						></div>
 					</div>
@@ -77,7 +77,7 @@ const SHADE_RECT_HEIGHT = 130
 
 const sliderClasses = 'h-1/5 rounded cursor-pointer'
 const sliderCursorClasses =
-	'relative h-[0.8rem] w-[0.8rem] rounded shadow border border-gray-200 bg-white'
+	'relative h-[0.8rem] w-[0.8rem] rounded shadow border border-gray-200 bg-white hover:scale-[1.1] transition-transform duration-200 ease-in-out'
 
 const currentColor = defineModel()
 

--- a/frontend/src/components/controls/ColorPicker.vue
+++ b/frontend/src/components/controls/ColorPicker.vue
@@ -2,7 +2,7 @@
 	<Popover @open="handlePopoverOpen">
 		<template #target="{ togglePopover }">
 			<div
-				class="my-2 h-4 w-4 cursor-pointer rounded-sm ring-1 ring-offset-1 ring-gray-200"
+				class="my-2 h-4 w-4 cursor-pointer rounded-sm ring-[1.5px] ring-offset-1 ring-gray-300"
 				:style="{ backgroundColor: currentColor }"
 				@click="togglePopover"
 			></div>

--- a/frontend/src/components/controls/SliderInput.vue
+++ b/frontend/src/components/controls/SliderInput.vue
@@ -110,4 +110,9 @@ input::-webkit-inner-spin-button {
 	cursor: pointer;
 	border-radius: 50%;
 }
+
+.slider:hover::-webkit-slider-thumb {
+	transform: scale(1.1);
+	transition: transform 0.2s;
+}
 </style>

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -5,6 +5,7 @@ import { slide, slideBounds } from './slide'
 
 import { generateUniqueId } from '../utils/helpers'
 import { guessTextColorFromBackground } from '../utils/color'
+import { presentation } from './presentation'
 
 const activeElementIds = ref([])
 const focusElementId = ref(null)
@@ -125,6 +126,17 @@ const duplicateElements = async (e, elements, displaceByPx = 0) => {
 const deleteElements = async (e) => {
 	activeElements.value.forEach((element) => {
 		if (['image', 'video'].includes(element.type)) {
+			// TODO: Handle this in a cleaner way
+			// Delete the file doc only if it's not used in other slides
+			const isFileDocUsed = presentation.data.slides.some((slide) => {
+				if (!slide.elements) return false
+				return JSON.parse(slide.elements).some((el) => {
+					return el.src === element.src
+				})
+			})
+
+			if (isFileDocUsed) return
+
 			call('frappe.client.delete', {
 				doctype: 'File',
 				name: element.file_name,


### PR DESCRIPTION
### Fix

When media elements are copied or duplicated, the url from the File document is added to the newly added element JSON. The file document is not duplicated, and deleting either the original element or the copy led to deletion of the file document since the deletion logic didn't account for multiple elements referring to same file before that feature was added.

Fixed this so now the file document only gets deleted if the same media attachment is not used elsewhere. Will maybe add a system to store references for a particular attachment instead of rechecking everytime but for now no useful attachment should be deleted otherwise the slide elements would break.

<br>

#### Before

https://github.com/user-attachments/assets/08589432-ffb6-4585-8a6e-cb55c40be58c

<br>

#### After

https://github.com/user-attachments/assets/a58ff3a8-8058-4a10-9f73-900480c16761

<br>

### Tiny

- Fix the position for navigation panel toggle button broken in https://github.com/frappe/slides/pull/45
- Add a basic border to image and video elements when border style is changed - 1px light gray border with a small border radius so the border shows up when a new border is added.