### PR TITLE
feat: collapse sections for shadow and misc properties by default

### DIFF
--- a/frontend/src/components/ImageProperties.vue
+++ b/frontend/src/components/ImageProperties.vue
@@ -1,16 +1,17 @@
 <template>
-	<div :class="sectionClasses">
-		<div :class="sectionTitleClasses">Orientation</div>
-		<div
-			v-for="(direction, index) in imageOrientationProperties"
-			:key="index"
-			class="flex cursor-pointer items-center justify-between"
-			@click="toggleImageOrientation(direction)"
-		>
-			<div class="text-sm text-gray-600">{{ direction.label }}</div>
-			<component :is="direction.icon" size="20" :strokeWidth="1.2" />
-		</div>
-	</div>
+	<CollapsibleSection title="Orientation" :initialState="true">
+		<template #default>
+			<div
+				v-for="(direction, index) in imageOrientationProperties"
+				:key="index"
+				class="flex cursor-pointer items-center justify-between"
+				@click="toggleImageOrientation(direction)"
+			>
+				<div class="text-sm text-gray-600">{{ direction.label }}</div>
+				<component :is="direction.icon" size="20" :strokeWidth="1.2" />
+			</div>
+		</template>
+	</CollapsibleSection>
 
 	<MediaProperties />
 </template>
@@ -21,7 +22,6 @@ import { FlipHorizontal, FlipVertical } from 'lucide-vue-next'
 import MediaProperties from '@/components/MediaProperties.vue'
 
 import { activeElement } from '@/stores/element'
-import { sectionClasses, sectionTitleClasses } from '@/utils/constants'
 
 const imageOrientationProperties = [
 	{

--- a/frontend/src/components/MediaProperties.vue
+++ b/frontend/src/components/MediaProperties.vue
@@ -3,19 +3,26 @@
 		<div :class="sectionTitleClasses">Border</div>
 
 		<div
-			class="flex h-8 w-full items-center gap-3 justify-between rounded border bg-gray-50 p-[2px] px-2"
+			class="flex h-8 w-full items-center gap-3 justify-between rounded-[10px] border bg-gray-50 p-0.5"
 		>
 			<div
 				v-for="(style, index) in borderStyles"
 				:key="index"
-				class="flex h-4/5 w-1/4 cursor-pointer items-center justify-center rounded-sm"
+				class="flex h-full w-1/4 cursor-pointer items-center justify-center rounded"
 				:class="activeElement.borderStyle == style ? 'bg-white shadow' : ''"
 				@click="addBorder(style)"
 			>
-				<LucideBan v-if="style == 'none'" class="h-4 w-4" />
+				<LucideBan
+					v-if="style == 'none'"
+					class="h-4 w-4"
+					:class="activeElement.borderStyle == style ? 'text-gray-800' : 'text-gray-500'"
+				/>
 				<div
 					v-else
-					class="h-4 w-5 rounded-sm border border-black"
+					class="h-4 w-5 rounded-sm border"
+					:class="
+						activeElement.borderStyle == style ? 'border-gray-800' : 'border-gray-500'
+					"
 					:style="{ borderStyle: style }"
 				></div>
 			</div>

--- a/frontend/src/components/MediaProperties.vue
+++ b/frontend/src/components/MediaProperties.vue
@@ -1,107 +1,111 @@
 <template>
-	<div :class="sectionClasses">
-		<div :class="sectionTitleClasses">Border</div>
-
-		<div
-			class="flex h-8 w-full items-center gap-3 justify-between rounded-[10px] border bg-gray-50 p-0.5"
-		>
+	<CollapsibleSection title="Border" :initialState="true">
+		<template #default>
 			<div
-				v-for="(style, index) in borderStyles"
-				:key="index"
-				class="flex h-full w-1/4 cursor-pointer items-center justify-center rounded"
-				:class="activeElement.borderStyle == style ? 'bg-white shadow' : ''"
-				@click="addBorder(style)"
+				class="flex h-8 w-full items-center gap-3 justify-between rounded-[10px] border bg-gray-50 p-0.5"
 			>
-				<LucideBan
-					v-if="style == 'none'"
-					class="h-4 w-4"
-					:class="activeElement.borderStyle == style ? 'text-gray-800' : 'text-gray-500'"
-				/>
 				<div
-					v-else
-					class="h-4 w-5 rounded-sm border"
-					:class="
-						activeElement.borderStyle == style ? 'border-gray-800' : 'border-gray-500'
-					"
-					:style="{ borderStyle: style }"
-				></div>
-			</div>
-		</div>
-
-		<div v-if="activeElement.borderStyle != 'none'" class="flex flex-col gap-4">
-			<div class="flex items-center justify-between">
-				<div class="text-sm text-gray-600">Width</div>
-				<div class="h-[30px] w-28">
-					<NumberInput
-						v-model="activeElement.borderWidth"
-						suffix="px"
-						:rangeStart="0"
-						:rangeEnd="50"
-						:rangeStep="0.5"
+					v-for="(style, index) in borderStyles"
+					:key="index"
+					class="flex h-full w-1/4 cursor-pointer items-center justify-center rounded"
+					:class="activeElement.borderStyle == style ? 'bg-white shadow' : ''"
+					@click="addBorder(style)"
+				>
+					<LucideBan
+						v-if="style == 'none'"
+						class="h-4 w-4"
+						:class="
+							activeElement.borderStyle == style ? 'text-gray-800' : 'text-gray-500'
+						"
 					/>
+					<div
+						v-else
+						class="h-4 w-5 rounded-sm border"
+						:class="
+							activeElement.borderStyle == style
+								? 'border-gray-800'
+								: 'border-gray-500'
+						"
+						:style="{ borderStyle: style }"
+					></div>
 				</div>
 			</div>
 
-			<div class="flex items-center justify-between">
-				<div class="text-sm text-gray-600">Radius</div>
-				<div class="h-[30px] w-28">
-					<NumberInput
-						v-model="activeElement.borderRadius"
-						suffix="px"
-						:rangeStart="1"
-						:rangeEnd="50"
-					/>
+			<div v-if="activeElement.borderStyle != 'none'" class="flex flex-col gap-4">
+				<div class="flex items-center justify-between">
+					<div class="text-sm text-gray-600">Width</div>
+					<div class="h-[30px] w-28">
+						<NumberInput
+							v-model="activeElement.borderWidth"
+							suffix="px"
+							:rangeStart="0"
+							:rangeEnd="50"
+							:rangeStep="0.5"
+						/>
+					</div>
+				</div>
+
+				<div class="flex items-center justify-between">
+					<div class="text-sm text-gray-600">Radius</div>
+					<div class="h-[30px] w-28">
+						<NumberInput
+							v-model="activeElement.borderRadius"
+							suffix="px"
+							:rangeStart="1"
+							:rangeEnd="50"
+						/>
+					</div>
+				</div>
+
+				<div class="flex items-center justify-between">
+					<div class="text-sm text-gray-600">Color</div>
+					<ColorPicker v-model="activeElement.borderColor" />
 				</div>
 			</div>
+		</template>
+	</CollapsibleSection>
 
+	<CollapsibleSection title="Shadow">
+		<template #default>
 			<div class="flex items-center justify-between">
 				<div class="text-sm text-gray-600">Color</div>
-				<ColorPicker v-model="activeElement.borderColor" />
+				<ColorPicker class="pe-[0.2px]" v-model="activeElement.shadowColor" />
 			</div>
-		</div>
-	</div>
 
-	<div :class="sectionClasses">
-		<div :class="sectionTitleClasses">Shadow</div>
+			<SliderInput
+				label="Offset X"
+				:rangeStart="-50"
+				:rangeEnd="50"
+				:modelValue="parseFloat(activeElement.shadowOffsetX) || 5"
+				@update:modelValue="(value) => (activeElement.shadowOffsetX = value)"
+			/>
 
-		<div class="flex items-center justify-between">
-			<div class="text-sm text-gray-600">Color</div>
-			<ColorPicker class="pe-[0.2px]" v-model="activeElement.shadowColor" />
-		</div>
+			<SliderInput
+				label="Offset Y"
+				:rangeStart="-50"
+				:rangeEnd="50"
+				:modelValue="parseFloat(activeElement.shadowOffsetY) || 5"
+				@update:modelValue="(value) => (activeElement.shadowOffsetY = value)"
+			/>
 
-		<SliderInput
-			label="Offset X"
-			:rangeStart="-50"
-			:rangeEnd="50"
-			:modelValue="parseFloat(activeElement.shadowOffsetX) || 5"
-			@update:modelValue="(value) => (activeElement.shadowOffsetX = value)"
-		/>
-
-		<SliderInput
-			label="Offset Y"
-			:rangeStart="-50"
-			:rangeEnd="50"
-			:modelValue="parseFloat(activeElement.shadowOffsetY) || 5"
-			@update:modelValue="(value) => (activeElement.shadowOffsetY = value)"
-		/>
-
-		<SliderInput
-			label="Spread"
-			:rangeStart="1"
-			:rangeEnd="500"
-			:modelValue="parseFloat(activeElement.shadowSpread) || 50"
-			@update:modelValue="(value) => (activeElement.shadowSpread = value)"
-		/>
-	</div>
+			<SliderInput
+				label="Spread"
+				:rangeStart="1"
+				:rangeEnd="500"
+				:modelValue="parseFloat(activeElement.shadowSpread) || 50"
+				@update:modelValue="(value) => (activeElement.shadowSpread = value)"
+			/>
+		</template>
+	</CollapsibleSection>
 </template>
 
 <script setup>
 import SliderInput from '@/components/controls/SliderInput.vue'
 import NumberInput from '@/components/controls/NumberInput.vue'
 import ColorPicker from '@/components/controls/ColorPicker.vue'
+import CollapsibleSection from '@/components/controls/CollapsibleSection.vue'
 
 import { activeElement } from '@/stores/element'
-import { sectionClasses, sectionTitleClasses } from '@/utils/constants'
 
 const borderStyles = ['none', 'solid', 'dashed', 'dotted']
 

--- a/frontend/src/components/PresentationHeader.vue
+++ b/frontend/src/components/PresentationHeader.vue
@@ -10,7 +10,7 @@
 		/>
 		<div
 			v-else
-			class="select-none font-semibold text-gray-700 flex items-center"
+			class="select-none font-semibold text-gray-700 flex items-center cursor-text"
 			@click="makeTitleEditable"
 		>
 			<div>{{ presentation.data?.title }}</div>

--- a/frontend/src/components/PropertiesPanel.vue
+++ b/frontend/src/components/PropertiesPanel.vue
@@ -6,15 +6,18 @@
 	>
 		<component :is="activeProperties" />
 
-		<div v-if="activeElement" :class="sectionClasses">
-			<div :class="sectionTitleClasses">Other</div>
-			<SliderInput
-				label="Opacity"
-				:rangeStart="0"
-				:rangeEnd="100"
-				:modelValue="parseFloat(activeElement.opacity) || 100"
-				@update:modelValue="(value) => (activeElement.opacity = value)"
-			/>
+		<div v-if="activeElement">
+			<CollapsibleSection title="Other">
+				<template #default>
+					<SliderInput
+						label="Opacity"
+						:rangeStart="0"
+						:rangeEnd="100"
+						:modelValue="parseFloat(activeElement.opacity) || 100"
+						@update:modelValue="(value) => (activeElement.opacity = value)"
+					/>
+				</template>
+			</CollapsibleSection>
 		</div>
 	</div>
 </template>
@@ -30,11 +33,11 @@ import ImageProperties from '@/components/ImageProperties.vue'
 import VideoProperties from '@/components/VideoProperties.vue'
 
 import SliderInput from '@/components/controls/SliderInput.vue'
+import CollapsibleSection from './controls/CollapsibleSection.vue'
 
 import { presentation } from '@/stores/presentation'
 import { slide } from '@/stores/slide'
 import { activeElement } from '@/stores/element'
-import { sectionClasses, sectionTitleClasses } from '@/utils/constants'
 
 const activeProperties = computed(() => {
 	const elementType = activeElement.value?.type

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -140,10 +140,17 @@ const handleMouseUp = (e, id) => {
 }
 
 const triggerDrag = (e, id) => {
-	if ((id && focusElementId.value !== id) || activeElementIds.value.length > 1) {
+	const notEditable = id && focusElementId.value !== id
+	const isMultiSelect = activeElementIds.value.length > 1
+	const isNotInSelection = id && !activeElementIds.value.includes(id)
+
+	// prevent drag if multiple are selected and id isn't in the selection
+	if (isMultiSelect && isNotInSelection) return
+
+	if (notEditable || isMultiSelect) {
 		startDragging(e)
 
-		if (id && activeElementIds.value.length < 2 && activeElementIds.value[0] !== id) {
+		if (id && !isMultiSelect && activeElementIds.value[0] !== id) {
 			activeElementIds.value = [id]
 			focusElementId.value = null
 		}

--- a/frontend/src/components/SlideProperties.vue
+++ b/frontend/src/components/SlideProperties.vue
@@ -13,32 +13,28 @@
 		</div>
 	</div>
 
-	<div :class="sectionClasses">
-		<CollapsibleSection :title="'Transition'" :titleClasses="sectionTitleClasses">
-			<template #default>
-				<div class="flex flex-col gap-4">
-					<FormControl
-						type="autocomplete"
-						:options="['Slide In', 'Fade', 'None']"
-						size="sm"
-						variant="subtle"
-						:modelValue="slide.transition || 'None'"
-						@update:modelValue="(option) => setSlideTransition(option)"
-					/>
+	<CollapsibleSection title="Transition" :initialState="true">
+		<template #default>
+			<FormControl
+				type="autocomplete"
+				:options="['Slide In', 'Fade', 'None']"
+				size="sm"
+				variant="subtle"
+				:modelValue="slide.transition || 'None'"
+				@update:modelValue="(option) => setSlideTransition(option)"
+			/>
 
-					<SliderInput
-						v-show="slide.transition && slide.transition != 'None'"
-						label="Duration"
-						:rangeStart="0"
-						:rangeEnd="4"
-						:rangeStep="0.1"
-						:modelValue="parseFloat(slide.transitionDuration) || 0"
-						@update:modelValue="(value) => setTransitionDuration(value)"
-					/>
-				</div>
-			</template>
-		</CollapsibleSection>
-	</div>
+			<SliderInput
+				v-show="slide.transition && slide.transition != 'None'"
+				label="Duration"
+				:rangeStart="0"
+				:rangeEnd="4"
+				:rangeStep="0.1"
+				:modelValue="parseFloat(slide.transitionDuration) || 0"
+				@update:modelValue="(value) => setTransitionDuration(value)"
+			/>
+		</template>
+	</CollapsibleSection>
 </template>
 
 <script setup>

--- a/frontend/src/components/TextProperties.vue
+++ b/frontend/src/components/TextProperties.vue
@@ -1,94 +1,97 @@
 <template>
-	<div :class="sectionClasses">
-		<div :class="sectionTitleClasses">Style</div>
+	<CollapsibleSection title="Style" :initialState="true">
+		<template #default>
+			<Select
+				:options="presetTextStyles"
+				:modelValue="activeElement.defaultStyle || 'body'"
+				@update:modelValue="applyPresetTextStyles"
+			/>
 
-		<Select
-			:options="presetTextStyles"
-			:modelValue="activeElement.defaultStyle || 'body'"
-			@update:modelValue="applyPresetTextStyles"
-		/>
-
-		<div class="flex items-center justify-between px-1">
-			<button
-				v-for="style in styleProperties"
-				:key="style.property"
-				class="cursor-pointer rounded-sm p-1"
-				:class="activeElement[style.property]?.includes(style.value) ? 'bg-gray-200' : ''"
-				@click="toggleTextProperty(style.property, style.value)"
-			>
-				<component :is="style.icon" size="16" :strokeWidth="1.5" />
-			</button>
-		</div>
-
-		<div class="flex items-center justify-between px-1">
-			<button
-				v-for="textAlign in ['left', 'center', 'right', 'justify']"
-				class="cursor-pointer rounded-sm p-1"
-				:class="activeElement.textAlign == textAlign ? 'bg-gray-200' : ''"
-				@click="activeElement.textAlign = textAlign"
-			>
-				<AlignLeft v-if="textAlign == 'left'" size="16" class="stroke-[1.5]" />
-				<AlignCenter v-if="textAlign == 'center'" size="16" class="stroke-[1.5]" />
-				<AlignRight v-if="textAlign == 'right'" size="16" class="stroke-[1.5]" />
-				<AlignJustify v-if="textAlign == 'justify'" size="16" class="stroke-[1.5]" />
-			</button>
-			<button class="cursor-pointer rounded-sm p-1">
-				<List size="16" class="stroke-[1.5]" />
-			</button>
-		</div>
-	</div>
-
-	<div :class="sectionClasses">
-		<div :class="sectionTitleClasses">Font</div>
-		<FormControl
-			type="autocomplete"
-			:options="textFonts"
-			size="sm"
-			variant="subtle"
-			:modelValue="activeElement.fontFamily"
-			@update:modelValue="(font) => (activeElement.fontFamily = font.value)"
-		/>
-
-		<div class="flex items-center justify-between">
-			<div class="text-sm text-gray-600">Size</div>
-			<div class="h-[30px] w-28">
-				<NumberInput
-					v-model="activeElement.fontSize"
-					suffix="px"
-					:rangeStart="5"
-					:rangeEnd="100"
-					:rangeStep="1"
-				/>
+			<div class="flex items-center justify-between">
+				<button
+					v-for="style in styleProperties"
+					:key="style.property"
+					class="cursor-pointer rounded-sm p-1.5"
+					:class="
+						activeElement[style.property]?.includes(style.value) ? 'bg-gray-200' : ''
+					"
+					@click="toggleTextProperty(style.property, style.value)"
+				>
+					<component :is="style.icon" size="18" :strokeWidth="1.5" />
+				</button>
 			</div>
-		</div>
 
-		<div class="flex items-center justify-between">
-			<div class="text-sm text-gray-600">Color</div>
-			<ColorPicker v-model="activeElement.color" />
-		</div>
-	</div>
+			<div class="flex items-center justify-between">
+				<button
+					v-for="textAlign in ['left', 'center', 'right', 'justify']"
+					class="cursor-pointer rounded-sm p-1.5"
+					:class="activeElement.textAlign == textAlign ? 'bg-gray-200' : ''"
+					@click="activeElement.textAlign = textAlign"
+				>
+					<AlignLeft v-if="textAlign == 'left'" size="18" class="stroke-[1.5]" />
+					<AlignCenter v-if="textAlign == 'center'" size="18" class="stroke-[1.5]" />
+					<AlignRight v-if="textAlign == 'right'" size="18" class="stroke-[1.5]" />
+					<AlignJustify v-if="textAlign == 'justify'" size="18" class="stroke-[1.5]" />
+				</button>
+				<button class="cursor-pointer rounded-sm p-1">
+					<List size="18" class="stroke-[1.5]" />
+				</button>
+			</div>
+		</template>
+	</CollapsibleSection>
 
-	<div :class="sectionClasses">
-		<div :class="sectionTitleClasses">Spacing</div>
+	<CollapsibleSection title="Font" :initialState="true">
+		<template #default>
+			<FormControl
+				type="autocomplete"
+				:options="textFonts"
+				size="sm"
+				variant="subtle"
+				:modelValue="activeElement.fontFamily"
+				@update:modelValue="(font) => (activeElement.fontFamily = font.value)"
+			/>
 
-		<SliderInput
-			label="Line Height"
-			:rangeStart="0.1"
-			:rangeEnd="5.0"
-			:rangeStep="0.1"
-			:modelValue="parseFloat(activeElement.lineHeight)"
-			@update:modelValue="(value) => (activeElement.lineHeight = value)"
-		/>
+			<div class="flex items-center justify-between">
+				<div class="text-sm text-gray-600">Size</div>
+				<div class="h-[30px] w-28">
+					<NumberInput
+						v-model="activeElement.fontSize"
+						suffix="px"
+						:rangeStart="5"
+						:rangeEnd="100"
+						:rangeStep="1"
+					/>
+				</div>
+			</div>
 
-		<SliderInput
-			label="Letter Spacing"
-			:rangeStart="-10"
-			:rangeEnd="50"
-			:rangeStep="0.1"
-			:modelValue="parseFloat(activeElement.letterSpacing)"
-			@update:modelValue="(value) => (activeElement.letterSpacing = value)"
-		/>
-	</div>
+			<div class="flex items-center justify-between">
+				<div class="text-sm text-gray-600">Color</div>
+				<ColorPicker v-model="activeElement.color" />
+			</div>
+		</template>
+	</CollapsibleSection>
+
+	<CollapsibleSection title="Spacing">
+		<template #default>
+			<SliderInput
+				label="Line Height"
+				:rangeStart="0.1"
+				:rangeEnd="5.0"
+				:rangeStep="0.1"
+				:modelValue="parseFloat(activeElement.lineHeight)"
+				@update:modelValue="(value) => (activeElement.lineHeight = value)"
+			/>
+
+			<SliderInput
+				label="Letter Spacing"
+				:rangeStart="-10"
+				:rangeEnd="50"
+				:rangeStep="0.1"
+				:modelValue="parseFloat(activeElement.letterSpacing)"
+				@update:modelValue="(value) => (activeElement.letterSpacing = value)"
+			/>
+		</template>
+	</CollapsibleSection>
 </template>
 
 <script setup>
@@ -110,6 +113,7 @@ import {
 import SliderInput from '@/components/controls/SliderInput.vue'
 import NumberInput from '@/components/controls/NumberInput.vue'
 import ColorPicker from '@/components/controls/ColorPicker.vue'
+import CollapsibleSection from '@/components/controls/CollapsibleSection.vue'
 
 import { slide } from '@/stores/slide'
 import {
@@ -118,9 +122,6 @@ import {
 	toggleTextProperty,
 	activeElement,
 } from '@/stores/element'
-
-const sectionClasses = 'flex flex-col gap-4 border-b p-4'
-const sectionTitleClasses = 'text-2xs font-semibold uppercase text-gray-700'
 
 const textFonts = [
 	'Arial',

--- a/frontend/src/components/VideoProperties.vue
+++ b/frontend/src/components/VideoProperties.vue
@@ -1,37 +1,37 @@
 <template>
-	<div :class="sectionClasses">
-		<div :class="sectionTitleClasses">Playback</div>
-
-		<div class="flex gap-4">
-			<div
-				v-for="(option, index) in playbackProperties"
-				:key="index"
-				:class="getPlaybackOptionClasses(option.property)"
-				@mouseenter="hoverOption = option.property"
-				@mouseleave="hoverOption = null"
-				@click="togglePlaybackOption(option.property)"
-			>
-				<component
-					:is="option.icon"
-					size="20"
-					:strokeWidth="1.2"
-					:class="getPlaybackTextClasses(option.property)"
-				/>
-				<div class="text-xs" :class="getPlaybackTextClasses(option.property)">
-					{{ option.label }}
+	<CollapsibleSection title="Playback" :initialState="true">
+		<template #default>
+			<div class="flex gap-4">
+				<div
+					v-for="(option, index) in playbackProperties"
+					:key="index"
+					:class="getPlaybackOptionClasses(option.property)"
+					@mouseenter="hoverOption = option.property"
+					@mouseleave="hoverOption = null"
+					@click="togglePlaybackOption(option.property)"
+				>
+					<component
+						:is="option.icon"
+						size="20"
+						:strokeWidth="1.2"
+						:class="getPlaybackTextClasses(option.property)"
+					/>
+					<div class="text-xs" :class="getPlaybackTextClasses(option.property)">
+						{{ option.label }}
+					</div>
 				</div>
 			</div>
-		</div>
 
-		<SliderInput
-			label="Speed"
-			:rangeStart="0.5"
-			:rangeEnd="2"
-			:rangeStep="0.1"
-			:modelValue="parseFloat(activeElement.playbackRate) || 1"
-			@update:modelValue="setPlaybackRate"
-		/>
-	</div>
+			<SliderInput
+				label="Speed"
+				:rangeStart="0.5"
+				:rangeEnd="2"
+				:rangeStep="0.1"
+				:modelValue="parseFloat(activeElement.playbackRate) || 1"
+				@update:modelValue="setPlaybackRate"
+			/>
+		</template>
+	</CollapsibleSection>
 
 	<MediaProperties />
 </template>
@@ -43,9 +43,9 @@ import { Repeat2, TvMinimalPlay } from 'lucide-vue-next'
 
 import MediaProperties from '@/components/MediaProperties.vue'
 import SliderInput from '@/components/controls/SliderInput.vue'
+import CollapsibleSection from '@/components/controls/CollapsibleSection.vue'
 
 import { activeElement } from '@/stores/element'
-import { sectionClasses, sectionTitleClasses } from '@/utils/constants'
 
 const hoverOption = ref(null)
 

--- a/frontend/src/components/controls/CollapsibleSection.vue
+++ b/frontend/src/components/controls/CollapsibleSection.vue
@@ -1,19 +1,23 @@
 <template>
-	<div class="flex flex-col gap-4 cursor-pointer">
-		<div class="flex justify-between items-center" @click="showContent = !showContent">
-			<div :class="titleClasses">{{ title }}</div>
-			<component
-				:is="showContent ? ChevronUp : ChevronDown"
-				size="16"
-				class="stroke-[1.5] text-gray-700"
-			/>
-		</div>
-
-		<transition name="slide-fade">
-			<div v-if="showContent">
-				<slot />
+	<div :class="sectionClasses">
+		<div class="flex flex-col gap-4 cursor-pointer">
+			<div class="flex justify-between items-center" @click="showContent = !showContent">
+				<div :class="titleClasses">{{ title }}</div>
+				<component
+					:is="showContent ? ChevronUp : ChevronDown"
+					size="14"
+					class="stroke-[1.5] text-gray-500"
+				/>
 			</div>
-		</transition>
+
+			<transition name="slide-fade">
+				<div v-if="showContent">
+					<div class="flex flex-col gap-4">
+						<slot />
+					</div>
+				</div>
+			</transition>
+		</div>
 	</div>
 </template>
 
@@ -21,15 +25,21 @@
 import { ref } from 'vue'
 import { ChevronDown, ChevronUp } from 'lucide-vue-next'
 
+import { sectionClasses, sectionTitleClasses } from '@/utils/constants'
+
 const props = defineProps({
 	title: String,
 	titleClasses: {
 		type: String,
-		default: 'text-base text-gray-700',
+		default: sectionTitleClasses,
+	},
+	initialState: {
+		type: Boolean,
+		default: false,
 	},
 })
 
-const showContent = ref(false)
+const showContent = ref(props.initialState)
 </script>
 
 <style>

--- a/frontend/src/components/controls/CollapsibleSection.vue
+++ b/frontend/src/components/controls/CollapsibleSection.vue
@@ -4,7 +4,7 @@
 			<div class="flex justify-between items-center" @click="showContent = !showContent">
 				<div :class="titleClasses">{{ title }}</div>
 				<component
-					:is="showContent ? ChevronUp : ChevronDown"
+					:is="showContent ? ChevronUp : ChevronRight"
 					size="14"
 					class="stroke-[1.5] text-gray-500"
 				/>
@@ -23,7 +23,7 @@
 
 <script setup>
 import { ref } from 'vue'
-import { ChevronDown, ChevronUp } from 'lucide-vue-next'
+import { ChevronRight, ChevronUp } from 'lucide-vue-next'
 
 import { sectionClasses, sectionTitleClasses } from '@/utils/constants'
 
@@ -44,7 +44,7 @@ const showContent = ref(props.initialState)
 
 <style>
 .slide-fade-enter-active {
-	transition: all 0.1s ease-out;
+	transition: all 0.08s ease-out;
 }
 
 .slide-fade-enter-from,

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -325,7 +325,7 @@ watch(
 )
 
 onMounted(() => {
-	autosaveInterval = setInterval(handleAutoSave, 60000)
+	autosaveInterval = setInterval(handleAutoSave, 2000)
 	document.addEventListener('keydown', handleKeyDown)
 })
 

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -31,6 +31,7 @@
 <script setup>
 import { ref, watch, computed, useTemplateRef, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import { useRoute, useRouter, onBeforeRouteLeave } from 'vue-router'
+import { toast } from 'vue-sonner'
 
 import { call } from 'frappe-ui'
 
@@ -189,7 +190,10 @@ const handleKeyDown = (e) => {
 }
 
 const startSlideShow = () => {
-	resetAndSave()
+	resetFocus()
+	nextTick(() => {
+		saveChanges()
+	})
 
 	router.replace({
 		name: 'Slideshow',
@@ -291,7 +295,12 @@ const duplicateSlide = async (e) => {
 const resetAndSave = () => {
 	resetFocus()
 	nextTick(() => {
-		saveChanges()
+		const toastProps = {
+			loading: `Saving ...`,
+			success: () => `Saved`,
+			error: () => 'Could not save presentation. Please try again.',
+		}
+		toast.promise(saveChanges(), toastProps)
 	})
 }
 

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -123,8 +123,8 @@ const duplicateElements = async (e, elements, displaceByPx = 0) => {
 	nextTick(() => (activeElementIds.value = newSelection))
 }
 
-const deleteElements = async (e) => {
-	activeElements.value.forEach((element) => {
+const deleteAttachments = async (elements) => {
+	elements.forEach((element) => {
 		if (['image', 'video'].includes(element.type)) {
 			// TODO: Handle this in a cleaner way
 			// Delete the file doc only if it's not used in other slides
@@ -143,6 +143,10 @@ const deleteElements = async (e) => {
 			})
 		}
 	})
+}
+
+const deleteElements = async (e) => {
+	deleteAttachments(activeElements.value)
 	const idsToDelete = activeElementIds.value
 	resetFocus()
 	nextTick(() => {


### PR DESCRIPTION
### Changes

- Reuse CollapsibleSection component to show only some sections for each element in the Properties Panel by default. Others can be toggled to view the properties inside.
- Fixed the issue where drag was triggered from any element even outside selection box. In ideal case, the selection should be overridden even if user triggers drag from outside the selection box not just on selection of an unselected element.
  <details>
  <summary> Before </summary>

  <br>

  https://github.com/user-attachments/assets/f8c5833f-c634-4a7e-8112-cd626019adc4

  </details>

  <details>
  <summary> After </summary>

  <br>

  https://github.com/user-attachments/assets/a422d753-5ba1-49d9-86f2-349f3755f081

  </details>

- Show a toast message after the user saves using CTRL + S for feedback.
- Decrease interval for autosave.