### PR TITLE
feat: auto-alignment through sidebar controls

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -8,6 +8,7 @@ export {}
 /* prettier-ignore */
 declare module 'vue' {
   export interface GlobalComponents {
+    AlignmentControls: typeof import('./src/components/AlignmentControls.vue')['default']
     CollapsibleSection: typeof import('./src/components/controls/CollapsibleSection.vue')['default']
     ColorPicker: typeof import('./src/components/controls/ColorPicker.vue')['default']
     DropTargetOverlay: typeof import('./src/components/DropTargetOverlay.vue')['default']

--- a/frontend/src/components/AlignmentControls.vue
+++ b/frontend/src/components/AlignmentControls.vue
@@ -20,7 +20,12 @@
 
 			<div :class="fieldLabelClasses">Horizontal</div>
 			<div class="grid grid-cols-3 gap-3">
-				<div :class="getAlignmentButtonClasses('left')" @click="performAlignment('left')">
+				<div
+					:class="getAlignmentButtonClasses('left')"
+					@click="performAlignment('left')"
+					@mouseenter="updateGuideVisibilityMap('leftEdge', true)"
+					@mouseleave="updateGuideVisibilityMap('leftEdge', false)"
+				>
 					<AlignStartVertical size="18" :strokeWidth="1.5" />
 				</div>
 				<div
@@ -31,7 +36,12 @@
 				>
 					<AlignCenterVertical size="18" :strokeWidth="1.5" />
 				</div>
-				<div :class="getAlignmentButtonClasses('right')" @click="performAlignment('right')">
+				<div
+					:class="getAlignmentButtonClasses('right')"
+					@click="performAlignment('right')"
+					@mouseenter="updateGuideVisibilityMap('rightEdge', true)"
+					@mouseleave="updateGuideVisibilityMap('rightEdge', false)"
+				>
 					<AlignEndVertical size="18" :strokeWidth="1.5" />
 				</div>
 			</div>

--- a/frontend/src/components/AlignmentControls.vue
+++ b/frontend/src/components/AlignmentControls.vue
@@ -24,8 +24,10 @@
 					<AlignStartVertical size="18" :strokeWidth="1.5" />
 				</div>
 				<div
-					:class="getAlignmentButtonClasses('centerX')"
-					@click="performAlignment('centerX')"
+					:class="getAlignmentButtonClasses('centerY')"
+					@click="performAlignment('centerY')"
+					@mouseenter="updateGuideVisibilityMap('centerY', true)"
+					@mouseleave="updateGuideVisibilityMap('centerY', false)"
 				>
 					<AlignCenterVertical size="18" :strokeWidth="1.5" />
 				</div>
@@ -40,8 +42,10 @@
 					<AlignStartHorizontal size="18" :strokeWidth="1.5" />
 				</div>
 				<div
-					:class="getAlignmentButtonClasses('centerY')"
-					@click="performAlignment('centerY')"
+					:class="getAlignmentButtonClasses('centerX')"
+					@click="performAlignment('centerX')"
+					@mouseenter="updateGuideVisibilityMap('centerX', true)"
+					@mouseleave="updateGuideVisibilityMap('centerX', false)"
 				>
 					<AlignCenterHorizontal size="18" :strokeWidth="1.5" />
 				</div>
@@ -70,7 +74,7 @@ import {
 
 import CollapsibleSection from '@/components/controls/CollapsibleSection.vue'
 
-import { slideBounds, selectionBounds } from '@/stores/slide'
+import { slideBounds, selectionBounds, guideVisibilityMap } from '@/stores/slide'
 import { fieldLabelClasses } from '@/utils/constants'
 
 const alignmentPositions = computed(() => {
@@ -81,16 +85,16 @@ const alignmentPositions = computed(() => {
 
 	return {
 		left: 0,
-		centerX: Math.round(slideWidth / 2) - Math.round(selectionWidth / 2),
+		centerY: Math.round(slideWidth / 2) - Math.round(selectionWidth / 2),
 		right: Math.round(slideWidth) - Math.round(selectionWidth),
 		top: 0,
-		centerY: Math.round(slideHeight / 2) - Math.round(selectionHeight / 2),
+		centerX: Math.round(slideHeight / 2) - Math.round(selectionHeight / 2),
 		bottom: Math.round(slideHeight) - Math.round(selectionHeight),
 	}
 })
 
 const isAligned = (direction) => {
-	const axis = ['left', 'centerX', 'right'].includes(direction) ? 'X' : 'Y'
+	const axis = ['left', 'centerY', 'right'].includes(direction) ? 'X' : 'Y'
 
 	const expectedPos = alignmentPositions.value[direction]
 
@@ -122,7 +126,7 @@ const alignVertically = (direction) => {
 const performAlignment = (direction) => {
 	switch (direction) {
 		case 'left':
-		case 'centerX':
+		case 'centerY':
 		case 'right':
 			alignHorizontally(direction)
 			break
@@ -131,5 +135,9 @@ const performAlignment = (direction) => {
 			alignVertically(direction)
 			break
 	}
+}
+
+const updateGuideVisibilityMap = (direction, value) => {
+	guideVisibilityMap[direction] = value
 }
 </script>

--- a/frontend/src/components/AlignmentControls.vue
+++ b/frontend/src/components/AlignmentControls.vue
@@ -18,59 +18,19 @@
 				/>
 			</div>
 
-			<div :class="fieldLabelClasses">Horizontal</div>
-			<div class="grid grid-cols-3 gap-3">
-				<div
-					:class="getAlignmentButtonClasses('left')"
-					@click="performAlignment('left')"
-					@mouseenter="updateGuideVisibilityMap('leftEdge', true)"
-					@mouseleave="updateGuideVisibilityMap('leftEdge', false)"
-				>
-					<AlignStartVertical size="18" :strokeWidth="1.5" />
-				</div>
-				<div
-					:class="getAlignmentButtonClasses('centerY')"
-					@click="performAlignment('centerY')"
-					@mouseenter="updateGuideVisibilityMap('centerY', true)"
-					@mouseleave="updateGuideVisibilityMap('centerY', false)"
-				>
-					<AlignCenterVertical size="18" :strokeWidth="1.5" />
-				</div>
-				<div
-					:class="getAlignmentButtonClasses('right')"
-					@click="performAlignment('right')"
-					@mouseenter="updateGuideVisibilityMap('rightEdge', true)"
-					@mouseleave="updateGuideVisibilityMap('rightEdge', false)"
-				>
-					<AlignEndVertical size="18" :strokeWidth="1.5" />
-				</div>
-			</div>
-
-			<div :class="fieldLabelClasses">Vertical</div>
-			<div class="grid grid-cols-3 gap-3">
-				<div
-					:class="getAlignmentButtonClasses('top')"
-					@click="performAlignment('top')"
-					@mouseenter="updateGuideVisibilityMap('topEdge', true)"
-					@mouseleave="updateGuideVisibilityMap('topEdge', false)"
-				>
-					<AlignStartHorizontal size="18" :strokeWidth="1.5" />
-				</div>
-				<div
-					:class="getAlignmentButtonClasses('centerX')"
-					@click="performAlignment('centerX')"
-					@mouseenter="updateGuideVisibilityMap('centerX', true)"
-					@mouseleave="updateGuideVisibilityMap('centerX', false)"
-				>
-					<AlignCenterHorizontal size="18" :strokeWidth="1.5" />
-				</div>
-				<div
-					:class="getAlignmentButtonClasses('bottom')"
-					@click="performAlignment('bottom')"
-					@mouseenter="updateGuideVisibilityMap('bottomEdge', true)"
-					@mouseleave="updateGuideVisibilityMap('bottomEdge', false)"
-				>
-					<AlignEndHorizontal size="18" :strokeWidth="1.5" />
+			<div v-for="axis in axes" :key="axis" class="flex flex-col gap-1.5">
+				<div :class="fieldLabelClasses">{{ axis.label }}</div>
+				<div class="grid grid-cols-3 gap-3">
+					<div
+						v-for="option in axis.options"
+						:key="option.direction"
+						:class="getAlignmentButtonClasses(option.direction)"
+						@click="performAlignment(option.direction)"
+						@mouseenter="updateGuideVisibilityMap(option.guide, true)"
+						@mouseleave="updateGuideVisibilityMap(option.guide, false)"
+					>
+						<component :is="option.icon" size="18" :strokeWidth="1.5" />
+					</div>
 				</div>
 			</div>
 		</template>
@@ -93,6 +53,53 @@ import CollapsibleSection from '@/components/controls/CollapsibleSection.vue'
 
 import { slideBounds, selectionBounds, guideVisibilityMap } from '@/stores/slide'
 import { fieldLabelClasses } from '@/utils/constants'
+
+const horizontalAlignmentOptions = [
+	{
+		direction: 'left',
+		guide: 'leftEdge',
+		icon: AlignStartVertical,
+	},
+	{
+		direction: 'centerY',
+		guide: 'centerY',
+		icon: AlignCenterVertical,
+	},
+	{
+		direction: 'right',
+		guide: 'rightEdge',
+		icon: AlignEndVertical,
+	},
+]
+
+const verticalAlignmentOptions = [
+	{
+		direction: 'top',
+		guide: 'topEdge',
+		icon: AlignStartHorizontal,
+	},
+	{
+		direction: 'centerX',
+		guide: 'centerX',
+		icon: AlignCenterHorizontal,
+	},
+	{
+		direction: 'bottom',
+		guide: 'bottomEdge',
+		icon: AlignEndHorizontal,
+	},
+]
+
+const axes = [
+	{
+		label: 'Horizontal',
+		options: horizontalAlignmentOptions,
+	},
+	{
+		label: 'Vertical',
+		options: verticalAlignmentOptions,
+	},
+]
 
 const alignmentPositions = computed(() => {
 	const slideWidth = slideBounds.width / slideBounds.scale

--- a/frontend/src/components/AlignmentControls.vue
+++ b/frontend/src/components/AlignmentControls.vue
@@ -1,0 +1,135 @@
+<template>
+	<CollapsibleSection title="Alignment" :initialState="true">
+		<template #default>
+			<div class="flex items-center gap-3">
+				<NumberInput
+					v-model="selectionBounds.left"
+					prefix="x"
+					:rangeStart="0"
+					:rangeStep="1"
+					:hideButtons="true"
+				/>
+				<NumberInput
+					v-model="selectionBounds.top"
+					prefix="y"
+					:rangeStart="0"
+					:rangeStep="1"
+					:hideButtons="true"
+				/>
+			</div>
+
+			<div :class="fieldLabelClasses">Horizontal</div>
+			<div class="grid grid-cols-3 gap-3">
+				<div :class="getAlignmentButtonClasses('left')" @click="performAlignment('left')">
+					<AlignStartVertical size="18" :strokeWidth="1.5" />
+				</div>
+				<div
+					:class="getAlignmentButtonClasses('centerX')"
+					@click="performAlignment('centerX')"
+				>
+					<AlignCenterVertical size="18" :strokeWidth="1.5" />
+				</div>
+				<div :class="getAlignmentButtonClasses('right')" @click="performAlignment('right')">
+					<AlignEndVertical size="18" :strokeWidth="1.5" />
+				</div>
+			</div>
+
+			<div :class="fieldLabelClasses">Vertical</div>
+			<div class="grid grid-cols-3 gap-3">
+				<div :class="getAlignmentButtonClasses('top')" @click="performAlignment('top')">
+					<AlignStartHorizontal size="18" :strokeWidth="1.5" />
+				</div>
+				<div
+					:class="getAlignmentButtonClasses('centerY')"
+					@click="performAlignment('centerY')"
+				>
+					<AlignCenterHorizontal size="18" :strokeWidth="1.5" />
+				</div>
+				<div
+					:class="getAlignmentButtonClasses('bottom')"
+					@click="performAlignment('bottom')"
+				>
+					<AlignEndHorizontal size="18" :strokeWidth="1.5" />
+				</div>
+			</div>
+		</template>
+	</CollapsibleSection>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+import {
+	AlignStartVertical,
+	AlignCenterVertical,
+	AlignEndVertical,
+	AlignStartHorizontal,
+	AlignCenterHorizontal,
+	AlignEndHorizontal,
+} from 'lucide-vue-next'
+
+import CollapsibleSection from '@/components/controls/CollapsibleSection.vue'
+
+import { slideBounds, selectionBounds } from '@/stores/slide'
+import { fieldLabelClasses } from '@/utils/constants'
+
+const alignmentPositions = computed(() => {
+	const slideWidth = slideBounds.width / slideBounds.scale
+	const slideHeight = slideBounds.height / slideBounds.scale
+
+	const { width: selectionWidth, height: selectionHeight } = selectionBounds
+
+	return {
+		left: 0,
+		centerX: Math.round(slideWidth / 2) - Math.round(selectionWidth / 2),
+		right: Math.round(slideWidth) - Math.round(selectionWidth),
+		top: 0,
+		centerY: Math.round(slideHeight / 2) - Math.round(selectionHeight / 2),
+		bottom: Math.round(slideHeight) - Math.round(selectionHeight),
+	}
+})
+
+const isAligned = (direction) => {
+	const axis = ['left', 'centerX', 'right'].includes(direction) ? 'X' : 'Y'
+
+	const expectedPos = alignmentPositions.value[direction]
+
+	const currentPos =
+		axis == 'X' ? Math.round(selectionBounds.left) : Math.round(selectionBounds.top)
+
+	return expectedPos == currentPos
+}
+
+const getAlignmentButtonClasses = (direction) => {
+	const baseClasses =
+		'flex cursor-pointer items-center justify-center rounded border py-1.5 hover:border-gray-400'
+
+	const activeClasses = isAligned(direction)
+		? 'border-gray-500 text-gray-900'
+		: 'text-gray-600 hover:text-gray-700'
+
+	return `${baseClasses} ${activeClasses}`
+}
+
+const alignHorizontally = (direction) => {
+	selectionBounds.left = Math.round(alignmentPositions.value[direction])
+}
+
+const alignVertically = (direction) => {
+	selectionBounds.top = Math.round(alignmentPositions.value[direction])
+}
+
+const performAlignment = (direction) => {
+	switch (direction) {
+		case 'left':
+		case 'centerX':
+		case 'right':
+			alignHorizontally(direction)
+			break
+		default:
+			// 'top', 'centerY', 'bottom'
+			alignVertically(direction)
+			break
+	}
+}
+</script>

--- a/frontend/src/components/AlignmentControls.vue
+++ b/frontend/src/components/AlignmentControls.vue
@@ -48,7 +48,12 @@
 
 			<div :class="fieldLabelClasses">Vertical</div>
 			<div class="grid grid-cols-3 gap-3">
-				<div :class="getAlignmentButtonClasses('top')" @click="performAlignment('top')">
+				<div
+					:class="getAlignmentButtonClasses('top')"
+					@click="performAlignment('top')"
+					@mouseenter="updateGuideVisibilityMap('topEdge', true)"
+					@mouseleave="updateGuideVisibilityMap('topEdge', false)"
+				>
 					<AlignStartHorizontal size="18" :strokeWidth="1.5" />
 				</div>
 				<div
@@ -62,6 +67,8 @@
 				<div
 					:class="getAlignmentButtonClasses('bottom')"
 					@click="performAlignment('bottom')"
+					@mouseenter="updateGuideVisibilityMap('bottomEdge', true)"
+					@mouseleave="updateGuideVisibilityMap('bottomEdge', false)"
 				>
 					<AlignEndHorizontal size="18" :strokeWidth="1.5" />
 				</div>

--- a/frontend/src/components/DropTargetOverlay.vue
+++ b/frontend/src/components/DropTargetOverlay.vue
@@ -12,7 +12,6 @@
 import { ref, useTemplateRef } from 'vue'
 
 import { presentationId } from '@/stores/presentation'
-import { addMediaElement } from '@/stores/element'
 import { handleUploadedMedia } from '@/utils/mediaUploads'
 
 const emit = defineEmits(['hideOverlay'])

--- a/frontend/src/components/PropertiesPanel.vue
+++ b/frontend/src/components/PropertiesPanel.vue
@@ -32,6 +32,19 @@
 							<AlignEndVertical size="18" :strokeWidth="1.5" />
 						</div>
 					</div>
+
+					<div :class="fieldLabelClasses">Vertical</div>
+					<div class="grid grid-cols-3 gap-3">
+						<div :class="quickAlignmentButtonClasses">
+							<AlignStartHorizontal size="18" :strokeWidth="1.5" />
+						</div>
+						<div :class="quickAlignmentButtonClasses">
+							<AlignCenterHorizontal size="18" :strokeWidth="1.5" />
+						</div>
+						<div :class="quickAlignmentButtonClasses">
+							<AlignEndHorizontal size="18" :strokeWidth="1.5" />
+						</div>
+					</div>
 				</template>
 			</CollapsibleSection>
 		</div>
@@ -58,7 +71,14 @@ import { computed } from 'vue'
 
 import { FormControl } from 'frappe-ui'
 
-import { AlignStartVertical, AlignCenterVertical, AlignEndVertical } from 'lucide-vue-next'
+import {
+	AlignStartVertical,
+	AlignCenterVertical,
+	AlignEndVertical,
+	AlignStartHorizontal,
+	AlignCenterHorizontal,
+	AlignEndHorizontal,
+} from 'lucide-vue-next'
 
 import SlideProperties from '@/components/SlideProperties.vue'
 import TextProperties from '@/components/TextProperties.vue'

--- a/frontend/src/components/PropertiesPanel.vue
+++ b/frontend/src/components/PropertiesPanel.vue
@@ -44,13 +44,22 @@
 
 					<div :class="fieldLabelClasses">Vertical</div>
 					<div class="grid grid-cols-3 gap-3">
-						<div :class="getAlignmentButtonClasses('top')">
+						<div
+							:class="getAlignmentButtonClasses('top')"
+							@click="performAlignment('top')"
+						>
 							<AlignStartHorizontal size="18" :strokeWidth="1.5" />
 						</div>
-						<div :class="getAlignmentButtonClasses('centerY')">
+						<div
+							:class="getAlignmentButtonClasses('centerY')"
+							@click="performAlignment('centerY')"
+						>
 							<AlignCenterHorizontal size="18" :strokeWidth="1.5" />
 						</div>
-						<div :class="getAlignmentButtonClasses('bottom')">
+						<div
+							:class="getAlignmentButtonClasses('bottom')"
+							@click="performAlignment('bottom')"
+						>
 							<AlignEndHorizontal size="18" :strokeWidth="1.5" />
 						</div>
 					</div>
@@ -162,6 +171,15 @@ const performAlignment = (direction) => {
 	} else if (direction === 'right') {
 		selectionBounds.left =
 			Math.round(slideBounds.width / slideBounds.scale) - Math.round(selectionBounds.width)
+	} else if (direction === 'top') {
+		selectionBounds.top = 0
+	} else if (direction === 'centerY') {
+		selectionBounds.top =
+			Math.round(slideBounds.height / (2 * slideBounds.scale)) -
+			Math.round(selectionBounds.height / 2)
+	} else if (direction === 'bottom') {
+		selectionBounds.top =
+			Math.round(slideBounds.height / slideBounds.scale) - Math.round(selectionBounds.height)
 	}
 }
 </script>

--- a/frontend/src/components/PropertiesPanel.vue
+++ b/frontend/src/components/PropertiesPanel.vue
@@ -22,13 +22,22 @@
 
 					<div :class="fieldLabelClasses">Horizontal</div>
 					<div class="grid grid-cols-3 gap-3">
-						<div :class="getAlignmentButtonClasses('left')">
+						<div
+							:class="getAlignmentButtonClasses('left')"
+							@click="performAlignment('left')"
+						>
 							<AlignStartVertical size="18" :strokeWidth="1.5" />
 						</div>
-						<div :class="getAlignmentButtonClasses('centerX')">
+						<div
+							:class="getAlignmentButtonClasses('centerX')"
+							@click="performAlignment('centerX')"
+						>
 							<AlignCenterVertical size="18" :strokeWidth="1.5" />
 						</div>
-						<div :class="getAlignmentButtonClasses('right')">
+						<div
+							:class="getAlignmentButtonClasses('right')"
+							@click="performAlignment('right')"
+						>
 							<AlignEndVertical size="18" :strokeWidth="1.5" />
 						</div>
 					</div>
@@ -87,7 +96,7 @@ import ImageProperties from '@/components/ImageProperties.vue'
 import VideoProperties from '@/components/VideoProperties.vue'
 
 import SliderInput from '@/components/controls/SliderInput.vue'
-import CollapsibleSection from './controls/CollapsibleSection.vue'
+import CollapsibleSection from '@/components/controls/CollapsibleSection.vue'
 
 import { presentation } from '@/stores/presentation'
 import { slide, selectionBounds, slideBounds } from '@/stores/slide'
@@ -141,6 +150,19 @@ const getAlignmentButtonClasses = (direction) => {
 		? 'border-gray-500 text-gray-900'
 		: 'text-gray-600 hover:text-gray-700'
 	return `${baseClasses} ${activeClasses}`
+}
+
+const performAlignment = (direction) => {
+	if (direction === 'left') {
+		selectionBounds.left = 0
+	} else if (direction === 'centerX') {
+		selectionBounds.left =
+			Math.round(slideBounds.width / (2 * slideBounds.scale)) -
+			Math.round(selectionBounds.width / 2)
+	} else if (direction === 'right') {
+		selectionBounds.left =
+			Math.round(slideBounds.width / slideBounds.scale) - Math.round(selectionBounds.width)
+	}
 }
 </script>
 

--- a/frontend/src/components/PropertiesPanel.vue
+++ b/frontend/src/components/PropertiesPanel.vue
@@ -5,7 +5,7 @@
 			<AlignmentControls v-if="activeElementIds.length" />
 		</div>
 		<div v-else>
-			<AlignmentControls />
+			<AlignmentControls v-if="activeElementIds.length" />
 			<component :is="activeProperties" />
 		</div>
 		<div v-if="activeElement">

--- a/frontend/src/components/PropertiesPanel.vue
+++ b/frontend/src/components/PropertiesPanel.vue
@@ -1,5 +1,27 @@
 <template>
 	<div v-if="presentation.data" class="flex w-64 flex-col border-l bg-white" @wheel.prevent>
+		<div v-if="activeElement">
+			<CollapsibleSection title="Alignment" :initialState="true">
+				<template #default>
+					<div class="flex items-center gap-3">
+						<NumberInput
+							v-model="selectionBounds.left"
+							prefix="x"
+							:rangeStart="0"
+							:rangeStep="1"
+							:hideButtons="true"
+						/>
+						<NumberInput
+							v-model="selectionBounds.top"
+							prefix="y"
+							:rangeStart="0"
+							:rangeStep="1"
+							:hideButtons="true"
+						/>
+					</div>
+				</template>
+			</CollapsibleSection>
+		</div>
 		<component :is="activeProperties" />
 
 		<div v-if="activeElement">
@@ -32,7 +54,7 @@ import SliderInput from '@/components/controls/SliderInput.vue'
 import CollapsibleSection from './controls/CollapsibleSection.vue'
 
 import { presentation } from '@/stores/presentation'
-import { slide } from '@/stores/slide'
+import { slide, selectionBounds } from '@/stores/slide'
 import { activeElement } from '@/stores/element'
 
 const activeProperties = computed(() => {

--- a/frontend/src/components/PropertiesPanel.vue
+++ b/frontend/src/components/PropertiesPanel.vue
@@ -115,71 +115,78 @@ import { fieldLabelClasses } from '@/utils/constants'
 const activeProperties = computed(() => {
 	const elementType = activeElement.value?.type
 
-	if (!elementType) return SlideProperties
+	switch (elementType) {
+		case 'text':
+			return TextProperties
+		case 'image':
+			return ImageProperties
+		case 'video':
+			return VideoProperties
+		default:
+			return SlideProperties
+	}
+})
 
-	if (elementType == 'text') return TextProperties
-	if (elementType == 'image') return ImageProperties
-	if (elementType == 'video') return VideoProperties
+const alignmentPositions = computed(() => {
+	return {
+		left: 0,
+		centerX:
+			Math.round(slideBounds.width / (2 * slideBounds.scale)) -
+			Math.round(selectionBounds.width / 2),
+		right:
+			Math.round(slideBounds.width / slideBounds.scale) - Math.round(selectionBounds.width),
+		top: 0,
+		centerY:
+			Math.round(slideBounds.height / (2 * slideBounds.scale)) -
+			Math.round(selectionBounds.height / 2),
+		bottom:
+			Math.round(slideBounds.height / slideBounds.scale) - Math.round(selectionBounds.height),
+	}
 })
 
 const isAligned = (direction) => {
-	if (direction === 'left') return Math.round(selectionBounds.left) == 0
-	if (direction === 'centerX') {
-		return (
-			Math.round(selectionBounds.left + selectionBounds.width / 2) ==
-			Math.round(slideBounds.width / (2 * slideBounds.scale))
-		)
-	}
-	if (direction === 'right') {
-		return (
-			Math.round(slideBounds.width / slideBounds.scale) ==
-			Math.round(selectionBounds.left + selectionBounds.width)
-		)
-	}
-	if (direction === 'top') return Math.round(selectionBounds.top) == 0
-	if (direction === 'centerY') {
-		return (
-			Math.round(selectionBounds.top + selectionBounds.height / 2) ==
-			Math.round(slideBounds.height / (2 * slideBounds.scale))
-		)
-	}
-	if (direction === 'bottom') {
-		return (
-			Math.round(slideBounds.height / slideBounds.scale) ==
-			Math.round(selectionBounds.top + selectionBounds.height)
-		)
-	}
-	return false
+	const axis = ['left', 'centerX', 'right'].includes(direction) ? 'X' : 'Y'
+
+	const expectedPos = alignmentPositions.value[direction]
+
+	const currentPos =
+		axis == 'X' ? Math.round(selectionBounds.left) : Math.round(selectionBounds.top)
+
+	return expectedPos == currentPos
 }
 
 const getAlignmentButtonClasses = (direction) => {
 	const baseClasses =
 		'flex cursor-pointer items-center justify-center rounded border py-1.5 hover:border-gray-400'
+
 	const activeClasses = isAligned(direction)
 		? 'border-gray-500 text-gray-900'
 		: 'text-gray-600 hover:text-gray-700'
+
 	return `${baseClasses} ${activeClasses}`
 }
 
+const alignHorizontally = (direction) => {
+	const newLeft = alignmentPositions.value[direction]
+	selectionBounds.left = Math.round(newLeft)
+}
+
+const alignVertically = (direction) => {
+	const newTop = alignmentPositions.value[direction]
+	selectionBounds.top = Math.round(newTop)
+}
+
 const performAlignment = (direction) => {
-	if (direction === 'left') {
-		selectionBounds.left = 0
-	} else if (direction === 'centerX') {
-		selectionBounds.left =
-			Math.round(slideBounds.width / (2 * slideBounds.scale)) -
-			Math.round(selectionBounds.width / 2)
-	} else if (direction === 'right') {
-		selectionBounds.left =
-			Math.round(slideBounds.width / slideBounds.scale) - Math.round(selectionBounds.width)
-	} else if (direction === 'top') {
-		selectionBounds.top = 0
-	} else if (direction === 'centerY') {
-		selectionBounds.top =
-			Math.round(slideBounds.height / (2 * slideBounds.scale)) -
-			Math.round(selectionBounds.height / 2)
-	} else if (direction === 'bottom') {
-		selectionBounds.top =
-			Math.round(slideBounds.height / slideBounds.scale) - Math.round(selectionBounds.height)
+	switch (direction) {
+		case 'left':
+		case 'centerX':
+		case 'right':
+			alignHorizontally(direction)
+			break
+		default:
+			// 'top', 'centerY', 'bottom'
+			alignVertically(direction)
+			break
 	}
 }
 </script>

--- a/frontend/src/components/PropertiesPanel.vue
+++ b/frontend/src/components/PropertiesPanel.vue
@@ -128,19 +128,18 @@ const activeProperties = computed(() => {
 })
 
 const alignmentPositions = computed(() => {
+	const slideWidth = slideBounds.width / slideBounds.scale
+	const slideHeight = slideBounds.height / slideBounds.scale
+
+	const { width: selectionWidth, height: selectionHeight } = selectionBounds
+
 	return {
 		left: 0,
-		centerX:
-			Math.round(slideBounds.width / (2 * slideBounds.scale)) -
-			Math.round(selectionBounds.width / 2),
-		right:
-			Math.round(slideBounds.width / slideBounds.scale) - Math.round(selectionBounds.width),
+		centerX: Math.round(slideWidth / 2) - Math.round(selectionWidth / 2),
+		right: Math.round(slideWidth) - Math.round(selectionWidth),
 		top: 0,
-		centerY:
-			Math.round(slideBounds.height / (2 * slideBounds.scale)) -
-			Math.round(selectionBounds.height / 2),
-		bottom:
-			Math.round(slideBounds.height / slideBounds.scale) - Math.round(selectionBounds.height),
+		centerY: Math.round(slideHeight / 2) - Math.round(selectionHeight / 2),
+		bottom: Math.round(slideHeight) - Math.round(selectionHeight),
 	}
 })
 

--- a/frontend/src/components/PropertiesPanel.vue
+++ b/frontend/src/components/PropertiesPanel.vue
@@ -1,9 +1,13 @@
 <template>
 	<div v-if="presentation.data" class="flex w-64 flex-col border-l bg-white" @wheel.prevent>
-		<AlignmentControls v-if="activeElement" />
-
-		<component :is="activeProperties" />
-
+		<div v-if="!activeElement">
+			<SlideProperties />
+			<AlignmentControls v-if="activeElementIds.length" />
+		</div>
+		<div v-else>
+			<AlignmentControls />
+			<component :is="activeProperties" />
+		</div>
 		<div v-if="activeElement">
 			<CollapsibleSection title="Other">
 				<template #default>
@@ -36,7 +40,7 @@ import CollapsibleSection from '@/components/controls/CollapsibleSection.vue'
 
 import { presentation } from '@/stores/presentation'
 import { slide } from '@/stores/slide'
-import { activeElement } from '@/stores/element'
+import { activeElement, activeElementIds } from '@/stores/element'
 
 const activeProperties = computed(() => {
 	const elementType = activeElement.value?.type
@@ -48,8 +52,6 @@ const activeProperties = computed(() => {
 			return ImageProperties
 		case 'video':
 			return VideoProperties
-		default:
-			return SlideProperties
 	}
 })
 </script>

--- a/frontend/src/components/PropertiesPanel.vue
+++ b/frontend/src/components/PropertiesPanel.vue
@@ -1,71 +1,6 @@
 <template>
 	<div v-if="presentation.data" class="flex w-64 flex-col border-l bg-white" @wheel.prevent>
-		<div v-if="activeElement">
-			<CollapsibleSection title="Alignment" :initialState="true">
-				<template #default>
-					<div class="flex items-center gap-3">
-						<NumberInput
-							v-model="selectionBounds.left"
-							prefix="x"
-							:rangeStart="0"
-							:rangeStep="1"
-							:hideButtons="true"
-						/>
-						<NumberInput
-							v-model="selectionBounds.top"
-							prefix="y"
-							:rangeStart="0"
-							:rangeStep="1"
-							:hideButtons="true"
-						/>
-					</div>
-
-					<div :class="fieldLabelClasses">Horizontal</div>
-					<div class="grid grid-cols-3 gap-3">
-						<div
-							:class="getAlignmentButtonClasses('left')"
-							@click="performAlignment('left')"
-						>
-							<AlignStartVertical size="18" :strokeWidth="1.5" />
-						</div>
-						<div
-							:class="getAlignmentButtonClasses('centerX')"
-							@click="performAlignment('centerX')"
-						>
-							<AlignCenterVertical size="18" :strokeWidth="1.5" />
-						</div>
-						<div
-							:class="getAlignmentButtonClasses('right')"
-							@click="performAlignment('right')"
-						>
-							<AlignEndVertical size="18" :strokeWidth="1.5" />
-						</div>
-					</div>
-
-					<div :class="fieldLabelClasses">Vertical</div>
-					<div class="grid grid-cols-3 gap-3">
-						<div
-							:class="getAlignmentButtonClasses('top')"
-							@click="performAlignment('top')"
-						>
-							<AlignStartHorizontal size="18" :strokeWidth="1.5" />
-						</div>
-						<div
-							:class="getAlignmentButtonClasses('centerY')"
-							@click="performAlignment('centerY')"
-						>
-							<AlignCenterHorizontal size="18" :strokeWidth="1.5" />
-						</div>
-						<div
-							:class="getAlignmentButtonClasses('bottom')"
-							@click="performAlignment('bottom')"
-						>
-							<AlignEndHorizontal size="18" :strokeWidth="1.5" />
-						</div>
-					</div>
-				</template>
-			</CollapsibleSection>
-		</div>
+		<AlignmentControls v-if="activeElement" />
 
 		<component :is="activeProperties" />
 
@@ -90,27 +25,18 @@ import { computed } from 'vue'
 
 import { FormControl } from 'frappe-ui'
 
-import {
-	AlignStartVertical,
-	AlignCenterVertical,
-	AlignEndVertical,
-	AlignStartHorizontal,
-	AlignCenterHorizontal,
-	AlignEndHorizontal,
-} from 'lucide-vue-next'
-
 import SlideProperties from '@/components/SlideProperties.vue'
 import TextProperties from '@/components/TextProperties.vue'
 import ImageProperties from '@/components/ImageProperties.vue'
 import VideoProperties from '@/components/VideoProperties.vue'
+import AlignmentControls from '@/components/AlignmentControls.vue'
 
 import SliderInput from '@/components/controls/SliderInput.vue'
 import CollapsibleSection from '@/components/controls/CollapsibleSection.vue'
 
 import { presentation } from '@/stores/presentation'
-import { slide, selectionBounds, slideBounds } from '@/stores/slide'
+import { slide } from '@/stores/slide'
 import { activeElement } from '@/stores/element'
-import { fieldLabelClasses } from '@/utils/constants'
 
 const activeProperties = computed(() => {
 	const elementType = activeElement.value?.type
@@ -126,68 +52,6 @@ const activeProperties = computed(() => {
 			return SlideProperties
 	}
 })
-
-const alignmentPositions = computed(() => {
-	const slideWidth = slideBounds.width / slideBounds.scale
-	const slideHeight = slideBounds.height / slideBounds.scale
-
-	const { width: selectionWidth, height: selectionHeight } = selectionBounds
-
-	return {
-		left: 0,
-		centerX: Math.round(slideWidth / 2) - Math.round(selectionWidth / 2),
-		right: Math.round(slideWidth) - Math.round(selectionWidth),
-		top: 0,
-		centerY: Math.round(slideHeight / 2) - Math.round(selectionHeight / 2),
-		bottom: Math.round(slideHeight) - Math.round(selectionHeight),
-	}
-})
-
-const isAligned = (direction) => {
-	const axis = ['left', 'centerX', 'right'].includes(direction) ? 'X' : 'Y'
-
-	const expectedPos = alignmentPositions.value[direction]
-
-	const currentPos =
-		axis == 'X' ? Math.round(selectionBounds.left) : Math.round(selectionBounds.top)
-
-	return expectedPos == currentPos
-}
-
-const getAlignmentButtonClasses = (direction) => {
-	const baseClasses =
-		'flex cursor-pointer items-center justify-center rounded border py-1.5 hover:border-gray-400'
-
-	const activeClasses = isAligned(direction)
-		? 'border-gray-500 text-gray-900'
-		: 'text-gray-600 hover:text-gray-700'
-
-	return `${baseClasses} ${activeClasses}`
-}
-
-const alignHorizontally = (direction) => {
-	const newLeft = alignmentPositions.value[direction]
-	selectionBounds.left = Math.round(newLeft)
-}
-
-const alignVertically = (direction) => {
-	const newTop = alignmentPositions.value[direction]
-	selectionBounds.top = Math.round(newTop)
-}
-
-const performAlignment = (direction) => {
-	switch (direction) {
-		case 'left':
-		case 'centerX':
-		case 'right':
-			alignHorizontally(direction)
-			break
-		default:
-			// 'top', 'centerY', 'bottom'
-			alignVertically(direction)
-			break
-	}
-}
 </script>
 
 <style scoped>

--- a/frontend/src/components/PropertiesPanel.vue
+++ b/frontend/src/components/PropertiesPanel.vue
@@ -22,32 +22,33 @@
 
 					<div :class="fieldLabelClasses">Horizontal</div>
 					<div class="grid grid-cols-3 gap-3">
-						<div :class="quickAlignmentButtonClasses">
+						<div :class="getAlignmentButtonClasses('left')">
 							<AlignStartVertical size="18" :strokeWidth="1.5" />
 						</div>
-						<div :class="quickAlignmentButtonClasses">
+						<div :class="getAlignmentButtonClasses('centerX')">
 							<AlignCenterVertical size="18" :strokeWidth="1.5" />
 						</div>
-						<div :class="quickAlignmentButtonClasses">
+						<div :class="getAlignmentButtonClasses('right')">
 							<AlignEndVertical size="18" :strokeWidth="1.5" />
 						</div>
 					</div>
 
 					<div :class="fieldLabelClasses">Vertical</div>
 					<div class="grid grid-cols-3 gap-3">
-						<div :class="quickAlignmentButtonClasses">
+						<div :class="getAlignmentButtonClasses('top')">
 							<AlignStartHorizontal size="18" :strokeWidth="1.5" />
 						</div>
-						<div :class="quickAlignmentButtonClasses">
+						<div :class="getAlignmentButtonClasses('centerY')">
 							<AlignCenterHorizontal size="18" :strokeWidth="1.5" />
 						</div>
-						<div :class="quickAlignmentButtonClasses">
+						<div :class="getAlignmentButtonClasses('bottom')">
 							<AlignEndHorizontal size="18" :strokeWidth="1.5" />
 						</div>
 					</div>
 				</template>
 			</CollapsibleSection>
 		</div>
+
 		<component :is="activeProperties" />
 
 		<div v-if="activeElement">
@@ -89,7 +90,7 @@ import SliderInput from '@/components/controls/SliderInput.vue'
 import CollapsibleSection from './controls/CollapsibleSection.vue'
 
 import { presentation } from '@/stores/presentation'
-import { slide, selectionBounds } from '@/stores/slide'
+import { slide, selectionBounds, slideBounds } from '@/stores/slide'
 import { activeElement } from '@/stores/element'
 import { fieldLabelClasses } from '@/utils/constants'
 
@@ -103,8 +104,44 @@ const activeProperties = computed(() => {
 	if (elementType == 'video') return VideoProperties
 })
 
-const quickAlignmentButtonClasses =
-	'flex cursor-pointer items-center justify-center rounded border py-1.5 text-gray-600'
+const isAligned = (direction) => {
+	if (direction === 'left') return Math.round(selectionBounds.left) == 0
+	if (direction === 'centerX') {
+		return (
+			Math.round(selectionBounds.left + selectionBounds.width / 2) ==
+			Math.round(slideBounds.width / (2 * slideBounds.scale))
+		)
+	}
+	if (direction === 'right') {
+		return (
+			Math.round(slideBounds.width / slideBounds.scale) ==
+			Math.round(selectionBounds.left + selectionBounds.width)
+		)
+	}
+	if (direction === 'top') return Math.round(selectionBounds.top) == 0
+	if (direction === 'centerY') {
+		return (
+			Math.round(selectionBounds.top + selectionBounds.height / 2) ==
+			Math.round(slideBounds.height / (2 * slideBounds.scale))
+		)
+	}
+	if (direction === 'bottom') {
+		return (
+			Math.round(slideBounds.height / slideBounds.scale) ==
+			Math.round(selectionBounds.top + selectionBounds.height)
+		)
+	}
+	return false
+}
+
+const getAlignmentButtonClasses = (direction) => {
+	const baseClasses =
+		'flex cursor-pointer items-center justify-center rounded border py-1.5 hover:border-gray-400'
+	const activeClasses = isAligned(direction)
+		? 'border-gray-500 text-gray-900'
+		: 'text-gray-600 hover:text-gray-700'
+	return `${baseClasses} ${activeClasses}`
+}
 </script>
 
 <style scoped>

--- a/frontend/src/components/PropertiesPanel.vue
+++ b/frontend/src/components/PropertiesPanel.vue
@@ -19,6 +19,19 @@
 							:hideButtons="true"
 						/>
 					</div>
+
+					<div :class="fieldLabelClasses">Horizontal</div>
+					<div class="grid grid-cols-3 gap-3">
+						<div :class="quickAlignmentButtonClasses">
+							<AlignStartVertical size="18" :strokeWidth="1.5" />
+						</div>
+						<div :class="quickAlignmentButtonClasses">
+							<AlignCenterVertical size="18" :strokeWidth="1.5" />
+						</div>
+						<div :class="quickAlignmentButtonClasses">
+							<AlignEndVertical size="18" :strokeWidth="1.5" />
+						</div>
+					</div>
 				</template>
 			</CollapsibleSection>
 		</div>
@@ -45,6 +58,8 @@ import { computed } from 'vue'
 
 import { FormControl } from 'frappe-ui'
 
+import { AlignStartVertical, AlignCenterVertical, AlignEndVertical } from 'lucide-vue-next'
+
 import SlideProperties from '@/components/SlideProperties.vue'
 import TextProperties from '@/components/TextProperties.vue'
 import ImageProperties from '@/components/ImageProperties.vue'
@@ -56,6 +71,7 @@ import CollapsibleSection from './controls/CollapsibleSection.vue'
 import { presentation } from '@/stores/presentation'
 import { slide, selectionBounds } from '@/stores/slide'
 import { activeElement } from '@/stores/element'
+import { fieldLabelClasses } from '@/utils/constants'
 
 const activeProperties = computed(() => {
 	const elementType = activeElement.value?.type
@@ -66,6 +82,9 @@ const activeProperties = computed(() => {
 	if (elementType == 'image') return ImageProperties
 	if (elementType == 'video') return VideoProperties
 })
+
+const quickAlignmentButtonClasses =
+	'flex cursor-pointer items-center justify-center rounded border py-1.5 text-gray-600'
 </script>
 
 <style scoped>

--- a/frontend/src/components/SelectionBox.vue
+++ b/frontend/src/components/SelectionBox.vue
@@ -159,8 +159,8 @@ const cropSelectionToFitContent = (elementIds) => {
 	updateSelectionBounds({
 		left: l,
 		top: t,
-		width: r - l + 1,
-		height: b - t + 1,
+		width: r - l,
+		height: b - t,
 	})
 }
 

--- a/frontend/src/components/SelectionBox.vue
+++ b/frontend/src/components/SelectionBox.vue
@@ -168,6 +168,8 @@ const resetSelection = (oldVal) => {
 	updateSelectionBounds({
 		width: 0,
 		height: 0,
+		left: 0,
+		top: 0,
 	})
 }
 
@@ -241,8 +243,8 @@ const handleSelection = (elementIds) => {
 }
 
 const handleSelectionChange = (elementIds, oldIds) => {
-	resetSelection(oldIds)
 	moveElementsToSlide(oldIds)
+	resetSelection(oldIds)
 	nextTick(() => handleSelection(elementIds))
 }
 

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -10,7 +10,7 @@
 			<div ref="slideRef" :class="slideClasses" :style="slideStyles">
 				<SelectionBox ref="selectionBox" @mousedown="(e) => handleMouseDown(e)" />
 
-				<SnapGuides v-if="isDragging" :visibilityMap="visibilityMap" />
+				<SnapGuides :isDragging="isDragging" :visibilityMap="visibilityMap" />
 
 				<SlideElement
 					v-for="element in slide.elements"

--- a/frontend/src/components/SnapGuides.vue
+++ b/frontend/src/components/SnapGuides.vue
@@ -124,6 +124,17 @@ const getHorizontalStyles = (direction) => {
 	}
 }
 
+const getEdgeStyles = (direction) => {
+	return {
+		...commonStyles,
+		width: ['leftEdge', 'rightEdge'].includes(direction) ? '2px' : '100%',
+		height: '100%',
+		left: direction == 'leftEdge' ? '0%' : '100%',
+		top: '0%',
+		display: isVisible(direction) ? 'block' : 'none',
+	}
+}
+
 const guideStyles = computed(() => {
 	return {
 		centerX: getCenterStyles('centerX'),
@@ -132,6 +143,8 @@ const guideStyles = computed(() => {
 		right: getVerticalStyles('right'),
 		top: getHorizontalStyles('top'),
 		bottom: getHorizontalStyles('bottom'),
+		leftEdge: getEdgeStyles('leftEdge'),
+		rightEdge: getEdgeStyles('rightEdge'),
 	}
 })
 </script>

--- a/frontend/src/components/SnapGuides.vue
+++ b/frontend/src/components/SnapGuides.vue
@@ -9,6 +9,8 @@
 			'bottom',
 			'leftEdge',
 			'rightEdge',
+			'topEdge',
+			'bottomEdge',
 		]"
 		:key="guide"
 		:style="guideStyles[guide]"
@@ -128,9 +130,9 @@ const getEdgeStyles = (direction) => {
 	return {
 		...commonStyles,
 		width: ['leftEdge', 'rightEdge'].includes(direction) ? '2px' : '100%',
-		height: '100%',
-		left: direction == 'leftEdge' ? '0%' : '100%',
-		top: '0%',
+		height: ['topEdge', 'bottomEdge'].includes(direction) ? '2px' : '100%',
+		left: direction == 'rightEdge' ? '100%' : '0%',
+		top: direction == 'bottomEdge' ? '100%' : '0%',
 		display: isVisible(direction) ? 'block' : 'none',
 	}
 }
@@ -145,6 +147,8 @@ const guideStyles = computed(() => {
 		bottom: getHorizontalStyles('bottom'),
 		leftEdge: getEdgeStyles('leftEdge'),
 		rightEdge: getEdgeStyles('rightEdge'),
+		topEdge: getEdgeStyles('topEdge'),
+		bottomEdge: getEdgeStyles('bottomEdge'),
 	}
 })
 </script>

--- a/frontend/src/components/SnapGuides.vue
+++ b/frontend/src/components/SnapGuides.vue
@@ -1,6 +1,15 @@
 <template>
 	<div
-		v-for="guide in ['centerX', 'centerY', 'left', 'right', 'top', 'bottom']"
+		v-for="guide in [
+			'centerX',
+			'centerY',
+			'left',
+			'right',
+			'top',
+			'bottom',
+			'leftEdge',
+			'rightEdge',
+		]"
 		:key="guide"
 		:style="guideStyles[guide]"
 	></div>
@@ -9,13 +18,17 @@
 <script setup>
 import { computed } from 'vue'
 
-import { slideBounds, selectionBounds } from '@/stores/slide'
+import { slideBounds, selectionBounds, guideVisibilityMap } from '@/stores/slide'
 import { pairElementId } from '@/stores/element'
 
 const props = defineProps({
 	visibilityMap: {
 		type: Object,
 		default: null,
+	},
+	isDragging: {
+		type: Boolean,
+		default: false,
 	},
 })
 
@@ -24,14 +37,20 @@ const commonStyles = {
 	position: 'fixed',
 }
 
+const isVisible = (axis) => {
+	const closeToSnap = props.isDragging && props.visibilityMap?.[axis]
+	const hoveringOverControl = guideVisibilityMap[axis]
+	return closeToSnap || hoveringOverControl
+}
+
 const getCenterStyles = (axis) => {
 	return {
 		...commonStyles,
-		width: axis === 'horizontal' ? '1px' : '100%',
-		height: axis === 'vertical' ? '1px' : '100%',
-		left: axis === 'horizontal' ? '50%' : '0',
-		top: axis === 'vertical' ? '50%' : '0',
-		display: props.visibilityMap?.[axis] ? 'block' : 'none',
+		width: axis === 'centerY' ? '1px' : '100%',
+		height: axis === 'centerX' ? '1px' : '100%',
+		left: axis === 'centerY' ? '50%' : '0',
+		top: axis === 'centerX' ? '50%' : '0',
+		display: isVisible(axis) ? 'block' : 'none',
 	}
 }
 
@@ -107,8 +126,8 @@ const getHorizontalStyles = (direction) => {
 
 const guideStyles = computed(() => {
 	return {
-		centerX: getCenterStyles('horizontal'),
-		centerY: getCenterStyles('vertical'),
+		centerX: getCenterStyles('centerX'),
+		centerY: getCenterStyles('centerY'),
 		left: getVerticalStyles('left'),
 		right: getVerticalStyles('right'),
 		top: getHorizontalStyles('top'),

--- a/frontend/src/components/SnapGuides.vue
+++ b/frontend/src/components/SnapGuides.vue
@@ -1,20 +1,5 @@
 <template>
-	<div
-		v-for="guide in [
-			'centerX',
-			'centerY',
-			'left',
-			'right',
-			'top',
-			'bottom',
-			'leftEdge',
-			'rightEdge',
-			'topEdge',
-			'bottomEdge',
-		]"
-		:key="guide"
-		:style="guideStyles[guide]"
-	></div>
+	<div v-for="guide in Object.keys(guideStyles)" :key="guide" :style="guideStyles[guide]"></div>
 </template>
 
 <script setup>
@@ -37,6 +22,7 @@ const props = defineProps({
 const commonStyles = {
 	backgroundColor: '#70b6f080',
 	position: 'fixed',
+	zIndex: 1000,
 }
 
 const isVisible = (axis) => {
@@ -129,8 +115,8 @@ const getHorizontalStyles = (direction) => {
 const getEdgeStyles = (direction) => {
 	return {
 		...commonStyles,
-		width: ['leftEdge', 'rightEdge'].includes(direction) ? '2px' : '100%',
-		height: ['topEdge', 'bottomEdge'].includes(direction) ? '2px' : '100%',
+		width: ['leftEdge', 'rightEdge'].includes(direction) ? '1.5px' : '100%',
+		height: ['topEdge', 'bottomEdge'].includes(direction) ? '1.5px' : '100%',
 		left: direction == 'rightEdge' ? '100%' : '0%',
 		top: direction == 'bottomEdge' ? '100%' : '0%',
 		display: isVisible(direction) ? 'block' : 'none',

--- a/frontend/src/components/controls/NumberInput.vue
+++ b/frontend/src/components/controls/NumberInput.vue
@@ -1,14 +1,18 @@
 <template>
 	<div class="flex h-7 w-full items-center justify-between rounded border bg-gray-50/80">
-		<div v-if="prefix" class="px-2 text-center text-xs text-gray-500">{{ prefix }}</div>
+		<div v-if="prefix" class="w-1/2 text-center text-xs font-medium text-gray-500">
+			{{ prefix }}
+		</div>
 		<input
 			type="number"
 			:class="inputClasses"
 			:value="parseFloat(parseFloat(modelValue).toFixed(2))"
 			@change="changeValue"
 		/>
-		<div v-if="suffix" class="px-2 text-center text-xs text-gray-500">{{ suffix }}</div>
-		<div class="flex h-full w-12 flex-col border-l">
+		<div v-if="suffix" class="w-1/2 text-center text-xs font-medium text-gray-500">
+			{{ suffix }}
+		</div>
+		<div v-if="!hideButtons" class="flex h-full w-12 flex-col border-l">
 			<button
 				class="flex h-1/2 cursor-pointer items-center justify-center rounded-tr border-b bg-white hover:bg-gray-200"
 				@click="modelValue + rangeStep <= props.rangeEnd && (modelValue += rangeStep)"
@@ -37,13 +41,18 @@ const props = defineProps({
 		type: Number,
 		default: 1,
 	},
+	hideButtons: {
+		type: Boolean,
+		default: false,
+	},
 })
 
 const modelValue = defineModel()
 
 const inputClasses = computed(() => {
-	const baseClasses =
-		'size-full border-none p-0 text-center text-xs font-semibold text-gray-800 focus:border-none focus:outline-none focus:ring-0'
+	let baseClasses =
+		'size-full border-none p-0 text-center text-xs font-medium text-gray-800 focus:border-none focus:outline-none focus:ring-0'
+	if (props.hideButtons) baseClasses += ' rounded-r'
 	if (props.prefix) return `${baseClasses}`
 	else return `${baseClasses} rounded-l`
 })

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -176,7 +176,7 @@ const handleGlobalShortcuts = (e) => {
 			if (e.metaKey) toggleSlideNavigator()
 			break
 		case 'a':
-			if (e.metaKey) selectAllElements()
+			if (e.metaKey) selectAllElements(e)
 			break
 		case 's':
 			if (e.metaKey) saveSlide(e)

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -1,7 +1,7 @@
 import { ref, computed, nextTick } from 'vue'
 import { call } from 'frappe-ui'
 
-import { slide, slideBounds } from './slide'
+import { selectionBounds, slide, slideBounds, updateSelectionBounds } from './slide'
 
 import { generateUniqueId } from '../utils/helpers'
 import { guessTextColorFromBackground } from '../utils/color'
@@ -41,23 +41,40 @@ const setActiveElements = (ids, focus = false) => {
 	}
 }
 
-const addTextElement = (text) => {
+const selectAndCenterElement = (elementId) => {
+	const slideWidth = Math.round(slideBounds.width / slideBounds.scale)
+	const slideHeight = Math.round(slideBounds.height / slideBounds.scale)
+
+	nextTick(() => {
+		setActiveElements([elementId])
+		// to allow centering element only after it's rendere in order to correctly calculate its offset from center
+		requestAnimationFrame(async () => {
+			await nextTick()
+			const elementRect = document
+				.querySelector(`[data-index="${elementId}"]`)
+				.getBoundingClientRect()
+
+			const elementWidth = Math.round(elementRect.width / slideBounds.scale)
+			const elementHeight = Math.round(elementRect.height / slideBounds.scale)
+
+			updateSelectionBounds({
+				left: (slideWidth - elementWidth - 0.1) / 2,
+				top: (slideHeight - elementHeight - 0.1) / 2,
+			})
+		})
+	})
+}
+
+const addTextElement = async (text) => {
 	const lastTextElement = slide.value.elements.reverse().find((element) => element.type == 'text')
-
-	// TODO: find better way to handle calculating offsets without rendering element and knowing exact dimensions
-	const elementWidth = 60.73 * slideBounds.scale
-	const elementHeight = 30 * slideBounds.scale
-
-	const slideWidth = slideBounds.width / slideBounds.scale
-	const slideHeight = slideBounds.height / slideBounds.scale
 
 	const element = {
 		id: generateUniqueId(),
 		content: text || 'Text',
 		type: 'text',
 		textAlign: 'center',
-		left: slideWidth / 2 - elementWidth / 2,
-		top: slideHeight / 2 - elementHeight / 2,
+		left: 0,
+		top: 0,
 	}
 
 	if (lastTextElement) {
@@ -71,7 +88,7 @@ const addTextElement = (text) => {
 	} else {
 		const slideColor = slide.value.background || '#ffffff'
 		element.fontSize = 30
-		element.fontFamily = 'Inter'
+		element.fontFamily = 'Arial'
 		element.fontWeight = 'normal'
 		element.color = guessTextColorFromBackground(slideColor)
 		element.lineHeight = 1
@@ -79,15 +96,15 @@ const addTextElement = (text) => {
 		element.opacity = 100
 	}
 	slide.value.elements.push(element)
-	nextTick(() => setActiveElements([element.id]))
+	selectAndCenterElement(element.id)
 }
 
-const addMediaElement = (file, type) => {
+const addMediaElement = async (file, type) => {
 	let element = {
 		id: generateUniqueId(),
 		width: 300,
-		left: 200,
-		top: 75,
+		left: 0,
+		top: 0,
 		opacity: 100,
 		type: type,
 		src: file.file_url,
@@ -107,7 +124,7 @@ const addMediaElement = (file, type) => {
 		element.playbackRate = 1
 	}
 	slide.value.elements.push(element)
-	nextTick(() => setActiveElements([element.id]))
+	selectAndCenterElement(element.id)
 }
 
 const duplicateElements = async (e, elements, displaceByPx = 0) => {

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -181,7 +181,8 @@ const deleteElements = async (e) => {
 	})
 }
 
-const selectAllElements = () => {
+const selectAllElements = (e) => {
+	e.preventDefault()
 	activeElementIds.value = slide.value.elements.map((element) => element.id)
 }
 

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -122,6 +122,8 @@ const updateSelectionBounds = (newBounds) => {
 const guideVisibilityMap = reactive({
 	centerX: false,
 	centerY: false,
+	leftEdge: false,
+	rightEdge: false,
 })
 
 export {

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -124,6 +124,8 @@ const guideVisibilityMap = reactive({
 	centerY: false,
 	leftEdge: false,
 	rightEdge: false,
+	topEdge: false,
+	bottomEdge: false,
 })
 
 export {

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -113,7 +113,10 @@ const saveChanges = async () => {
 const slideBounds = reactive({})
 
 const updateSelectionBounds = (newBounds) => {
-	Object.assign(selectionBounds, newBounds)
+	const roundedBounds = Object.fromEntries(
+		Object.entries(newBounds).map(([key, value]) => [key, Math.round(value)]),
+	)
+	Object.assign(selectionBounds, roundedBounds)
 }
 
 export {

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -119,11 +119,17 @@ const updateSelectionBounds = (newBounds) => {
 	Object.assign(selectionBounds, roundedBounds)
 }
 
+const guideVisibilityMap = reactive({
+	centerX: false,
+	centerY: false,
+})
+
 export {
 	slideIndex,
 	slide,
 	slideBounds,
 	selectionBounds,
+	guideVisibilityMap,
 	loadSlide,
 	updateSlideState,
 	saveChanges,

--- a/frontend/src/utils/snap.js
+++ b/frontend/src/utils/snap.js
@@ -12,8 +12,8 @@ export const useSnapping = (target, parent) => {
 	let snapTimeout = null
 
 	const diffs = reactive({
-		vertical: 0,
-		horizontal: 0,
+		centerX: 0,
+		centerY: 0,
 		left: 0,
 		right: 0,
 		top: 0,
@@ -21,8 +21,8 @@ export const useSnapping = (target, parent) => {
 	})
 
 	const prevDiffs = reactive({
-		vertical: 0,
-		horizontal: 0,
+		centerX: 0,
+		centerY: 0,
 		left: 0,
 		right: 0,
 		top: 0,
@@ -32,8 +32,8 @@ export const useSnapping = (target, parent) => {
 	const visibilityMap = computed(() => {
 		if (!target.value) return
 		return {
-			vertical: Math.abs(diffs.vertical) < CENTER_PROXIMITY_THRESHOLD,
-			horizontal: Math.abs(diffs.horizontal) < CENTER_PROXIMITY_THRESHOLD,
+			centerX: Math.abs(diffs.centerX) < CENTER_PROXIMITY_THRESHOLD,
+			centerY: Math.abs(diffs.centerY) < CENTER_PROXIMITY_THRESHOLD,
 			left: Math.abs(diffs.left) < PROXIMITY_THRESHOLD,
 			right: Math.abs(diffs.right) < PROXIMITY_THRESHOLD,
 			top: Math.abs(diffs.top) < PROXIMITY_THRESHOLD,
@@ -45,7 +45,7 @@ export const useSnapping = (target, parent) => {
 		if (!target.value) return
 		let slideCenter, elementCenter
 
-		if (axis == 'X') {
+		if (axis == 'Y') {
 			const elementLeft = selectionBounds.left * slideBounds.scale + slideBounds.left
 			const elementWidth = selectionBounds.width * slideBounds.scale
 
@@ -125,15 +125,10 @@ export const useSnapping = (target, parent) => {
 	const updateGuides = () => {
 		if (!target.value) return
 
-		prevDiffs.vertical = diffs.vertical
-		prevDiffs.horizontal = diffs.horizontal
-		prevDiffs.left = diffs.left
-		prevDiffs.right = diffs.right
-		prevDiffs.top = diffs.top
-		prevDiffs.bottom = diffs.bottom
+		Object.assign(prevDiffs, diffs)
 
-		diffs.vertical = getDiffFromCenter('Y')
-		diffs.horizontal = getDiffFromCenter('X')
+		diffs.centerX = getDiffFromCenter('X')
+		diffs.centerY = getDiffFromCenter('Y')
 
 		setPairedDiffs()
 	}
@@ -143,7 +138,7 @@ export const useSnapping = (target, parent) => {
 		const prevDiff = prevDiffs[axis]
 
 		let threshold, margin
-		if (['horizontal', 'vertical'].includes(axis)) {
+		if (['centerX', 'centerY'].includes(axis)) {
 			threshold = CENTER_PROXIMITY_THRESHOLD
 			margin = 2
 		} else {
@@ -188,8 +183,8 @@ export const useSnapping = (target, parent) => {
 
 	const getCenterOffsets = () => {
 		return {
-			offsetX: applySnapMovement('horizontal'),
-			offsetY: applySnapMovement('vertical'),
+			offsetX: applySnapMovement('centerY'),
+			offsetY: applySnapMovement('centerX'),
 		}
 	}
 


### PR DESCRIPTION
### Description

- Added current X and Y co-ordinates in the properties panel.

- Added the ability to automatically place items at the left edge, center (X axis) and right edge based on the selected option from the Horizontal Alignment options. Similar for the Y axis - top edge, center (Y axis) and bottom edge.

- Added extra alignment guides on each of the edges. Apart from the guides showing up while dragging, now on hovering over any of the alignment options that particular guide gets highlighted as a visual cue for where the selection will be placed.

- The alignment controls also work for multiple selections where the entire cropped section is moved in order to align in any of the directions.

<br>

### Video

  https://github.com/user-attachments/assets/49c53b25-677d-4045-af75-1b69b45996ec

<br>

### Other Changes

  <details>
  <summary>Video</summary>
  
  <br>
    
  https://github.com/user-attachments/assets/e2f93a87-6b06-4dd6-a6ed-5cee53b5d814
  
  
  </details>

- Use dynamic values to place newly added elements in the center. Since the dimensions of the element can only be used for calculating the left and top offsets **after** rendering the element in the DOM once, it requires a nextTick to dynamically update these offsets.

- Fix z-index for guides.


