### PR TITLE
feat: capture video poster on upload

### DIFF
--- a/frontend/src/components/VideoElement.vue
+++ b/frontend/src/components/VideoElement.vue
@@ -8,7 +8,6 @@
 			:playbackRate="element.playbackRate"
 			@timeupdate="updateProgress"
 			@loadedmetadata="updateDuration"
-			@loadeddata.once="initPoster"
 			@ended="resetProgress"
 			preload="auto"
 			:poster="element.poster"
@@ -45,9 +44,8 @@ import { ref, computed, useTemplateRef, inject } from 'vue'
 
 import { Play, Pause } from 'lucide-vue-next'
 
-import { inSlideShow, presentationId } from '@/stores/presentation'
+import { inSlideShow } from '@/stores/presentation'
 import { activeElementIds } from '@/stores/element'
-import { createResource } from 'frappe-ui'
 
 const element = defineModel('element', {
 	type: Object,
@@ -165,30 +163,5 @@ const handleHoverChange = (e) => {
 	} else if (e.type === 'mouseleave') {
 		hoverOver.value = false
 	}
-}
-
-const savePoster = createResource({
-	url: 'slides.slides.doctype.presentation.presentation.save_base64_thumbnail',
-	makeParams: (posterDataUrl) => ({
-		presentation_name: presentationId.value,
-		base64_data: posterDataUrl,
-		prefix: 'poster',
-	}),
-})
-
-const generatePoster = async (video) => {
-	const canvas = document.createElement('canvas')
-	canvas.width = video.videoWidth
-	canvas.height = video.videoHeight
-
-	const context = canvas.getContext('2d')
-	context.drawImage(video, 0, 0, canvas.width, canvas.height)
-	const posterDataUrl = canvas.toDataURL('image/jpeg')
-	element.value.poster = await savePoster.submit(posterDataUrl)
-}
-
-const initPoster = (e) => {
-	if (!el.value || element.value.poster) return
-	generatePoster(el.value)
 }
 </script>

--- a/frontend/src/components/VideoElement.vue
+++ b/frontend/src/components/VideoElement.vue
@@ -148,8 +148,8 @@ const seekTimestamp = (e) => {
 }
 
 const gradientOverlayStyles = computed(() => ({
-	background: `radial-gradient(circle at center, rgba(0, 0, 0, 0.4) 0%, rgba(0, 0, 0, 0.2) 5%, rgba(0, 0, 0, 0) 100%),
-	linear-gradient(to top, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.2) 20%, rgba(0, 0, 0, 0) 100%)`,
+	background: `radial-gradient(circle at center, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.1) 5%, rgba(0, 0, 0, 0) 100%),
+        linear-gradient(to top, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.1) 15%, rgba(0, 0, 0, 0) 100%)`,
 	opacity: showProgressBar.value ? 1 : 0,
 	borderRadius: `${element.value.borderRadius}px`,
 }))

--- a/frontend/src/components/VideoElement.vue
+++ b/frontend/src/components/VideoElement.vue
@@ -111,16 +111,14 @@ const progress = ref(0)
 
 const updateProgress = () => {
 	const video = el.value
-	if (duration.value) {
-		progress.value = Math.round((video.currentTime / duration.value) * 100)
-	}
+	if (!video || !duration.value) return
+	progress.value = Math.round((video.currentTime / duration.value) * 100)
 }
 
 const updateDuration = () => {
 	const video = el.value
-	if (video.duration) {
-		duration.value = video.duration
-	}
+	if (!video || !video.duration) return
+	duration.value = video.duration
 }
 
 const hoverOver = ref(false)

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -51,8 +51,23 @@ const isSlideDirty = () => {
 
 	return !isEqual(data, updatedData)
 }
+const replaceVideoWithPoster = async (videoElement) => {
+	if (!videoElement.poster) return null
 
-const getThumbnailHtml = () => {
+	const img = document.createElement('img')
+	img.src = videoElement.poster
+	img.style.width = videoElement.style.width
+	img.style.height = videoElement.style.height
+	img.style.objectFit = 'cover'
+	img.style.objectPosition = 'center'
+	img.style.position = 'absolute'
+	img.style.left = videoElement.style.left
+	img.style.top = videoElement.style.top
+
+	await videoElement.replaceWith(img)
+}
+
+const getThumbnailHtml = async () => {
 	const slideRef = document.querySelector('.slide')
 
 	const clone = slideRef.cloneNode(true)
@@ -62,7 +77,7 @@ const getThumbnailHtml = () => {
 	clone.style.top = '0'
 	clone.style.transform = 'scale(1)'
 
-	clone.querySelectorAll('*').forEach((element) => {
+	await clone.querySelectorAll('*').forEach(async (element) => {
 		if (element.hasAttribute('data-index')) {
 			element.style.position = 'absolute'
 			// compensate for baseline alignment done by html2canvas for text
@@ -71,13 +86,17 @@ const getThumbnailHtml = () => {
 				element.style.top = `${parseFloat(element.style.top) - offsetTop}px`
 			}
 		}
+
+		if (element.tagName == 'VIDEO') {
+			await replaceVideoWithPoster(element)
+		}
 	})
 
 	return clone
 }
 
 const getSlideThumbnail = async () => {
-	const thumbnailHtml = getThumbnailHtml()
+	const thumbnailHtml = await getThumbnailHtml()
 
 	document.body.appendChild(thumbnailHtml)
 

--- a/slides/slides/doctype/presentation/presentation.py
+++ b/slides/slides/doctype/presentation/presentation.py
@@ -22,7 +22,7 @@ class Presentation(Document):
 			if slide.thumbnail and slide.thumbnail.startswith("data:image"):
 				old_thumbnail = old_slides[slide.idx - 1].thumbnail
 				delete_old_thumbnail(slide.name, old_thumbnail)
-				slide.thumbnail = save_base64_thumbnail(slide.thumbnail, self.name)
+				slide.thumbnail = save_base64_thumbnail(slide.thumbnail, self.name, "thumbnail")
 
 	def validate(self):
 		self.update_thumbnails()
@@ -39,10 +39,11 @@ def delete_old_thumbnail(slide_id: Document, old_thumbnail: str | None = None):
 			frappe.log_error(f"Failed to remove old thumbnail: {e}")
 
 
-def save_base64_thumbnail(base64_data: str, presentation_name: str) -> str:
+@frappe.whitelist()
+def save_base64_thumbnail(base64_data: str, presentation_name: str, prefix: str) -> str:
 	header, b64 = base64_data.split(",", 1)
 	ext = header.split("/")[1].split(";")[0]
-	filename = f"thumbnail-{uuid.uuid4().hex[:6]}.{ext}"
+	filename = f"{prefix}-{uuid.uuid4().hex[:6]}.{ext}"
 
 	file_doc = frappe.get_doc(
 		{


### PR DESCRIPTION
### Problem
In order to generate thumbnails with the changing content on the slide irrespective of the current zoom level, had recently switched to a different approach instead of directly capturing the current slide content using html2canvas. A cloned version of the content is created outside of the visible area and that html is used to capture an image using html2canvas with a constant **scale: 1**. Since a cloned div is now used, video elements need to be re-loaded in that div before the image can be taken. This broke thumbnails since the logic didn't account for waiting until the video is loaded. 

### Solution
In order to solve this, a video poster image is now captured and stored. This solves the issue and is better because -
- Current video frame should not affect the slide thumbnail. There should be a fixed frame for the video on the thumbnail.
- While generating thumbnails, the video does not need to be loaded again and again since we only require one frame from the video which can be handled just once when a new video element is inserted.

### Changes
- The poster image is stored as an attachment with a prefix of `poster-` when a new video is uploaded.
- When thumbnails are generated the video element is replaced with the poster image.

<br>

#### Before

Video does not appear in thumbnail due to unloaded data.

https://github.com/user-attachments/assets/02f55437-fbc9-440a-b81f-693b099db406

<br>

#### After

Poster captured correctly with the first frame.

https://github.com/user-attachments/assets/b44ac392-3c42-4b7e-9c1b-47ffd79cc3e3

