### PR TITLE
feat: bullet lists

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
 	"dependencies": {
 		"@tiptap/extension-bullet-list": "^2.0.3",
 		"@tiptap/extension-color": "^2.0.3",
+		"@tiptap/extension-list-item": "^2.0.3",
 		"@tiptap/extension-text-align": "^2.0.3",
 		"@tiptap/extension-text-style": "^2.0.3",
 		"@tiptap/extension-underline": "^2.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
 		"serve": "vite preview"
 	},
 	"dependencies": {
+		"@tiptap/extension-bullet-list": "^2.0.3",
 		"@tiptap/extension-color": "^2.0.3",
 		"@tiptap/extension-text-align": "^2.0.3",
 		"@tiptap/extension-text-style": "^2.0.3",

--- a/frontend/src/components/TextElement.vue
+++ b/frontend/src/components/TextElement.vue
@@ -26,7 +26,7 @@ const element = defineModel('element', {
 
 const emit = defineEmits(['clearTimeouts'])
 
-const editor = initTextEditor(element.value.content)
+const editor = initTextEditor(element.value.content, element.value.editorMetadata)
 
 const editorStyles = computed(() => ({
 	cursor: focusElementId.value == element.value.id ? 'text' : '',

--- a/frontend/src/components/TextElement.vue
+++ b/frontend/src/components/TextElement.vue
@@ -117,4 +117,26 @@ watch(
 	top: 0.1em;
 	font-size: 1em;
 }
+
+.tiptap ol {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	counter-reset: step;
+}
+
+.tiptap ol li {
+	counter-increment: step;
+	position: relative;
+	padding-left: calc(2ch + 0.2em);
+}
+
+.tiptap ol li::before {
+	content: counter(step) '.';
+	position: absolute;
+	left: 0;
+	top: 0;
+	width: 2ch;
+	text-align: right;
+}
 </style>

--- a/frontend/src/components/TextElement.vue
+++ b/frontend/src/components/TextElement.vue
@@ -98,3 +98,23 @@ watch(
 	},
 )
 </script>
+
+<style>
+.tiptap > ul {
+	list-style: none;
+	padding-left: 0;
+}
+
+.tiptap > ul li {
+	position: relative;
+	padding-left: 0.6em;
+}
+
+.tiptap > ul li::before {
+	content: '•';
+	position: absolute;
+	left: 0;
+	top: 0.1em;
+	font-size: 1em;
+}
+</style>

--- a/frontend/src/components/TextElement.vue
+++ b/frontend/src/components/TextElement.vue
@@ -15,11 +15,9 @@ import { EditorContent } from '@tiptap/vue-3'
 import { useTextEditor } from '@/composables/useTextEditor'
 
 import { focusElementId, deleteElements, activeElement, activeElementIds } from '@/stores/element'
-import { initTextEditor } from '@/stores/tiptapSetup'
-
 import { setCursorPositionAtEnd } from '@/utils/helpers'
 
-const { activeEditor } = useTextEditor()
+const { activeEditor, initTextEditor } = useTextEditor()
 
 const element = defineModel('element', {
 	type: Object,

--- a/frontend/src/components/TextProperties.vue
+++ b/frontend/src/components/TextProperties.vue
@@ -41,20 +41,12 @@
 					</div>
 				</div>
 
-				<div
-					class="ms-2.5 flex h-full w-1/6 cursor-pointer items-center justify-center rounded-md py-2"
-					:class="{
-						'bg-gray-100 text-gray-800':
-							editorStyles.bulletList || editorStyles.orderedList,
-					}"
-					@click="updateProperty('bulletList')"
-				>
-					<ListOrdered
-						v-if="editorStyles.orderedList"
+				<div :class="listButtonClasses" @click="updateProperty('list')">
+					<component
+						:is="editorStyles.orderedList ? ListOrdered : List"
 						size="16"
-						class="cursor-pointer stroke-[1.5] text-gray-600"
+						class="stroke-[1.5] text-gray-600"
 					/>
-					<List v-else size="16" class="cursor-pointer stroke-[1.5] text-gray-600" />
 				</div>
 			</div>
 		</template>
@@ -268,6 +260,13 @@ const applyPresetTextStyles = (textStyle) => {
 
 	activeElement.value.defaultStyle = textStyle
 }
+
+const listButtonClasses = computed(() => {
+	const baseClasses =
+		'ms-2.5 flex h-full w-1/6 cursor-pointer items-center justify-center rounded py-2'
+	const isActive = editorStyles.value.bulletList || editorStyles.value.orderedList
+	return `${baseClasses} ${isActive ? 'bg-gray-100 text-gray-800' : ''}`
+})
 
 const getFontStyleButtonClasses = (property) => {
 	const baseClasses = 'cursor-pointer rounded flex items-center justify-center py-1.5'

--- a/frontend/src/components/TextProperties.vue
+++ b/frontend/src/components/TextProperties.vue
@@ -33,11 +33,7 @@
 						:class="getTabClasses(textAlign.alignValue)"
 						@click="updateProperty('textAlign', textAlign.alignValue)"
 					>
-						<component
-							:is="textAlign.icon"
-							size="16"
-							:class="getAlignIconClasses(textAlign.alignValue)"
-						/>
+						<component :is="textAlign.icon" size="16" :strokeWidth="1.5" />
 					</div>
 				</div>
 
@@ -45,7 +41,7 @@
 					<component
 						:is="editorStyles.orderedList ? ListOrdered : List"
 						size="16"
-						class="stroke-[1.5] text-gray-600"
+						:strokeWidth="1.5"
 					/>
 				</div>
 			</div>
@@ -265,7 +261,7 @@ const listButtonClasses = computed(() => {
 	const baseClasses =
 		'ms-2.5 flex h-full w-1/6 cursor-pointer items-center justify-center rounded py-2'
 	const isActive = editorStyles.bulletList || editorStyles.orderedList
-	return `${baseClasses} ${isActive ? 'bg-gray-100 text-gray-800' : ''}`
+	return `${baseClasses} ${isActive ? 'bg-gray-100 text-gray-800' : 'text-gray-600'}`
 })
 
 const getFontStyleButtonClasses = (property) => {
@@ -283,17 +279,9 @@ const getFontStyleIconClasses = (property) => {
 const getTabClasses = (alignValue) => {
 	const baseClasses = 'rounded h-full flex items-center justify-center w-1/5 cursor-pointer'
 	if (editorStyles.textAlign == alignValue) {
-		return `${baseClasses} bg-white shadow`
+		return `${baseClasses} bg-white shadow text-gray-800`
 	}
-	return baseClasses
-}
-
-const getAlignIconClasses = (alignValue) => {
-	const baseClasses = 'stroke-[1.5] text-gray-600'
-	if (editorStyles.textAlign == alignValue) {
-		return `${baseClasses} text-gray-800`
-	}
-	return baseClasses
+	return `${baseClasses} text-gray-600`
 }
 </script>
 

--- a/frontend/src/components/TextProperties.vue
+++ b/frontend/src/components/TextProperties.vue
@@ -90,7 +90,7 @@
 				:rangeStart="0.1"
 				:rangeEnd="5.0"
 				:rangeStep="0.1"
-				:modelValue="editorStyles.lineHeight"
+				:modelValue="activeElement?.editorMetadata?.lineHeight || 1"
 				@update:modelValue="(value) => updateProperty('lineHeight', parseFloat(value))"
 			/>
 

--- a/frontend/src/components/TextProperties.vue
+++ b/frontend/src/components/TextProperties.vue
@@ -42,10 +42,19 @@
 				</div>
 
 				<div
-					class="flex h-full w-1/5 items-center justify-center ps-2"
-					@click="toggleMark('bulletList')"
+					class="ms-2.5 flex h-full w-1/6 cursor-pointer items-center justify-center rounded-md py-2"
+					:class="{
+						'bg-gray-100 text-gray-800':
+							editorStyles.bulletList || editorStyles.orderedList,
+					}"
+					@click="updateProperty('bulletList')"
 				>
-					<List size="16" class="cursor-pointer stroke-[1.5] text-gray-600" />
+					<ListOrdered
+						v-if="editorStyles.orderedList"
+						size="16"
+						class="cursor-pointer stroke-[1.5] text-gray-600"
+					/>
+					<List v-else size="16" class="cursor-pointer stroke-[1.5] text-gray-600" />
 				</div>
 			</div>
 		</template>
@@ -131,6 +140,7 @@ import {
 	Strikethrough,
 	CaseUpper,
 	List,
+	ListOrdered,
 	AlignLeft,
 	AlignCenter,
 	AlignRight,

--- a/frontend/src/components/TextProperties.vue
+++ b/frontend/src/components/TextProperties.vue
@@ -264,25 +264,25 @@ const applyPresetTextStyles = (textStyle) => {
 const listButtonClasses = computed(() => {
 	const baseClasses =
 		'ms-2.5 flex h-full w-1/6 cursor-pointer items-center justify-center rounded py-2'
-	const isActive = editorStyles.value.bulletList || editorStyles.value.orderedList
+	const isActive = editorStyles.bulletList || editorStyles.orderedList
 	return `${baseClasses} ${isActive ? 'bg-gray-100 text-gray-800' : ''}`
 })
 
 const getFontStyleButtonClasses = (property) => {
 	const baseClasses = 'cursor-pointer rounded flex items-center justify-center py-1.5'
-	if (editorStyles.value[property]) {
+	if (editorStyles[property]) {
 		return `${baseClasses} bg-gray-100`
 	}
 	return baseClasses
 }
 
 const getFontStyleIconClasses = (property) => {
-	return editorStyles.value[property] ? 'text-gray-900' : 'text-gray-700'
+	return editorStyles[property] ? 'text-gray-900' : 'text-gray-700'
 }
 
 const getTabClasses = (alignValue) => {
 	const baseClasses = 'rounded h-full flex items-center justify-center w-1/5 cursor-pointer'
-	if (editorStyles.value.textAlign === alignValue) {
+	if (editorStyles.textAlign == alignValue) {
 		return `${baseClasses} bg-white shadow`
 	}
 	return baseClasses
@@ -290,7 +290,7 @@ const getTabClasses = (alignValue) => {
 
 const getAlignIconClasses = (alignValue) => {
 	const baseClasses = 'stroke-[1.5] text-gray-600'
-	if (editorStyles.value.textAlign === alignValue) {
+	if (editorStyles.textAlign == alignValue) {
 		return `${baseClasses} text-gray-800`
 	}
 	return baseClasses

--- a/frontend/src/components/TextProperties.vue
+++ b/frontend/src/components/TextProperties.vue
@@ -23,20 +23,29 @@
 				</button>
 			</div>
 
-			<div
-				class="flex h-8 w-full items-center justify-between rounded-[10px] border bg-gray-100 p-0.5"
-			>
+			<div class="flex items-center justify-between">
 				<div
-					v-for="textAlign in textAlignProperties"
-					:key="textAlign.alignValue"
-					:class="getTabClasses(textAlign.alignValue)"
-					@click="updateProperty('textAlign', textAlign.alignValue)"
+					class="flex h-8 w-4/5 items-center justify-between rounded-[10px] border bg-gray-100 p-0.5"
 				>
-					<component
-						:is="textAlign.icon"
-						size="16"
-						:class="getAlignIconClasses(textAlign.alignValue)"
-					/>
+					<div
+						v-for="textAlign in textAlignProperties"
+						:key="textAlign.alignValue"
+						:class="getTabClasses(textAlign.alignValue)"
+						@click="updateProperty('textAlign', textAlign.alignValue)"
+					>
+						<component
+							:is="textAlign.icon"
+							size="16"
+							:class="getAlignIconClasses(textAlign.alignValue)"
+						/>
+					</div>
+				</div>
+
+				<div
+					class="flex h-full w-1/5 items-center justify-center ps-2"
+					@click="toggleMark('bulletList')"
+				>
+					<List size="16" class="cursor-pointer stroke-[1.5] text-gray-600" />
 				</div>
 			</div>
 		</template>
@@ -263,7 +272,7 @@ const getFontStyleIconClasses = (property) => {
 }
 
 const getTabClasses = (alignValue) => {
-	const baseClasses = 'rounded h-full flex items-center justify-center w-1/6 cursor-pointer'
+	const baseClasses = 'rounded h-full flex items-center justify-center w-1/5 cursor-pointer'
 	if (editorStyles.value.textAlign === alignValue) {
 		return `${baseClasses} bg-white shadow`
 	}

--- a/frontend/src/composables/useTextEditor.js
+++ b/frontend/src/composables/useTextEditor.js
@@ -64,9 +64,10 @@ export const useTextEditor = () => {
 		const chain = currentEditor.chain().focus()
 
 		const { empty } = currentEditor.state.selection
-		if (empty) chain.selectAll()
+		if (empty && property != 'bulletList') chain.selectAll()
 
 		if (property == 'uppercase') return toggleCapitalize(chain)
+		if (property == 'bulletList') return chain.toggleBulletList().run()
 
 		chain[markCommands[property]](property).run()
 	}

--- a/frontend/src/composables/useTextEditor.js
+++ b/frontend/src/composables/useTextEditor.js
@@ -208,6 +208,7 @@ export const useTextEditor = () => {
 			editable: false,
 			content: content,
 			onTransaction: ({ transaction, editor }) => update({ transaction, editor }),
+			onSelectionUpdate: ({ editor }) => update({ transaction: editor.state.tr, editor }),
 		})
 	}
 

--- a/frontend/src/composables/useTextEditor.js
+++ b/frontend/src/composables/useTextEditor.js
@@ -152,27 +152,6 @@ export const useTextEditor = () => {
 		return currentStyle ? `${currentStyle}; ${newStyle}` : newStyle
 	}
 
-	const changeListMarkers = (property, value) => {
-		activeEditor.value.commands.command(({ tr, state }) => {
-			const listItemType = state.schema.nodes.listItem
-
-			tr.doc.descendants((node, pos) => {
-				if (node.type === listItemType) {
-					const currentStyle = typeof node.attrs.style == 'string' ? node.attrs.style : ''
-
-					const newStyle = getCSSString(currentStyle, property, value)
-
-					tr.setNodeMarkup(pos, listItemType, {
-						...node.attrs,
-						style: newStyle,
-					})
-				}
-			})
-
-			return true
-		})
-	}
-
 	const setListProperty = () => {
 		if (!activeEditor.value.isEditable) selectListBlock()
 

--- a/frontend/src/composables/useTextEditor.js
+++ b/frontend/src/composables/useTextEditor.js
@@ -29,6 +29,8 @@ export const useTextEditor = () => {
 			italic: editor.isActive('italic'),
 			strike: editor.isActive('strike'),
 			underline: editor.isActive('underline'),
+			bulletList: editor.isActive('bulletList'),
+			orderedList: editor.isActive('orderedList'),
 			uppercase: activeStyles.textTransform == 'uppercase',
 			textAlign: editor.getAttributes('paragraph').textAlign || 'left',
 			fontSize: parseInt(activeStyles.fontSize, 10) || null,
@@ -64,18 +66,29 @@ export const useTextEditor = () => {
 		const chain = currentEditor.chain().focus()
 
 		const { empty } = currentEditor.state.selection
-		if (empty && property != 'bulletList') chain.selectAll()
+		if (empty) chain.selectAll()
 
 		if (property == 'uppercase') return toggleCapitalize(chain)
-		if (property == 'bulletList') return chain.toggleBulletList().run()
 
 		chain[markCommands[property]](property).run()
+	}
+
+	const setListProperty = (chain) => {
+		if (editorStyles.value.bulletList) {
+			chain.toggleBulletList().toggleOrderedList().run()
+		} else if (editorStyles.value.orderedList) {
+			chain.toggleOrderedList().run()
+		} else {
+			chain.toggleBulletList().run()
+		}
 	}
 
 	const updateProperty = (property, value) => {
 		const currentEditor = activeEditor.value
 
 		const chain = currentEditor.chain().focus()
+
+		if (property == 'bulletList') return setListProperty(chain)
 
 		const { empty } = currentEditor.state.selection
 		if (empty) chain.selectAll()

--- a/frontend/src/composables/useTextEditor.js
+++ b/frontend/src/composables/useTextEditor.js
@@ -88,7 +88,7 @@ export const useTextEditor = () => {
 
 		const chain = currentEditor.chain().focus()
 
-		if (property == 'bulletList') return setListProperty(chain)
+		if (property == 'list') return setListProperty(chain)
 
 		const { empty } = currentEditor.state.selection
 		if (empty) chain.selectAll()

--- a/frontend/src/composables/useTextEditor.js
+++ b/frontend/src/composables/useTextEditor.js
@@ -16,6 +16,8 @@ export const useTextEditor = () => {
 		lineHeight: null,
 		letterSpacing: null,
 		opacity: null,
+		bulletList: false,
+		orderedList: false,
 	})
 
 	const update = () => {
@@ -112,12 +114,23 @@ export const useTextEditor = () => {
 		})
 	}
 
+	const initListMarkers = (chain) => {
+		changeListMarkers('fontSize', editorStyles.value.fontSize)
+		changeListMarkers('fontFamily', editorStyles.value.fontFamily)
+		changeListMarkers('color', editorStyles.value.color)
+		changeListMarkers('opacity', editorStyles.value.opacity)
+	}
+
 	const updateProperty = (property, value) => {
 		const currentEditor = activeEditor.value
 
 		const chain = currentEditor.chain().focus()
 
-		if (property == 'list') return setListProperty(chain)
+		if (property == 'list') {
+			setListProperty(chain)
+			initListMarkers(chain)
+			return
+		}
 
 		const { empty } = currentEditor.state.selection
 		if (empty) chain.selectAll()

--- a/frontend/src/composables/useTextEditor.js
+++ b/frontend/src/composables/useTextEditor.js
@@ -173,13 +173,17 @@ export const useTextEditor = () => {
 		})
 	}
 
-	const setListProperty = (chain) => {
+	const setListProperty = () => {
 		if (!activeEditor.value.isEditable) selectListBlock()
 
-		if (!activeEditor.value.isActive('orderedList')) {
-			activeEditor.value.chain().focus().wrapInList('orderedList').run()
+		const chain = activeEditor.value.chain().focus()
+
+		if (activeEditor.value.isActive('orderedList')) {
+			chain.liftListItem('listItem').run()
+		} else if (activeEditor.value.isActive('bulletList')) {
+			chain.liftListItem('listItem').wrapInList('orderedList').run()
 		} else {
-			activeEditor.value.chain().focus().liftListItem('listItem').run()
+			chain.wrapInList('bulletList').run()
 		}
 	}
 
@@ -188,7 +192,7 @@ export const useTextEditor = () => {
 
 		const chain = currentEditor.chain().focus()
 
-		if (property == 'list') return setListProperty(chain)
+		if (property == 'list') return setListProperty()
 
 		const { empty } = currentEditor.state.selection
 		if (empty) chain.selectAll()

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -80,7 +80,6 @@ const getElementContent = (element) => {
 									fontSize: element.fontSize,
 									fontFamily: element.fontFamily,
 									color: element.color,
-									lineHeight: 1,
 									letterSpacing: 0,
 									opacity: 100,
 								},
@@ -108,6 +107,9 @@ const addTextElement = async (text) => {
 		top: 0,
 		type: 'text',
 		content: getElementContent(elementPresets),
+		editorMetadata: {
+			lineHeight: 1,
+		},
 	}
 
 	slide.value.elements.push(element)

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -99,16 +99,10 @@ export const extensions = [
 	}),
 	PastePlainText,
 	BulletList.configure({
-		HTMLAttributes: {
-			class: 'list-disc pl-6',
-		},
 		keepAttributes: true,
 		keepMarks: true,
 	}),
 	OrderedList.configure({
-		HTMLAttributes: {
-			class: 'list-decimal pl-6',
-		},
 		keepAttributes: true,
 		keepMarks: true,
 	}),

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -85,38 +85,32 @@ const CustomListItem = ListItem.extend({
 	},
 })
 
-export const initTextEditor = (content) => {
-	return new Editor({
-		extensions: [
-			StarterKit.configure({
-				bulletList: false,
-				orderedList: false,
-				listItem: false,
-			}),
-			CustomTextStyle,
-			Underline,
-			Color,
-			TextAlign.configure({
-				types: ['paragraph'],
-			}),
-			PastePlainText,
-			BulletList.configure({
-				HTMLAttributes: {
-					class: 'list-disc pl-6',
-				},
-				keepAttributes: true,
-				keepMarks: true,
-			}),
-			OrderedList.configure({
-				HTMLAttributes: {
-					class: 'list-decimal pl-6',
-				},
-				keepAttributes: true,
-				keepMarks: true,
-			}),
-			CustomListItem,
-		],
-		editable: false,
-		content: content,
-	})
-}
+export const extensions = [
+	StarterKit.configure({
+		bulletList: false,
+		orderedList: false,
+		listItem: false,
+	}),
+	CustomTextStyle,
+	Underline,
+	Color,
+	TextAlign.configure({
+		types: ['paragraph'],
+	}),
+	PastePlainText,
+	BulletList.configure({
+		HTMLAttributes: {
+			class: 'list-disc pl-6',
+		},
+		keepAttributes: true,
+		keepMarks: true,
+	}),
+	OrderedList.configure({
+		HTMLAttributes: {
+			class: 'list-decimal pl-6',
+		},
+		keepAttributes: true,
+		keepMarks: true,
+	}),
+	CustomListItem,
+]

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -5,6 +5,7 @@ import StarterKit from '@tiptap/starter-kit'
 import TextStyle from '@tiptap/extension-text-style'
 import TextAlign from '@tiptap/extension-text-align'
 import Underline from '@tiptap/extension-underline'
+import BulletList from '@tiptap/extension-bullet-list'
 import Color from '@tiptap/extension-color'
 import { Plugin } from 'prosemirror-state'
 
@@ -71,7 +72,9 @@ const PastePlainText = Extension.create({
 export const initTextEditor = (content) => {
 	return new Editor({
 		extensions: [
-			StarterKit,
+			StarterKit.configure({
+				bulletList: false,
+			}),
 			CustomTextStyle,
 			Underline,
 			Color,
@@ -79,6 +82,11 @@ export const initTextEditor = (content) => {
 				types: ['paragraph'],
 			}),
 			PastePlainText,
+			BulletList.configure({
+				HTMLAttributes: {
+					class: 'list-disc pl-6',
+				},
+			}),
 		],
 		editable: false,
 		content: content,

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -7,6 +7,7 @@ import TextAlign from '@tiptap/extension-text-align'
 import Underline from '@tiptap/extension-underline'
 import BulletList from '@tiptap/extension-bullet-list'
 import OrderedList from '@tiptap/extension-ordered-list'
+import ListItem from '@tiptap/extension-list-item'
 import Color from '@tiptap/extension-color'
 import { Plugin } from 'prosemirror-state'
 
@@ -70,12 +71,27 @@ const PastePlainText = Extension.create({
 	},
 })
 
+const CustomListItem = ListItem.extend({
+	addAttributes() {
+		return {
+			style: {
+				default: null,
+				parseHTML: (element) => element.getAttribute('style') || null,
+				renderHTML: (attributes) => {
+					return attributes.style ? { style: attributes.style } : {}
+				},
+			},
+		}
+	},
+})
+
 export const initTextEditor = (content) => {
 	return new Editor({
 		extensions: [
 			StarterKit.configure({
 				bulletList: false,
 				orderedList: false,
+				listItem: false,
 			}),
 			CustomTextStyle,
 			Underline,
@@ -88,12 +104,17 @@ export const initTextEditor = (content) => {
 				HTMLAttributes: {
 					class: 'list-disc pl-6',
 				},
+				keepAttributes: true,
+				keepMarks: true,
 			}),
 			OrderedList.configure({
 				HTMLAttributes: {
 					class: 'list-decimal pl-6',
 				},
+				keepAttributes: true,
+				keepMarks: true,
 			}),
+			CustomListItem,
 		],
 		editable: false,
 		content: content,

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -6,6 +6,7 @@ import TextStyle from '@tiptap/extension-text-style'
 import TextAlign from '@tiptap/extension-text-align'
 import Underline from '@tiptap/extension-underline'
 import BulletList from '@tiptap/extension-bullet-list'
+import OrderedList from '@tiptap/extension-ordered-list'
 import Color from '@tiptap/extension-color'
 import { Plugin } from 'prosemirror-state'
 
@@ -74,6 +75,7 @@ export const initTextEditor = (content) => {
 		extensions: [
 			StarterKit.configure({
 				bulletList: false,
+				orderedList: false,
 			}),
 			CustomTextStyle,
 			Underline,
@@ -85,6 +87,11 @@ export const initTextEditor = (content) => {
 			BulletList.configure({
 				HTMLAttributes: {
 					class: 'list-disc pl-6',
+				},
+			}),
+			OrderedList.configure({
+				HTMLAttributes: {
+					class: 'list-decimal pl-6',
 				},
 			}),
 		],

--- a/yarn.lock
+++ b/yarn.lock
@@ -915,7 +915,7 @@
   dependencies:
     linkifyjs "^4.2.0"
 
-"@tiptap/extension-list-item@^2.26.1":
+"@tiptap/extension-list-item@^2.0.3", "@tiptap/extension-list-item@^2.26.1":
   version "2.26.1"
   resolved "https://registry.yarnpkg.com/@tiptap/extension-list-item/-/extension-list-item-2.26.1.tgz#932e041245d3a696c943e9d4a32cdf59cb386e88"
   integrity sha512-quOXckC73Luc3x+Dcm88YAEBW+Crh3x5uvtQOQtn2GEG91AshrvbnhGRiYnfvEN7UhWIS+FYI5liHFcRKSUKrQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -826,7 +826,7 @@
   dependencies:
     tippy.js "^6.3.7"
 
-"@tiptap/extension-bullet-list@^2.26.1":
+"@tiptap/extension-bullet-list@^2.0.3", "@tiptap/extension-bullet-list@^2.26.1":
   version "2.26.1"
   resolved "https://registry.yarnpkg.com/@tiptap/extension-bullet-list/-/extension-bullet-list-2.26.1.tgz#b92170ca5d0b3404599799277fd73a124e81d093"
   integrity sha512-HHakuV4ckYCDOnBbne088FvCEP4YICw+wgPBz/V2dfpiFYQ4WzT0LPK9s7OFMCN+ROraoug+1ryN1Z1KdIgujQ==


### PR DESCRIPTION
### Description
Add the ability to make unordered and ordered lists.
- The list button toggles between three states - bullets, numbers and no list.
- If a selection is made, default tiptap list handlers work. If nothing is selected, allow list types by creating a new TextSelection and setting the list style for all text blocks.
- Customize list markers (`li::before`) to inherit the styles of the text block in the `onTransaction` hook. Don't use list style position `outside` to avoid text wrapping inconsistencies.

<br> 

### Other Changes
- Add onSelectionUpdate hook to correctly update current editorStyles state which is used in the Properties Panel to highlist current styles.
- Change how line height is added to the Text Element. Do not add it as an inline style since this breaks the list styles. Add it globally for all list items. 

