### PR TITLE
feat: dynamic resistance instead of setTimeout after snap

### DIFF
--- a/frontend/src/components/AlignmentControls.vue
+++ b/frontend/src/components/AlignmentControls.vue
@@ -120,12 +120,12 @@ const alignmentPositions = computed(() => {
 const isAligned = (direction) => {
 	const axis = ['left', 'centerY', 'right'].includes(direction) ? 'X' : 'Y'
 
-	const expectedPos = Math.round(alignmentPositions.value[direction] * 100) / 100
+	const expectedPos = Math.round(alignmentPositions.value[direction] * 10) / 10
 
 	const currentPos =
 		axis == 'X'
-			? Math.round(selectionBounds.left * 100) / 100
-			: Math.round(selectionBounds.top * 100) / 100
+			? Math.round(selectionBounds.left * 10) / 10
+			: Math.round(selectionBounds.top * 10) / 10
 
 	return expectedPos == currentPos
 }

--- a/frontend/src/components/AlignmentControls.vue
+++ b/frontend/src/components/AlignmentControls.vue
@@ -109,7 +109,7 @@ const alignmentPositions = computed(() => {
 
 	return {
 		left: 0,
-		centerY: Math.round(slideWidth / 2) - Math.round(selectionWidth / 2),
+		centerY: (slideWidth - selectionWidth) / 2,
 		right: Math.round(slideWidth) - Math.round(selectionWidth),
 		top: 0,
 		centerX: Math.round(slideHeight / 2) - Math.round(selectionHeight / 2),
@@ -120,10 +120,12 @@ const alignmentPositions = computed(() => {
 const isAligned = (direction) => {
 	const axis = ['left', 'centerY', 'right'].includes(direction) ? 'X' : 'Y'
 
-	const expectedPos = alignmentPositions.value[direction]
+	const expectedPos = Math.round(alignmentPositions.value[direction] * 100) / 100
 
 	const currentPos =
-		axis == 'X' ? Math.round(selectionBounds.left) : Math.round(selectionBounds.top)
+		axis == 'X'
+			? Math.round(selectionBounds.left * 100) / 100
+			: Math.round(selectionBounds.top * 100) / 100
 
 	return expectedPos == currentPos
 }

--- a/frontend/src/components/AlignmentControls.vue
+++ b/frontend/src/components/AlignmentControls.vue
@@ -110,10 +110,10 @@ const alignmentPositions = computed(() => {
 	return {
 		left: 0,
 		centerY: (slideWidth - selectionWidth) / 2,
-		right: Math.round(slideWidth) - Math.round(selectionWidth),
+		right: slideWidth - selectionWidth,
 		top: 0,
 		centerX: (slideHeight - selectionHeight) / 2,
-		bottom: Math.round(slideHeight) - Math.round(selectionHeight),
+		bottom: slideHeight - selectionHeight,
 	}
 })
 

--- a/frontend/src/components/AlignmentControls.vue
+++ b/frontend/src/components/AlignmentControls.vue
@@ -112,7 +112,7 @@ const alignmentPositions = computed(() => {
 		centerY: (slideWidth - selectionWidth) / 2,
 		right: Math.round(slideWidth) - Math.round(selectionWidth),
 		top: 0,
-		centerX: Math.round(slideHeight / 2) - Math.round(selectionHeight / 2),
+		centerX: (slideHeight - selectionHeight) / 2,
 		bottom: Math.round(slideHeight) - Math.round(selectionHeight),
 	}
 })

--- a/frontend/src/components/ResizeHandle.vue
+++ b/frontend/src/components/ResizeHandle.vue
@@ -8,6 +8,8 @@
 <script setup>
 import { computed } from 'vue'
 
+import { slideBounds } from '@/stores/slide'
+
 const props = defineProps({
 	direction: {
 		type: String,
@@ -28,19 +30,16 @@ const baseStyles = {
 	borderRadius: '10px',
 }
 
-const widthHandleStyles = {
-	width: '4px',
-	height: '14px',
-	cursor: 'ew-resize',
-	top: 'calc(50% - 7px)',
-}
-
 const getWidthResizerStyles = () => {
+	const offsetX = `-${3 / slideBounds.scale}px`
 	return {
 		...baseStyles,
-		...widthHandleStyles,
-		left: props.direction === 'left' ? '-3px' : 'auto',
-		right: props.direction === 'right' ? '-3px' : 'auto',
+		cursor: 'ew-resize',
+		left: props.direction === 'left' ? offsetX : 'auto',
+		right: props.direction === 'right' ? offsetX : 'auto',
+		top: `calc(50% - ${7 / slideBounds.scale}px)`,
+		width: `${4 / slideBounds.scale}px`,
+		height: `${14 / slideBounds.scale}px`,
 	}
 }
 
@@ -52,15 +51,18 @@ const getDimensionResizerStyles = () => {
 		'bottom-left': 'nesw-resize',
 		'bottom-right': 'nwse-resize',
 	}
-	const offset = props.currentResizer ? '-5px' : '-4.5px'
+	const offset = props.currentResizer
+		? `-${5 / slideBounds.scale}px`
+		: `-${4.5 / slideBounds.scale}px`
+	const size = props.currentResizer ? `${10 / slideBounds.scale}px` : `${7 / slideBounds.scale}px`
 	return {
 		...baseStyles,
 		top: resizer.includes('top') ? offset : 'auto',
 		bottom: resizer.includes('bottom') ? offset : 'auto',
 		left: resizer.includes('left') ? offset : 'auto',
 		right: resizer.includes('right') ? offset : 'auto',
-		width: props.currentResizer ? '10px' : '7px',
-		height: props.currentResizer ? '10px' : '7px',
+		width: size,
+		height: size,
 		cursor: cursorStyles[resizer],
 	}
 }

--- a/frontend/src/components/Resizer.vue
+++ b/frontend/src/components/Resizer.vue
@@ -62,7 +62,7 @@ const getScaledValue = (value) => `${value / slideBounds.scale}px`
 
 const getTextIndicatorPosition = () => {
 	const resizer = currentResizer.value
-	const offsetX = getScaledValue(selectionBounds.width + 20)
+	const offsetX = `${20 / slideBounds.scale + selectionBounds.width}px`
 	const offsetY = getScaledValue(12)
 
 	return {

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -224,20 +224,23 @@ const togglePanZoom = () => {
 	allowPanAndZoom.value = !allowPanAndZoom.value
 }
 
+const applyResistance = (axis, delta) => {
+	const val = axis == 'X' ? delta.x : delta.y
+	return resistanceMap[axis] && Math.abs(val) < 3
+}
+
 const getTotalPositionDelta = (delta) => {
 	const snapDelta = getSnapDelta()
 
-	let left = delta.x
-	let top = delta.y
+	const left = snapDelta.x || delta.x
+	const top = snapDelta.y || delta.y
 
-	if (snapDelta.x) {
-		left = snapDelta.x
-	}
-	const final_left = resistanceMap['X'] && Math.abs(delta.x) < 3 ? 0 : left
+	const final_left = applyResistance('X', delta) ? 0 : left
+	const final_top = applyResistance('Y', delta) ? 0 : top
 
 	return {
 		left: final_left,
-		top: delta.y,
+		top: final_top,
 	}
 }
 

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -71,7 +71,7 @@ const { isDragging, positionDelta, startDragging } = useDragAndDrop()
 
 const { dimensionDelta, currentResizer, resizeCursor, startResize } = useResizer()
 
-const { visibilityMap, updateGuides, disableMovement, getSnapDelta } = useSnapping(
+const { visibilityMap, resistanceMap, updateGuides, getSnapDelta } = useSnapping(
 	selectionBoxRef,
 	slideRef,
 )
@@ -227,22 +227,28 @@ const togglePanZoom = () => {
 const getTotalPositionDelta = (delta) => {
 	const snapDelta = getSnapDelta()
 
+	let left = delta.x
+	let top = delta.y
+
+	if (snapDelta.x) {
+		left = snapDelta.x
+	}
+	const final_left = resistanceMap['X'] && Math.abs(delta.x) < 3 ? 0 : left
+
 	return {
-		left: delta.x + snapDelta.x,
-		top: delta.y + snapDelta.y,
+		left: final_left,
+		top: delta.y,
 	}
 }
 
 const handlePositionChange = (delta) => {
 	updateGuides()
 
-	if (!disableMovement.value) {
-		const totalDelta = getTotalPositionDelta(delta)
-		updateSelectionBounds({
-			left: selectionBounds.left + totalDelta.left / scale.value,
-			top: selectionBounds.top + totalDelta.top / scale.value,
-		})
-	}
+	const totalDelta = getTotalPositionDelta(delta)
+	updateSelectionBounds({
+		left: selectionBounds.left + totalDelta.left / scale.value,
+		top: selectionBounds.top + totalDelta.top / scale.value,
+	})
 }
 
 const applyAspectRatio = (offset) => {

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -225,8 +225,20 @@ const togglePanZoom = () => {
 }
 
 const applyResistance = (axis, delta) => {
-	const val = axis == 'X' ? delta.x : delta.y
-	return resistanceMap[axis] && Math.abs(val) < 3
+	const escapeDelta = 3
+
+	let useResistance = false
+	let pullDelta = null
+
+	if (axis == 'X') {
+		useResistance = resistanceMap.left || resistanceMap.right || resistanceMap.centerY
+		pullDelta = delta.x
+	} else if (axis == 'Y') {
+		useResistance = resistanceMap.top || resistanceMap.bottom || resistanceMap.centerX
+		pullDelta = delta.y
+	}
+
+	return useResistance && Math.abs(pullDelta) < escapeDelta
 }
 
 const getTotalPositionDelta = (delta) => {

--- a/frontend/src/components/SlideElement.vue
+++ b/frontend/src/components/SlideElement.vue
@@ -44,9 +44,9 @@ const elementDivRef = useTemplateRef('elementDiv')
 const outline = computed(() => {
 	switch (props.outline) {
 		case 'primary':
-			return '#70B6F0 solid 2px'
+			return `#70B6F0 solid ${2 / slideBounds.scale}px`
 		case 'secondary':
-			return '#70b6f080 solid 2px'
+			return `#70B6F0 solid ${2 / slideBounds.scale}px`
 		default:
 			return props.outline
 	}

--- a/frontend/src/components/controls/NumberInput.vue
+++ b/frontend/src/components/controls/NumberInput.vue
@@ -6,7 +6,7 @@
 		<input
 			type="number"
 			:class="inputClasses"
-			:value="parseFloat(parseFloat(modelValue).toFixed(2))"
+			:value="Math.round(modelValue)"
 			@change="changeValue"
 		/>
 		<div v-if="suffix" class="w-1/2 text-center text-xs font-medium text-gray-500">

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -58,8 +58,8 @@ const selectAndCenterElement = (elementId) => {
 			const elementHeight = elementRect.height / slideBounds.scale
 
 			updateSelectionBounds({
-				left: (slideWidth - elementWidth - 0.1) / 2,
-				top: (slideHeight - elementHeight - 0.1) / 2,
+				left: (slideWidth - elementWidth) / 2,
+				top: (slideHeight - elementHeight) / 2,
 			})
 		})
 	})

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -42,8 +42,8 @@ const setActiveElements = (ids, focus = false) => {
 }
 
 const selectAndCenterElement = (elementId) => {
-	const slideWidth = Math.round(slideBounds.width / slideBounds.scale)
-	const slideHeight = Math.round(slideBounds.height / slideBounds.scale)
+	const slideWidth = slideBounds.width / slideBounds.scale
+	const slideHeight = slideBounds.height / slideBounds.scale
 
 	nextTick(() => {
 		setActiveElements([elementId])
@@ -54,8 +54,8 @@ const selectAndCenterElement = (elementId) => {
 				.querySelector(`[data-index="${elementId}"]`)
 				.getBoundingClientRect()
 
-			const elementWidth = Math.round(elementRect.width / slideBounds.scale)
-			const elementHeight = Math.round(elementRect.height / slideBounds.scale)
+			const elementWidth = elementRect.width / slideBounds.scale
+			const elementHeight = elementRect.height / slideBounds.scale
 
 			updateSelectionBounds({
 				left: (slideWidth - elementWidth - 0.1) / 2,

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -114,7 +114,7 @@ const slideBounds = reactive({})
 
 const updateSelectionBounds = (newBounds) => {
 	const roundedBounds = Object.fromEntries(
-		Object.entries(newBounds).map(([key, value]) => [key, Math.round(value)]),
+		Object.entries(newBounds).map(([key, value]) => [key, Math.round(value * 100) / 100]),
 	)
 	Object.assign(selectionBounds, roundedBounds)
 }

--- a/frontend/src/utils/snap.js
+++ b/frontend/src/utils/snap.js
@@ -156,7 +156,7 @@ export const useSnapping = (target, parent) => {
 		})
 	}
 
-	const updateGuides = () => {
+	const updateDiffs = () => {
 		if (!target.value) return
 
 		Object.assign(prevDiffs, diffs)
@@ -272,10 +272,17 @@ export const useSnapping = (target, parent) => {
 		}
 	}
 
+	const handleSnapping = () => {
+		// update diffs based on current position
+		updateDiffs()
+
+		// return delta to apply for closest snap
+		return getSnapDelta()
+	}
+
 	return {
 		visibilityMap,
 		resistanceMap,
-		updateGuides,
-		getSnapDelta,
+		handleSnapping,
 	}
 }

--- a/frontend/src/utils/snap.js
+++ b/frontend/src/utils/snap.js
@@ -83,9 +83,9 @@ export const useSnapping = (target, parent) => {
 	const canElementPair = (diffsFromElement) => {
 		if (!diffsFromElement) return false
 
-		return Object.values(diffsFromElement).some((direction, diff) => {
+		return Object.entries(diffsFromElement).some(([direction, diff]) => {
 			const threshold = getDynamicThresholds(direction).threshold
-			return Math.abs(diff) < threshold
+			return diff !== null && Math.abs(diff) < threshold
 		})
 	}
 

--- a/frontend/src/utils/snap.js
+++ b/frontend/src/utils/snap.js
@@ -3,12 +3,7 @@ import { selectionBounds, slide, slideBounds } from '../stores/slide'
 import { activeElementIds, pairElementId } from '../stores/element'
 
 export const useSnapping = (target, parent) => {
-	const PROXIMITY_THRESHOLD = 8
-
 	const snapMovement = ref({ x: 0, y: 0 })
-
-	const hasSnapped = ref(false)
-	let snapTimeout = null
 
 	const diffs = reactive({
 		centerX: null,
@@ -34,6 +29,9 @@ export const useSnapping = (target, parent) => {
 			centerX: Math.abs(diffs.centerX) < getDynamicThresholds('centerX').threshold,
 			centerY: Math.abs(diffs.centerY) < getDynamicThresholds('centerY').threshold,
 			left: Math.abs(diffs.left) < getDynamicThresholds('left').threshold,
+			right: Math.abs(diffs.right) < getDynamicThresholds('right').threshold,
+			top: Math.abs(diffs.top) < getDynamicThresholds('top').threshold,
+			bottom: Math.abs(diffs.bottom) < getDynamicThresholds('bottom').threshold,
 		}
 	})
 
@@ -59,7 +57,12 @@ export const useSnapping = (target, parent) => {
 	}
 
 	const canElementPair = (diffLeft, diffRight, diffTop, diffBottom) => {
-		return Math.abs(diffLeft) < getDynamicThresholds('left').threshold
+		return (
+			Math.abs(diffLeft) < getDynamicThresholds('left').threshold ||
+			Math.abs(diffRight) < getDynamicThresholds('right').threshold ||
+			Math.abs(diffTop) < getDynamicThresholds('top').threshold ||
+			Math.abs(diffBottom) < getDynamicThresholds('bottom').threshold
+		)
 	}
 
 	const getActiveElementBounds = () => {
@@ -161,8 +164,9 @@ export const useSnapping = (target, parent) => {
 
 	const handleSnapMovement = (axis) => {
 		const isMovingAway = () => {
-			// If current diff is greater, element is moving away
 			if (diff == null || prevDiff == null) return false
+
+			// If current diff is greater, element is moving away
 			const currDiffGreater = Math.abs(diff) >= Math.abs(prevDiff)
 
 			// If element just snapped, the prev diff is the threshold point
@@ -185,9 +189,13 @@ export const useSnapping = (target, parent) => {
 		}
 
 		const { diff, prevDiff } = getDiffsForAxis(axis)
+
 		const { threshold, resistance_threshold, margin } = getThresholdsAndMargin(axis)
+
 		const movingAway = isMovingAway()
+
 		setResistanceMap()
+
 		return getSnapOffset()
 	}
 

--- a/frontend/src/utils/snap.js
+++ b/frontend/src/utils/snap.js
@@ -139,13 +139,13 @@ export const useSnapping = (target, parent) => {
 
 	const getDynamicThreshold = (axis) => {
 		const scaleFactor = 0.1
-		const scaled = selectionBounds.width * slideBounds.scale * scaleFactor
-		const minThreshold = ['centerX', 'centerY'].includes(axis) ? scaled / 2 : 5
-		const maxThreshold = ['centerX', 'centerY'].includes(axis) ? scaled * 2 : 50
+		const scaledWidth = selectionBounds.width * slideBounds.scale * scaleFactor
+		const minThreshold = ['centerX', 'centerY'].includes(axis) ? scaledWidth / 2 : 5
+		const maxThreshold = ['centerX', 'centerY'].includes(axis) ? scaledWidth * 2 : 50
 
 		return {
-			threshold: Math.max(minThreshold, Math.min(maxThreshold, scaled)),
-			resistance_threshold: scaled * 0.15,
+			threshold: Math.max(minThreshold, Math.min(maxThreshold, scaledWidth)),
+			resistance_threshold: scaledWidth * 0.15,
 		}
 	}
 
@@ -182,6 +182,7 @@ export const useSnapping = (target, parent) => {
 		}
 
 		const setResistanceMap = () => {
+			if (!['centerX', 'centerY'].includes(axis)) return
 			const direction = axis == 'centerY' ? 'X' : 'Y'
 			const withinResistanceRange = movingAway && Math.abs(diff) < resistance_threshold
 

--- a/frontend/src/utils/snap.js
+++ b/frontend/src/utils/snap.js
@@ -132,12 +132,16 @@ export const useSnapping = (target, parent) => {
 	const unpairElement = () => {
 		pairElementId.value = null
 
-		Object.assign(diffs, {
-			left: null,
-			right: null,
-			top: null,
-			bottom: null,
-		})
+		const resetDiffs = () => {
+			return ['left', 'right', 'top', 'bottom'].reduce((map, direction) => {
+				map[direction] = null
+				return map
+			}, {})
+		}
+
+		Object.assign(diffs, resetDiffs())
+		Object.assign(resistanceMap, resetDiffs())
+		Object.assign(prevDiffs, resetDiffs())
 	}
 
 	const setPairedDiffs = () => {
@@ -232,23 +236,27 @@ export const useSnapping = (target, parent) => {
 		}
 	}
 
+	const getOffset = (axis) => {
+		let start, end
+
+		if (axis == 'X') {
+			start = 'left'
+			end = 'right'
+		} else {
+			start = 'top'
+			end = 'bottom'
+		}
+
+		if (Math.abs(diffs[end]) < Math.abs(diffs[start])) return handleSnapMovement(end)
+
+		return handleSnapMovement(start)
+	}
+
 	const getPairedOffsets = () => {
-		let offsetLeft = 0,
-			offsetTop = 0
-
-		if (Math.abs(diffs.right) < Math.abs(diffs.left)) {
-			offsetLeft = handleSnapMovement('right')
-		} else {
-			offsetLeft = handleSnapMovement('left')
+		return {
+			offsetLeft: getOffset('X'),
+			offsetTop: getOffset('Y'),
 		}
-
-		if (Math.abs(diffs.bottom) < Math.abs(diffs.top)) {
-			offsetTop = handleSnapMovement('bottom')
-		} else {
-			offsetTop = handleSnapMovement('top')
-		}
-
-		return { offsetLeft, offsetTop }
 	}
 
 	const getSnapDelta = () => {


### PR DESCRIPTION
### Changes

Remove the snapping implementation that used setTimeout to introduce slight delay after snap so that the element stays at the snapped position. 

#### Before 

- Element movement felt janky.
- Precision of snapped position was slightly off.
- Mouse cursor became out of sync due to user pulling the cursor away but movement being disabled due to setTimeout.

#### After

- Use dynamically calculated threshold depending on element size to introduce some resistance right after snapping. This feels a tad bit smoother for now.
- Fixed a few precision issues in order to correct final position.
- Mismatch between currrent cursor position and expected element position reduced a little after removing setTimeout.

### Other

- Use dynamic margins and thresholds even for triggering the snap at different scales.
- Change Resize Handle sizes based on zoom.
- Fix resize indicator offset for different scales.