### PR TITLE
feat: pasting media from external sources + unique attachment docs

### DIFF
--- a/frontend/src/components/DropTargetOverlay.vue
+++ b/frontend/src/components/DropTargetOverlay.vue
@@ -10,12 +10,10 @@
 
 <script setup>
 import { ref, useTemplateRef } from 'vue'
-import { toast } from 'vue-sonner'
-
-import { FileUploadHandler } from 'frappe-ui'
 
 import { presentationId } from '@/stores/presentation'
 import { addMediaElement } from '@/stores/element'
+import { handleUploadedMedia } from '@/utils/mediaUploads'
 
 const emit = defineEmits(['hideOverlay'])
 
@@ -26,46 +24,9 @@ const handleDragLeave = (e) => {
 	emit('hideOverlay', false)
 }
 
-const fileUploadHandler = new FileUploadHandler()
-
-const uploadMedia = (file, fileType) => {
-	return new Promise((resolve, reject) => {
-		fileUploadHandler
-			.upload(file, {
-				doctype: 'Presentation',
-				docname: presentationId.value,
-				private: true,
-			})
-			.then((fileDoc) => {
-				addMediaElement(fileDoc, fileType)
-				resolve(fileDoc)
-			})
-			.catch((error) => {
-				reject(error)
-			})
-	})
-}
-
-const uploadFiles = (files) => {
-	files.forEach((file, index) => {
-		const fileType = file.type.split('/')[0]
-		if (!['image', 'video'].includes(fileType)) return
-
-		const toastProps = {
-			loading: `Uploading (${index + 1}/${files.length}): ${file.name}`,
-			success: (data) => `Uploaded: ${file.name}`,
-			error: (data) => 'Upload failed. Please try again.',
-		}
-
-		// run after current call stack so toast's expand animation works
-		setTimeout(() => toast.promise(uploadMedia(file, fileType), toastProps), 0)
-	})
-}
-
 const handleMediaDrop = async (e) => {
 	e.preventDefault()
 	emit('hideOverlay', false)
-	const files = e.dataTransfer.files
-	uploadFiles(files)
+	handleUploadedMedia(e.dataTransfer.files)
 }
 </script>

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -305,4 +305,5 @@ export {
 	handleCopy,
 	handlePaste,
 	updateElementWidth,
+	deleteAttachments,
 }

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -251,18 +251,16 @@ const pasteElements = (e, clipboardJSON) => {
 	duplicateElements(e, elements)
 }
 
-const getUpdatedJSON = async (json) => {
-	return await call('slides.slides.doctype.presentation.presentation.get_updated_json', {
-		presentation: presentationId.value,
-		json: JSON.parse(json),
-	})
-}
-
 const handlePastedJSON = async (json) => {
-	if (copiedFromId.value == presentationId.value) return duplicateElements(null, json)
-
-	const updatedJSON = await getUpdatedJSON(json)
-	duplicateElements(null, updatedJSON)
+	if (copiedFromId.value !== presentationId.value) {
+		// if pasted elements are from a different presentation
+		// add file attachments correctly to current presentation + update docnames in json
+		json = await call('slides.slides.doctype.presentation.presentation.get_updated_json', {
+			presentation: presentationId.value,
+			json: JSON.parse(json),
+		})
+	}
+	duplicateElements(null, json)
 }
 
 const handlePaste = (e) => {

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -90,7 +90,7 @@ const addMediaElement = (file, type) => {
 		opacity: 100,
 		type: type,
 		src: file.file_url,
-		file_name: file.name,
+		attachmentName: file.name,
 		borderStyle: 'none',
 		borderWidth: 0,
 		borderRadius: 0,
@@ -138,6 +138,7 @@ const deleteAttachments = async (elements) => {
 			const isFileDocUsed = presentation.data.slides.some((slide) => {
 				if (!slide.elements) return false
 				return JSON.parse(slide.elements).some((el) => {
+					if (element.id == el.id) return false
 					return el.src === element.src
 				})
 			})
@@ -146,14 +147,14 @@ const deleteAttachments = async (elements) => {
 
 			call('frappe.client.delete', {
 				doctype: 'File',
-				name: element.file_name,
+				name: element.attachmentName,
 			})
 		}
 	})
 }
 
 const deleteElements = async (e) => {
-	// deleteAttachments(activeElements.value)
+	deleteAttachments(activeElements.value)
 	const idsToDelete = activeElementIds.value
 	resetFocus()
 	nextTick(() => {
@@ -257,7 +258,7 @@ const handlePastedJSON = async (json) => {
 		// add file attachments correctly to current presentation + update docnames in json
 		json = await call('slides.slides.doctype.presentation.presentation.get_updated_json', {
 			presentation: presentationId.value,
-			json: JSON.parse(json),
+			json: json,
 		})
 	}
 	duplicateElements(null, json)
@@ -270,7 +271,7 @@ const handlePaste = (e) => {
 	if (clipboardText) pasteText(clipboardText)
 
 	const clipboardJSON = e.clipboardData.getData('application/json')
-	if (clipboardJSON) handlePastedJSON(clipboardJSON)
+	if (clipboardJSON) handlePastedJSON(JSON.parse(clipboardJSON))
 }
 
 const updateElementWidth = (deltaWidth) => {

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -5,6 +5,7 @@ import { slide, slideBounds } from './slide'
 
 import { generateUniqueId } from '../utils/helpers'
 import { guessTextColorFromBackground } from '../utils/color'
+import { handleUploadedMedia } from '../utils/mediaUploads'
 import { presentation, presentationId } from './presentation'
 
 const activeElementIds = ref([])
@@ -237,18 +238,13 @@ const handleCopy = (e) => {
 	copiedFromId.value = presentationId.value
 }
 
-const pasteText = (clipboardText) => {
+const handlePastedText = (clipboardText) => {
 	if (focusElementId.value) {
 		document.execCommand('insertText', false, clipboardText)
 	} else {
 		resetFocus()
 		addTextElement(clipboardText)
 	}
-}
-
-const pasteElements = (e, clipboardJSON) => {
-	const elements = JSON.parse(clipboardJSON)
-	duplicateElements(e, elements)
 }
 
 const handlePastedJSON = async (json) => {
@@ -266,8 +262,11 @@ const handlePastedJSON = async (json) => {
 const handlePaste = (e) => {
 	e.preventDefault()
 
+	const clipboardItems = e.clipboardData.items
+	if (clipboardItems) handleUploadedMedia(clipboardItems)
+
 	const clipboardText = e.clipboardData.getData('text/plain')
-	if (clipboardText) pasteText(clipboardText)
+	if (clipboardText) handlePastedText(clipboardText)
 
 	const clipboardJSON = e.clipboardData.getData('application/json')
 	if (clipboardJSON) handlePastedJSON(JSON.parse(clipboardJSON))

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -130,20 +130,19 @@ const duplicateElements = async (e, elements, displaceByPx = 0) => {
 	nextTick(() => (activeElementIds.value = newSelection))
 }
 
+const isFileDocUsed = (element) => {
+	return presentation.data.slides.some((slide) => {
+		if (!slide.elements) return false
+
+		const elements = JSON.parse(slide.elements)
+		return elements.some((el) => el.id !== element.id && el.src === element.src)
+	})
+}
+
 const deleteAttachments = async (elements) => {
 	elements.forEach((element) => {
 		if (['image', 'video'].includes(element.type)) {
-			// TODO: Handle this in a cleaner way
-			// Delete the file doc only if it's not used in other slides
-			const isFileDocUsed = presentation.data.slides.some((slide) => {
-				if (!slide.elements) return false
-				return JSON.parse(slide.elements).some((el) => {
-					if (element.id == el.id) return false
-					return el.src === element.src
-				})
-			})
-
-			if (isFileDocUsed) return
+			if (isFileDocUsed(element)) return
 
 			call('frappe.client.delete', {
 				doctype: 'File',

--- a/frontend/src/utils/mediaUploads.js
+++ b/frontend/src/utils/mediaUploads.js
@@ -1,0 +1,60 @@
+import { FileUploadHandler } from 'frappe-ui'
+import { toast } from 'vue-sonner'
+
+import { presentationId } from '../stores/presentation'
+import { addMediaElement } from '../stores/element'
+
+const fileUploadHandler = new FileUploadHandler()
+
+const uploadMedia = (file, fileType) => {
+	return new Promise((resolve, reject) => {
+		fileUploadHandler
+			.upload(file, {
+				doctype: 'Presentation',
+				docname: presentationId.value,
+				private: true,
+			})
+			.then((fileDoc) => {
+				addMediaElement(fileDoc, fileType)
+				resolve(fileDoc)
+			})
+			.catch((error) => {
+				reject(error)
+			})
+	})
+}
+
+const isDataTransferItem = (obj) => {
+	return obj && typeof obj === 'object' && 'kind' in obj && 'getAsFile' in obj
+}
+
+const isFile = (obj) => {
+	return obj instanceof File
+}
+
+const getFileObject = (file) => {
+	if (isDataTransferItem(file)) {
+		return file.getAsFile()
+	} else if (isFile(file)) {
+		return file
+	}
+}
+
+export const handleUploadedMedia = (files) => {
+	files.forEach((file, index) => {
+		file = getFileObject(file)
+		if (!file) return
+
+		const fileType = file.type.split('/')[0]
+		if (!['image', 'video'].includes(fileType)) return
+
+		const toastProps = {
+			loading: `Uploading (${index + 1}/${files.length}): ${file.name}`,
+			success: (data) => `Uploaded: ${file.name}`,
+			error: (data) => 'Upload failed. Please try again.',
+		}
+
+		// run after current call stack so toast's expand animation works
+		setTimeout(() => toast.promise(uploadMedia(file, fileType), toastProps), 0)
+	})
+}


### PR DESCRIPTION
### Changes

- Added the ability to paste images and videos from the clipboard.

- Create a separate File document for image or videos when they are copied from one presentation and pasted into a separate one in order to address https://github.com/frappe/slides/pull/46#discussion_r2144182959

- Checked and fixed a few cases where the File document got deleted irrespective of being used elsewhere. Now, when a new element is added / pasted inside the editor, a new File document is only created as an attachment to the Presentation if it doesn't exist for that presentation. Since a single document exists for the url for any number of elements for that presentation, before deleting elements we check if it's used anywhere else in the presentation.

- When a slide is deleted, added the logic to cleanup attachments for elements of that slide. When the presentation is deleted, framework automatically deletes the attachments since they are not used anywhere else and are unique to that presentation name.


----


#### Pasting Image From External Source

https://github.com/user-attachments/assets/1db7df79-cf35-4e4d-b712-58ca130207ce


