### PR TITLE
feat: decode base64 thumbnails as attachments 

### DIFF
--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -28,7 +28,7 @@
 
 	<DropTargetOverlay v-show="mediaDragOver" @hideOverlay="hideOverlay" />
 
-	<OverflowContentOverlay v-if="!activeElementIds.length" />
+	<OverflowContentOverlay />
 </template>
 
 <script setup>

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -94,7 +94,6 @@ const targetStyles = computed(() => ({
 
 const slideStyles = computed(() => ({
 	backgroundColor: slide.value.background || 'white',
-	'--showEdgeOverlay': !activeElementIds.value.length ? 'block' : 'none',
 	cursor: isDragging.value ? 'move' : resizeCursor.value || 'default',
 }))
 

--- a/frontend/src/components/TextProperties.vue
+++ b/frontend/src/components/TextProperties.vue
@@ -60,7 +60,7 @@
 						v-model="activeElement.fontSize"
 						suffix="px"
 						:rangeStart="5"
-						:rangeEnd="100"
+						:rangeEnd="800"
 						:rangeStep="1"
 					/>
 				</div>

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -321,7 +321,7 @@ const resetSlideState = () => {
 		elements: [],
 		background: '',
 		transition: '',
-		transitionDuration: 0,
+		transitionDuration: '0',
 	}
 }
 

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -65,6 +65,11 @@ const getThumbnailHtml = () => {
 	clone.querySelectorAll('*').forEach((element) => {
 		if (element.hasAttribute('data-index')) {
 			element.style.position = 'absolute'
+			// compensate for baseline alignment done by html2canvas for text
+			if (element.firstChild.hasAttribute('contenteditable')) {
+				const offsetTop = element.firstChild.style.fontSize.replace('px', '') * 0.4
+				element.style.top = `${parseFloat(element.style.top) - offsetTop}px`
+			}
 		}
 	})
 

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -52,13 +52,36 @@ const isSlideDirty = () => {
 	return !isEqual(data, updatedData)
 }
 
-const getSlideThumbnail = async () => {
+const getThumbnailHtml = () => {
 	const slideRef = document.querySelector('.slide')
-	const scale = slideRef.getBoundingClientRect().width / 960
-	if (scale !== 1) {
-		return slide.value.thumbnail
-	}
-	const canvas = await html2canvas(slideRef)
+
+	const clone = slideRef.cloneNode(true)
+
+	clone.style.position = 'absolute'
+	clone.style.left = '-9999px'
+	clone.style.top = '0'
+	clone.style.transform = 'scale(1)'
+
+	clone.querySelectorAll('*').forEach((element) => {
+		if (element.hasAttribute('data-index')) {
+			element.style.position = 'absolute'
+		}
+	})
+
+	return clone
+}
+
+const getSlideThumbnail = async () => {
+	const thumbnailHtml = getThumbnailHtml()
+
+	document.body.appendChild(thumbnailHtml)
+
+	const canvas = await html2canvas(thumbnailHtml, {
+		scale: window.devicePixelRatio,
+	})
+
+	document.body.removeChild(thumbnailHtml)
+
 	return canvas.toDataURL('image/png')
 }
 

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -107,6 +107,8 @@ const saveChanges = async () => {
 		doc: presentation.data,
 	})
 
+	slide.value.thumbnail = presentation.data.slides[slideIndex.value].thumbnail
+
 	await presentation.reload()
 }
 

--- a/slides/slides/doctype/presentation/presentation.py
+++ b/slides/slides/doctype/presentation/presentation.py
@@ -11,7 +11,7 @@ import frappe
 from frappe.model.document import Document
 
 
-def save_base64_thumbnail(base64_data):
+def save_base64_thumbnail(base64_data, presentation_name):
 	header, b64 = base64_data.split(",", 1)
 	ext = header.split("/")[1].split(";")[0]
 	filename = f"{uuid.uuid4().hex[:7]}.{ext}"
@@ -21,7 +21,9 @@ def save_base64_thumbnail(base64_data):
 			"doctype": "File",
 			"file_name": filename,
 			"content": base64.b64decode(b64),
-			"is_private": 0,
+			"is_private": 1,
+			"attached_to_doctype": "Presentation",
+			"attached_to_name": presentation_name,
 		}
 	).insert()
 
@@ -35,7 +37,7 @@ class Presentation(Document):
 	def validate(self):
 		for slide in self.slides:
 			if slide.thumbnail and slide.thumbnail.startswith("data:image"):
-				slide.thumbnail = save_base64_thumbnail(slide.thumbnail)
+				slide.thumbnail = save_base64_thumbnail(slide.thumbnail, self.name)
 
 
 def slug(text: str) -> str:

--- a/slides/slides/doctype/presentation/presentation.py
+++ b/slides/slides/doctype/presentation/presentation.py
@@ -37,7 +37,7 @@ def delete_old_thumbnail(old_thumbnail: str):
 			frappe.log_error(f"Failed to remove old thumbnail: {e}")
 
 
-def save_base64_thumbnail(base64_data, presentation_name):
+def save_base64_thumbnail(base64_data: str, presentation_name: str) -> str:
 	header, b64 = base64_data.split(",", 1)
 	ext = header.split("/")[1].split(";")[0]
 	filename = f"thumbnail-{uuid.uuid4().hex[:7]}.{ext}"
@@ -127,6 +127,7 @@ def insert_slide(name, index):
 @frappe.whitelist()
 def delete_slide(name, index):
 	presentation = frappe.get_doc("Presentation", name)
+	delete_old_thumbnail(presentation.slides[index].thumbnail)
 	presentation.slides = presentation.slides[:index] + presentation.slides[index + 1 :]
 	for i in range(index, len(presentation.slides)):
 		presentation.slides[i].idx -= 1

--- a/slides/slides/doctype/presentation/presentation.py
+++ b/slides/slides/doctype/presentation/presentation.py
@@ -14,7 +14,7 @@ from frappe.model.document import Document
 def save_base64_thumbnail(base64_data, presentation_name):
 	header, b64 = base64_data.split(",", 1)
 	ext = header.split("/")[1].split(";")[0]
-	filename = f"{uuid.uuid4().hex[:7]}.{ext}"
+	filename = f"thumbnail-{uuid.uuid4().hex[:7]}.{ext}"
 
 	file_doc = frappe.get_doc(
 		{

--- a/slides/slides/doctype/presentation/presentation.py
+++ b/slides/slides/doctype/presentation/presentation.py
@@ -42,7 +42,7 @@ def delete_old_thumbnail(slide_id: Document, old_thumbnail: str | None = None):
 def save_base64_thumbnail(base64_data: str, presentation_name: str) -> str:
 	header, b64 = base64_data.split(",", 1)
 	ext = header.split("/")[1].split(";")[0]
-	filename = f"thumbnail-{uuid.uuid4().hex[:7]}.{ext}"
+	filename = f"thumbnail-{uuid.uuid4().hex[:6]}.{ext}"
 
 	file_doc = frappe.get_doc(
 		{


### PR DESCRIPTION
### Changes

- Instead of saving raw base64 thumbnails, decode them into files.
- After updating the thumbnail for a specific slide, delete the unused one.
- After deleting the slide, delete the orphaned thumbnail.
- Save the thumbnails with a common prefix `thumbnail-` to distinguish them from the normal media attachments which are used for slide content.

### Other Changes 

- Save thumbnails irrespective of current scale.
- Compensate for slight mismatch in the visual position for text and generated position. This happens because `html2canvas` renders the provided html content in the canvas and the baseline position for text characters is different in that case.