### PR TITLE
fix: use HSV for parsing and hex 8 string for storing colors

### DIFF
--- a/frontend/src/components/MediaProperties.vue
+++ b/frontend/src/components/MediaProperties.vue
@@ -113,7 +113,7 @@ const addBorder = (style) => {
 }
 
 const getTabClasses = (style) => {
-	const baseClasses = 'flex h-full w-1/4 cursor-pointer items-center justify-center rounded'
+	const baseClasses = 'flex h-full w-1/6 cursor-pointer items-center justify-center rounded'
 	if (activeElement.value.borderStyle == style) {
 		return `${baseClasses} bg-white shadow`
 	}

--- a/frontend/src/components/PresentationList.vue
+++ b/frontend/src/components/PresentationList.vue
@@ -1,29 +1,35 @@
 <template>
 	<div :class="backgroundClasses">
 		<!-- Header -->
-		<div class="font-semibold text-base cursor-default text-gray-600 lg:px-40 px-32">
-			Presentations ({{ presentations?.length }})
+		<div class="font-semibold text-base cursor-default text-gray-700 lg:px-40 px-32">
+			Presentations <span v-if="presentations?.length">({{ presentations?.length }})</span>
 		</div>
 
-		<div class="grid grid-cols-3 lg:grid-cols-4 lg:px-40 lg:py-6 px-32 py-4 lg:gap-10 gap-8">
+		<div class="lg:px-40 px-32 py-4">
 			<div
-				v-for="presentation in presentations"
-				:key="presentation.name"
-				class="flex flex-col gap-2"
+				v-if="presentations?.length"
+				class="grid grid-cols-3 lg:grid-cols-4 lg:gap-10 gap-8"
 			>
-				<!-- Presentation Card -->
-				<!-- added bg-white temporarily to support for first slides with no generated thumbnail -->
 				<div
-					class="aspect-[16/9] bg-white rounded-lg shadow-xl cursor-pointer hover:scale-[1.01]"
-					:style="getCardStyles(presentation)"
-					@click="(e) => setPreviewPresentation(e, presentation)"
-				></div>
+					v-for="presentation in presentations"
+					:key="presentation.name"
+					class="flex flex-col gap-2"
+				>
+					<!-- Presentation Card -->
+					<!-- added bg-white temporarily to support for first slides with no generated thumbnail -->
+					<div
+						class="aspect-[16/9] bg-white rounded-lg shadow-xl cursor-pointer hover:scale-[1.01]"
+						:style="getCardStyles(presentation)"
+						@click="(e) => setPreviewPresentation(e, presentation)"
+					></div>
 
-				<!-- Presentation Title  -->
-				<div class="lg:text-base md:text-sm truncate cursor-default text-gray-700 px-2">
-					{{ presentation.title }}
+					<!-- Presentation Title  -->
+					<div class="lg:text-base md:text-sm truncate cursor-default text-gray-700 px-2">
+						{{ presentation.title }}
+					</div>
 				</div>
 			</div>
+			<div v-else class="text-sm text-gray-600">No presentations created yet.</div>
 		</div>
 	</div>
 
@@ -42,7 +48,7 @@ const props = defineProps({
 const emit = defineEmits(['setPreview'])
 
 const backgroundClasses = computed(() => {
-	const baseClasses = 'size-full bg-gray-100 flex flex-col gap-2 py-6 overflow-y-auto'
+	const baseClasses = 'size-full bg-gray-100 flex flex-col gap-2 py-8 overflow-y-auto'
 	if (props.blur) return `${baseClasses} blur-[1px]`
 	return baseClasses
 })

--- a/frontend/src/components/TextProperties.vue
+++ b/frontend/src/components/TextProperties.vue
@@ -227,7 +227,7 @@ const getFontStyleIconClasses = (property, value) => {
 }
 
 const getTabClasses = (alignValue) => {
-	const baseClasses = 'rounded h-full flex items-center justify-center px-4 cursor-pointer'
+	const baseClasses = 'rounded h-full flex items-center justify-center w-1/6 cursor-pointer'
 	if (activeElement.value.textAlign === alignValue) {
 		return `${baseClasses} bg-white shadow`
 	}

--- a/frontend/src/components/controls/ColorPicker.vue
+++ b/frontend/src/components/controls/ColorPicker.vue
@@ -91,8 +91,8 @@ const colorValue = ref()
 const shadeStyles = computed(() => {
 	return {
 		background: `linear-gradient(transparent, black), linear-gradient(to right, white, ${currentHue.value})`,
-		width: '170px',
-		height: '130px',
+		width: `${SHADE_RECT_WIDTH}px`,
+		height: `${SHADE_RECT_HEIGHT}px`,
 	}
 })
 
@@ -145,7 +145,7 @@ const updateHue = (e) => {
 	// set currentHue with full saturation and 50% lightness
 	currentHue.value = tinycolor({ h: colorHue.value, s: 1, l: 0.5 })
 
-	// update currentColor based on exact hue, saturation, and lightness
+	// update currentColor based on exact hue, saturation, and value
 	currentColor.value = tinycolor
 		.fromRatio({
 			h: colorHue.value,
@@ -213,10 +213,12 @@ const endUpdateOpacity = (e) => {
 
 const handlePopoverOpen = () => {
 	const initialHsv = tinycolor(currentColor.value).toHsv()
+
 	colorHue.value = initialHsv.h
 	colorSaturation.value = initialHsv.s
 	colorValue.value = initialHsv.v
 	currentOpacity.value = initialHsv.a
+
 	currentHue.value = tinycolor({ h: colorHue.value, s: 1, l: 0.5 })
 }
 </script>

--- a/frontend/src/components/controls/ColorPicker.vue
+++ b/frontend/src/components/controls/ColorPicker.vue
@@ -84,9 +84,9 @@ const currentColor = defineModel()
 const currentHue = ref()
 const currentOpacity = ref()
 
-const hue = ref(0)
-const saturation = ref()
-const lightness = ref()
+const colorHue = ref(0)
+const colorSaturation = ref()
+const colorValue = ref()
 
 const shadeStyles = computed(() => {
 	return {
@@ -105,11 +105,13 @@ const colorSliderStyles = computed(() => {
 
 const opacitySliderStyles = `background: linear-gradient(to right, rgba(0, 0, 0, 0), rgba(0, 0, 0, 1))`
 
-const shadeRectStyles = computed(() => ({
-	backgroundColor: currentColor.value,
-	left: shadeCursorLeft.value,
-	top: shadeCursorTop.value,
-}))
+const shadeRectStyles = computed(() => {
+	return {
+		backgroundColor: currentColor.value,
+		left: shadeCursorLeft.value,
+		top: shadeCursorTop.value,
+	}
+})
 
 const handleUpdateHue = (e) => {
 	updateHue(e)
@@ -118,7 +120,7 @@ const handleUpdateHue = (e) => {
 }
 
 const hueCursorLeft = computed(() => {
-	return `${SLIDER_WIDTH - (hue.value / 360) * SLIDER_WIDTH - 6}px`
+	return `${SLIDER_WIDTH - (colorHue.value / 360) * SLIDER_WIDTH - 6}px`
 })
 
 const opacityCursorLeft = computed(() => {
@@ -126,11 +128,11 @@ const opacityCursorLeft = computed(() => {
 })
 
 const shadeCursorLeft = computed(() => {
-	return `${saturation.value * SHADE_RECT_WIDTH - 6}px`
+	return `${colorSaturation.value * SHADE_RECT_WIDTH - 6}px`
 })
 
 const shadeCursorTop = computed(() => {
-	return `${(1 - lightness.value) * SHADE_RECT_HEIGHT - 6}px`
+	return `${(1 - colorValue.value) * SHADE_RECT_HEIGHT - 6}px`
 })
 
 const updateHue = (e) => {
@@ -138,20 +140,20 @@ const updateHue = (e) => {
 	const clientX = e.clientX - unref(colorRect.left)
 
 	const x = Math.min(Math.max(clientX, 0), SLIDER_WIDTH)
-	hue.value = 360 - (360 * x) / SLIDER_WIDTH
+	colorHue.value = 360 - (360 * x) / SLIDER_WIDTH
 
 	// set currentHue with full saturation and 50% lightness
-	currentHue.value = tinycolor('hsl ' + hue.value + ' 1 .5').toHslString()
+	currentHue.value = tinycolor({ h: colorHue.value, s: 1, l: 0.5 })
 
 	// update currentColor based on exact hue, saturation, and lightness
 	currentColor.value = tinycolor
 		.fromRatio({
-			h: hue.value,
-			s: saturation.value * 100,
-			v: lightness.value * 100,
+			h: colorHue.value,
+			s: colorSaturation.value * 100,
+			v: colorValue.value * 100,
 			a: currentOpacity.value,
 		})
-		.toHslString()
+		.toHex8String()
 }
 
 const endUpdateHue = (e) => {
@@ -173,17 +175,15 @@ const updateShade = (e) => {
 	const x = Math.min(Math.max(clientX, 0), SHADE_RECT_WIDTH)
 	const y = Math.min(Math.max(clientY, 0), SHADE_RECT_HEIGHT)
 
-	lightness.value = 1 - y / SHADE_RECT_HEIGHT
-	saturation.value = x / SHADE_RECT_WIDTH
+	colorSaturation.value = x / SHADE_RECT_WIDTH
+	colorValue.value = 1 - y / SHADE_RECT_HEIGHT
 
-	currentColor.value = tinycolor
-		.fromRatio({
-			h: hue.value,
-			s: saturation.value * 100,
-			v: lightness.value * 100,
-			a: currentOpacity.value,
-		})
-		.toHslString()
+	currentColor.value = tinycolor({
+		h: colorHue.value,
+		s: colorSaturation.value * 100,
+		v: colorValue.value * 100,
+		a: currentOpacity.value,
+	}).toHex8String()
 }
 
 const endUpdateShade = (e) => {
@@ -204,7 +204,7 @@ const updateOpacity = (e) => {
 	const x = Math.min(Math.max(clientX, 0), SLIDER_WIDTH)
 
 	currentOpacity.value = x / SLIDER_WIDTH
-	currentColor.value = tinycolor(currentColor.value).setAlpha(currentOpacity.value).toHslString()
+	currentColor.value = tinycolor(currentColor.value).setAlpha(currentOpacity.value).toHex8String()
 }
 
 const endUpdateOpacity = (e) => {
@@ -212,13 +212,11 @@ const endUpdateOpacity = (e) => {
 }
 
 const handlePopoverOpen = () => {
-	const initialHsl = tinycolor(currentColor.value).toHsl()
-
-	hue.value = initialHsl.h
-	saturation.value = initialHsl.s
-	lightness.value = initialHsl.l
-
-	currentOpacity.value = initialHsl.a
-	currentHue.value = tinycolor('hsl ' + hue.value + ' 1 .5').toHslString()
+	const initialHsv = tinycolor(currentColor.value).toHsv()
+	colorHue.value = initialHsv.h
+	colorSaturation.value = initialHsv.s
+	colorValue.value = initialHsv.v
+	currentOpacity.value = initialHsv.a
+	currentHue.value = tinycolor({ h: colorHue.value, s: 1, l: 0.5 })
 }
 </script>

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -43,13 +43,20 @@ const setActiveElements = (ids, focus = false) => {
 const addTextElement = (text) => {
 	const lastTextElement = slide.value.elements.reverse().find((element) => element.type == 'text')
 
+	// TODO: find better way to handle calculating offsets without rendering element and knowing exact dimensions
+	const elementWidth = 60.73 * slideBounds.scale
+	const elementHeight = 30 * slideBounds.scale
+
+	const slideWidth = slideBounds.width / slideBounds.scale
+	const slideHeight = slideBounds.height / slideBounds.scale
+
 	const element = {
 		id: generateUniqueId(),
-		left: 100,
-		top: 100,
 		content: text || 'Text',
 		type: 'text',
 		textAlign: 'center',
+		left: slideWidth / 2 - elementWidth / 2,
+		top: slideHeight / 2 - elementHeight / 2,
 	}
 
 	if (lastTextElement) {

--- a/frontend/src/utils/color.js
+++ b/frontend/src/utils/color.js
@@ -1,27 +1,15 @@
-import tinycolor from 'tinycolor2'
-
-const hslToRgb = (hslString) => {
-	return tinycolor(hslString).toRgb()
-}
-
 export const isBackgroundColorDark = (colorString) => {
-	let match = colorString?.match(/^rgba?\(\s*(\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d*\.?\d+)\s*)?\)$/)
-	const HSLmatch = colorString?.match(
-		/^hsla?\(\s*(\d+),\s*(\d+)%\s*,\s*(\d+)%\s*(?:,\s*(\d*\.?\d+)\s*)?\)$/,
-	)
-	if (HSLmatch) {
-		const rgbValue = hslToRgb(colorString)
-		match = [null, rgbValue.r, rgbValue.g, rgbValue.b]
-	}
-	if (!match) return false
-	const r = parseInt(match[1], 10)
-	const g = parseInt(match[2], 10)
-	const b = parseInt(match[3], 10)
+	const rgb = colorString.replace('#', '')
+
+	const r = parseInt(rgb.slice(0, 2), 16)
+	const g = parseInt(rgb.slice(2, 4), 16)
+	const b = parseInt(rgb.slice(4, 6), 16)
+
 	const luminance = 0.2989 * r + 0.587 * g + 0.114 * b
 	return luminance < 128
 }
 
 export const guessTextColorFromBackground = (colorString) => {
-	const textColor = isBackgroundColorDark(colorString) ? 'hsl(0, 0%, 100%)' : 'hsl(0, 0%, 0%)'
+	const textColor = isBackgroundColorDark(colorString) ? '#ffffff' : '#000000'
 	return textColor
 }


### PR DESCRIPTION
### Changes

- Even though the correct Hue was picked up from the stored color value, the initial color did not account for all components including opacity in the final color value. In order to fix that, switched to calculating all values for the Color Picker in HSV format and converting them to normal hex values before storing. This also enables easier parsing of r, g, b values directly from the hex while determining if the slide has a dark or light background. 
- Changed the padding around each option in the textAlign property tabs and the borderStyle property.
- Don't show presentation count if none exist.