### PR TITLE
feat: preserve styles on emptying text element content

### DIFF
--- a/frontend/src/components/ResizeHandle.vue
+++ b/frontend/src/components/ResizeHandle.vue
@@ -1,9 +1,5 @@
 <template>
-	<div
-		:style="resizerStyles"
-		@mousedown="$emit('startResize', $event)"
-		@dblclick="handleDoubleClick"
-	></div>
+	<div :style="resizerStyles" @mousedown="$emit('startResize', $event)"></div>
 </template>
 <script setup>
 import { computed } from 'vue'
@@ -21,7 +17,7 @@ const props = defineProps({
 	},
 })
 
-const emit = defineEmits(['startResize', 'resizeToFitContent'])
+const emit = defineEmits(['startResize'])
 
 const baseStyles = {
 	position: 'absolute',
@@ -81,12 +77,4 @@ const resizerStyles = computed(() => {
 			return {}
 	}
 })
-
-const handleDoubleClick = (e) => {
-	e.stopPropagation()
-
-	if (['left', 'right'].includes(props.direction)) {
-		emit('resizeToFitContent', e)
-	}
-}
 </script>

--- a/frontend/src/components/Resizer.vue
+++ b/frontend/src/components/Resizer.vue
@@ -6,7 +6,6 @@
 			:key="resizeHandle.direction"
 			:direction="resizeHandle.direction"
 			@startResize="(e) => startResize(e, resizeHandle.direction)"
-			@resizeToFitContent="$emit('resizeToFitContent')"
 		/>
 
 		<ResizeIndicator

--- a/frontend/src/components/SlideElement.vue
+++ b/frontend/src/components/SlideElement.vue
@@ -6,12 +6,7 @@
 			@clearTimeouts="$emit('clearTimeouts')"
 		/>
 
-		<Resizer
-			v-if="showResizers"
-			:elementType="element.type"
-			:dimensions="selectionBounds"
-			@resizeToFitContent="resizeToFitContent"
-		/>
+		<Resizer v-if="showResizers" :elementType="element.type" :dimensions="selectionBounds" />
 	</div>
 </template>
 
@@ -88,20 +83,4 @@ const showResizers = computed(() => {
 	if (!activeElement.value || focusElementId.value) return false
 	return activeElement.value.id == element.value.id && !props.isDragging
 })
-
-const resizeToFitContent = () => {
-	// create range of the text node within TextElement
-	const target = elementDivRef.value
-	const range = document.createRange()
-	const textNode = target.firstChild
-	const originalWidth = target.offsetWidth
-	range.selectNodeContents(textNode)
-
-	// find out width of text content
-	const textWidth = range.getBoundingClientRect().width
-
-	const newWidth = textWidth - originalWidth + 5 / slideBounds.scale
-
-	updateElementWidth(newWidth)
-}
 </script>

--- a/frontend/src/components/TextElement.vue
+++ b/frontend/src/components/TextElement.vue
@@ -50,7 +50,10 @@ const makeElementEditable = () => {
 
 	activeEditor.value.setEditable(true)
 	activeEditor.value.commands.focus()
-	activeEditor.value.commands.selectAll()
+	activeEditor.value.commands.setTextSelection({
+		from: 0,
+		to: activeEditor.value.state.doc.content.size,
+	})
 }
 
 const handleDoubleClick = (e) => {

--- a/frontend/src/components/TextElement.vue
+++ b/frontend/src/components/TextElement.vue
@@ -31,11 +31,11 @@ const editor = initTextEditor(element.value.content, element.value.editorMetadat
 const isEditable = computed(() => focusElementId.value == element.value.id)
 
 const editorStyles = computed(() => ({
-	cursor: focusElementId.value == element.value.id ? 'text' : '',
+	cursor: isEditable.value ? 'text' : 'default',
 }))
 
 const handleMouseDown = (e) => {
-	if (focusElementId.value == element.value.id) {
+	if (isEditable.value) {
 		e.stopPropagation()
 		return
 	}

--- a/frontend/src/components/TextElement.vue
+++ b/frontend/src/components/TextElement.vue
@@ -14,6 +14,7 @@ import { EditorContent } from '@tiptap/vue-3'
 
 import { useTextEditor } from '@/composables/useTextEditor'
 
+import { inSlideShow } from '@/stores/presentation'
 import { focusElementId, deleteElements, activeElement, activeElementIds } from '@/stores/element'
 
 const { activeEditor, initTextEditor } = useTextEditor()
@@ -26,6 +27,8 @@ const element = defineModel('element', {
 const emit = defineEmits(['clearTimeouts'])
 
 const editor = initTextEditor(element.value.content, element.value.editorMetadata)
+
+const isEditable = computed(() => focusElementId.value == element.value.id)
 
 const editorStyles = computed(() => ({
 	cursor: focusElementId.value == element.value.id ? 'text' : '',
@@ -50,7 +53,7 @@ const makeElementEditable = () => {
 }
 
 const handleDoubleClick = (e) => {
-	if (focusElementId.value == element.value.id) {
+	if (inSlideShow.value || isEditable.value) {
 		e.stopPropagation()
 		return
 	}

--- a/frontend/src/components/TextElement.vue
+++ b/frontend/src/components/TextElement.vue
@@ -32,6 +32,7 @@ const isEditable = computed(() => focusElementId.value == element.value.id)
 
 const editorStyles = computed(() => ({
 	cursor: isEditable.value ? 'text' : 'default',
+	userSelect: isEditable.value ? 'text' : 'none',
 }))
 
 const handleMouseDown = (e) => {

--- a/frontend/src/composables/useTextEditor.js
+++ b/frontend/src/composables/useTextEditor.js
@@ -220,7 +220,7 @@ export const useTextEditor = () => {
 	const getEditorProps = (editorMetadata) => {
 		return {
 			attributes: {
-				style: `line-height: ${editorMetadata?.lineHeight || 1}`,
+				style: `line-height: ${editorMetadata?.lineHeight || 1.5}`,
 			},
 		}
 	}

--- a/frontend/src/composables/useTextEditor.js
+++ b/frontend/src/composables/useTextEditor.js
@@ -54,6 +54,9 @@ export const useTextEditor = () => {
 
 		let chain = editor.chain().focus()
 
+		if (oldStyles.textAlign) chain = chain.setTextAlign(oldStyles.textAlign)
+		if (oldStyles.color) chain = chain.setColor(oldStyles.color)
+
 		chain = chain.setMark('textStyle', {
 			fontSize: oldStyles.fontSize,
 			fontFamily: oldStyles.fontFamily,

--- a/frontend/src/composables/useTextEditor.js
+++ b/frontend/src/composables/useTextEditor.js
@@ -23,6 +23,8 @@ const editorStyles = reactive({
 	orderedList: false,
 })
 
+const lastUsedStyles = reactive({ ...editorStyles })
+
 export const useTextEditor = () => {
 	const setEditorStyles = (editor) => {
 		if (!editor) return
@@ -47,8 +49,47 @@ export const useTextEditor = () => {
 		})
 	}
 
+	const applyLastUsedStyles = (editor) => {
+		const oldStyles = JSON.parse(JSON.stringify(lastUsedStyles))
+
+		let chain = editor.chain().focus()
+
+		chain = chain.setMark('textStyle', {
+			fontSize: oldStyles.fontSize,
+			fontFamily: oldStyles.fontFamily,
+			letterSpacing: oldStyles.letterSpacing,
+			opacity: oldStyles.opacity,
+			textTransform: oldStyles.uppercase ? 'uppercase' : null,
+		})
+
+		if (oldStyles.bold) chain = chain.setBold()
+		if (oldStyles.italic) chain = chain.setItalic()
+		if (oldStyles.underline) chain = chain.setUnderline()
+		if (oldStyles.strike) chain = chain.setStrike()
+
+		chain.run()
+	}
+
+	let isRestoringStyles = false
+
 	const updateEditor = ({ transaction, editor }) => {
+		const textContent = editor.getText().trim()
+
+		if (transaction.docChanged && textContent.length == 0 && !isRestoringStyles) {
+			isRestoringStyles = true
+			applyLastUsedStyles(editor)
+			setTimeout(() => {
+				isRestoringStyles = false
+			}, 0)
+
+			return
+		}
+
 		setEditorStyles(editor)
+
+		for (const key in editorStyles) {
+			lastUsedStyles[key] = editorStyles[key]
+		}
 
 		const changeListMarkers = !editor.isEditable || editor.state.selection.empty
 		changeListMarkers && updateListStyles({ transaction, editor })
@@ -241,6 +282,9 @@ export const useTextEditor = () => {
 		() => activeEditor.value,
 		(newEditor) => {
 			setEditorStyles(newEditor)
+			for (const key in editorStyles) {
+				lastUsedStyles[key] = editorStyles[key]
+			}
 		},
 	)
 

--- a/frontend/src/pages/Slideshow.vue
+++ b/frontend/src/pages/Slideshow.vue
@@ -107,7 +107,8 @@ const transitionMap = {
 }
 
 const applyTransitionStyles = (hook) => {
-	const styles = transitionMap[slide.value.transition][hook]
+	const styles = transitionMap[slide.value.transition]?.[hook]
+	if (!styles) return
 
 	let transformVal = styles.transform
 	if (transformVal && Array.isArray(transformVal)) {

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -108,7 +108,7 @@ const addTextElement = async (text) => {
 		type: 'text',
 		content: getElementContent(elementPresets),
 		editorMetadata: {
-			lineHeight: 1.4,
+			lineHeight: 1.5,
 		},
 	}
 


### PR DESCRIPTION
### Description
Tiptap editor automatically removes all marks when the user clears full content of the editor. What makes more sense for Text elements on slides is to hold same styles until explicitly changed. 

### Changes
- Maintain a reactive object to preserve previous styles. 
- When the document changes and that transaction goes through check if the editor has become completely empty.
- Re-apply the preserved styles at the current cursor position.

<br>

Previously this happened -

https://github.com/user-attachments/assets/ccb280f1-97cd-483a-be6a-da15081206cd

<br>

Basically enables this behaviour -


https://github.com/user-attachments/assets/d12e82ef-3a6f-4524-953e-38c7e6425162

<br>

### Fixes

- Don't show text cursor for Slideshow mode.
- Disable user select and focus correctly in Slideshow mode.
- Temporarily remove auto-fitting text content to the Text element.