### PR TITLE
fix: separate out element positioning state from selection layer

### DIFF
--- a/frontend/src/components/DropTargetOverlay.vue
+++ b/frontend/src/components/DropTargetOverlay.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		ref="overlay"
-		class="z-15 fixed left-0 top-0 size-full bg-blue-400 opacity-10"
+		class="z-15 absolute left-0 top-0 size-full bg-blue-400 opacity-10"
 		@dragleave.prevent="handleDragLeave"
 		@dragover.prevent
 		@drop="handleMediaDrop"

--- a/frontend/src/components/DropTargetOverlay.vue
+++ b/frontend/src/components/DropTargetOverlay.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		ref="overlay"
-		class="z-15 absolute left-0 top-0 size-full bg-blue-400 opacity-10"
+		class="absolute left-0 top-0 size-full bg-blue-400 opacity-10"
 		@dragleave.prevent="handleDragLeave"
 		@dragover.prevent
 		@drop="handleMediaDrop"

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -1,5 +1,8 @@
 <template>
-	<div class="z-10 flex items-center justify-between border-b bg-white p-2" @wheel.prevent>
+	<div
+		class="relative z-10 flex items-center justify-between border-b bg-white p-2"
+		@wheel.prevent
+	>
 		<router-link class="flex items-center gap-2" :to="{ name: 'Home' }">
 			<img src="/slides-logo.svg" class="h-7" />
 			<div class="text-base font-semibold">Slides</div>

--- a/frontend/src/components/NavigationPanel.vue
+++ b/frontend/src/components/NavigationPanel.vue
@@ -109,7 +109,7 @@ const getThumbnailStyles = (s) => {
 }
 
 const toggleButtonClasses = computed(() => {
-	const baseClasses = 'z-20 flex cursor-pointer items-center border bg-white'
+	const baseClasses = 'flex cursor-pointer items-center border bg-white'
 	if (showNavigator.value) {
 		return `${baseClasses} fixed -left-0.4 bottom-0 h-10 w-48 justify-between p-4`
 	}

--- a/frontend/src/components/NavigationPanel.vue
+++ b/frontend/src/components/NavigationPanel.vue
@@ -7,6 +7,7 @@
 		@wheel="handleScrollBarWheelEvent"
 	>
 		<div
+			ref="scrollableArea"
 			v-if="presentation.data"
 			class="flex h-full flex-col overflow-y-auto p-4 pb-14 custom-scrollbar"
 			:style="scrollbarStyles"
@@ -62,6 +63,8 @@ import { handleScrollBarWheelEvent } from '@/utils/helpers'
 import { useAttrs } from 'vue'
 
 const attrs = useAttrs()
+
+const scrollableArea = useTemplateRef('scrollableArea')
 
 const showNavigator = defineModel('showNavigator', {
 	type: Boolean,
@@ -142,15 +145,27 @@ const scrollbarStyles = computed(() => ({
 
 const slideThumbnailsRef = ref([])
 
+const scrollThumbnailToView = (element) => {
+	if (!scrollableArea.value) return
+
+	const isScrollable = scrollableArea.value.scrollHeight > scrollableArea.value.clientHeight
+
+	if (isScrollable) {
+		// adjust offset for top padding - 16px
+		const offset = element.offsetTop - scrollableArea.value.offsetTop - 16
+
+		scrollableArea.value.scrollTo({
+			top: offset,
+			behavior: 'smooth',
+		})
+	}
+}
+
 const handleScrollChange = (index) => {
 	const el = slideThumbnailsRef.value[index]
 
 	if (!el) return
-	el.scrollIntoView({
-		behavior: 'smooth',
-		block: 'start',
-		inline: 'nearest',
-	})
+	scrollThumbnailToView(el)
 }
 
 watch(

--- a/frontend/src/components/OverflowContentOverlay.vue
+++ b/frontend/src/components/OverflowContentOverlay.vue
@@ -32,11 +32,14 @@ const maskStyles = computed(() => ({
 	pointerEvents: 'none',
 }))
 
-const rectAttributes = computed(() => ({
-	fill: 'black',
-	x: slideBounds.left,
-	y: (slideBounds.top || 0) - 45, // subtract navbar height
-	width: slideBounds.width,
-	height: slideBounds.height,
-}))
+const rectAttributes = computed(() => {
+	if (!slideBounds.left) return {}
+	return {
+		x: slideBounds.left,
+		y: slideBounds.top - 45, // subtract navbar height
+		width: slideBounds.width,
+		height: slideBounds.height,
+		fill: 'black',
+	}
+})
 </script>

--- a/frontend/src/components/OverflowContentOverlay.vue
+++ b/frontend/src/components/OverflowContentOverlay.vue
@@ -8,13 +8,7 @@
 					<rect width="100%" height="100%" fill="white" />
 
 					<!-- cutout the section for the slide -->
-					<rect
-						fill="black"
-						:x="slideBounds.left"
-						:y="slideBounds.top"
-						:width="slideBounds.width"
-						:height="slideBounds.height"
-					/>
+					<rect v-bind="rectAttributes" />
 				</mask>
 			</defs>
 		</svg>
@@ -26,7 +20,7 @@ import { computed } from 'vue'
 import { slideBounds } from '@/stores/slide'
 
 const maskStyles = computed(() => ({
-	position: 'fixed',
+	position: 'absolute',
 	top: 0,
 	left: 0,
 	width: '100vw',
@@ -36,5 +30,13 @@ const maskStyles = computed(() => ({
 	mask: 'url(#hole-mask)',
 	webkitMask: 'url(#hole-mask)',
 	pointerEvents: 'none',
+}))
+
+const rectAttributes = computed(() => ({
+	fill: 'black',
+	x: slideBounds.left,
+	y: (slideBounds.top || 0) - 45, // subtract navbar height
+	width: slideBounds.width,
+	height: slideBounds.height,
 }))
 </script>

--- a/frontend/src/components/PresentationPreview.vue
+++ b/frontend/src/components/PresentationPreview.vue
@@ -51,7 +51,7 @@
 			</div>
 		</div>
 
-		<div class="absolute bottom-0 left-0 z-10 h-[53%] w-full bg-white" @click.stop></div>
+		<div class="absolute bottom-0 left-0 h-[53%] w-full bg-white" @click.stop></div>
 	</div>
 </template>
 

--- a/frontend/src/components/PresentationPreview.vue
+++ b/frontend/src/components/PresentationPreview.vue
@@ -86,7 +86,7 @@ const slideThumbnails = createResource({
 
 const previewOverlayClasses = computed(() => {
 	const baseClasses =
-		'fixed left-0 size-full transition-all duration-300 ease-in-out flex items-center backdrop-blur-[1px] bg-gray-900/25'
+		'absolute left-0 size-full transition-all duration-300 ease-in-out flex items-center backdrop-blur-[1px] bg-gray-900/25'
 	if (props.presentation) {
 		return `${baseClasses} top-0`
 	}

--- a/frontend/src/components/ResizeHandle.vue
+++ b/frontend/src/components/ResizeHandle.vue
@@ -25,7 +25,7 @@ const emit = defineEmits(['startResize', 'resizeToFitContent'])
 
 const baseStyles = {
 	position: 'absolute',
-	zIndex: 100,
+	zIndex: 5,
 	backgroundColor: '#70b6f0',
 	borderRadius: '10px',
 }

--- a/frontend/src/components/ResizeIndicator.vue
+++ b/frontend/src/components/ResizeIndicator.vue
@@ -30,7 +30,7 @@ const props = defineProps({
 
 const styles = computed(() => ({
 	position: 'absolute',
-	zIndex: 100,
+	zIndex: 5,
 	...props.indicatorStyles,
 }))
 

--- a/frontend/src/components/SelectionBox.vue
+++ b/frontend/src/components/SelectionBox.vue
@@ -28,7 +28,6 @@ let mousedownStart
 
 const boxStyles = computed(() => ({
 	position: 'absolute',
-	zIndex: 1000,
 	backgroundColor: activeElementIds.value.length == 1 ? '' : '#70b6f018',
 	border: activeElementIds.value.length == 1 ? '' : '0.1px solid #70b6f092',
 	width: `${selectionBounds.width}px`,

--- a/frontend/src/components/SelectionBox.vue
+++ b/frontend/src/components/SelectionBox.vue
@@ -240,11 +240,11 @@ const handleSelection = (elementIds) => {
 	if (!elementIds.length) return
 	document.removeEventListener('mouseup', endSelection)
 	cropSelectionToFitContent(elementIds)
-	moveElementsToBox(elementIds)
+	// moveElementsToBox(elementIds)
 }
 
 const handleSelectionChange = (elementIds, oldIds) => {
-	moveElementsToSlide(oldIds)
+	// moveElementsToSlide(oldIds)
 	resetSelection(oldIds)
 	nextTick(() => handleSelection(elementIds))
 }

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -94,6 +94,7 @@ const slideStyles = computed(() => ({
 	transform: transform.value,
 	backgroundColor: slide.value.background || '#ffffff',
 	cursor: isDragging.value ? 'move' : resizeCursor.value || 'default',
+	zIndex: 0,
 }))
 
 const getElementOutline = (element) => {

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -2,37 +2,30 @@
 	<div ref="slideContainer" class="flex size-full" @dragenter="showOverlay">
 		<!-- when mounting place slide directly in the center of the visible container -->
 		<!-- 1/2 width of viewport + 1/2 width of offset caused due to thinner navigation panel -->
-		<div
-			ref="target"
-			:style="targetStyles"
-			class="fixed left-[calc(50%-512px)] top-[calc(50%-270px)]"
-		>
-			<div ref="slideRef" :class="slideClasses" :style="slideStyles">
-				<SelectionBox ref="selectionBox" @mousedown="(e) => handleMouseDown(e)" />
+		<div ref="slideRef" :style="slideStyles" :class="slideClasses">
+			<SelectionBox ref="selectionBox" @mousedown="(e) => handleMouseDown(e)" />
 
-				<SnapGuides :isDragging="isDragging" :visibilityMap="visibilityMap" />
+			<SnapGuides :isDragging="isDragging" :visibilityMap="visibilityMap" />
 
-				<SlideElement
-					v-for="element in slide.elements"
-					:key="element.id"
-					:element="element"
-					:outline="getElementOutline(element)"
-					:isDragging="isDragging"
-					:data-index="element.id"
-					@mousedown="(e) => handleMouseDown(e, element)"
-					@clearTimeouts="clearTimeouts"
-				/>
-			</div>
+			<SlideElement
+				v-for="element in slide.elements"
+				:key="element.id"
+				:element
+				:elementOffset
+				:isDragging
+				:data-index="element.id"
+				:outline="getElementOutline(element)"
+				@mousedown="(e) => handleMouseDown(e, element)"
+				@clearTimeouts="clearTimeouts"
+			/>
 		</div>
+		<DropTargetOverlay v-show="mediaDragOver" @hideOverlay="hideOverlay" />
+		<OverflowContentOverlay />
 	</div>
-
-	<DropTargetOverlay v-show="mediaDragOver" @hideOverlay="hideOverlay" />
-
-	<OverflowContentOverlay />
 </template>
 
 <script setup>
-import { ref, computed, watch, useTemplateRef, nextTick, onMounted, provide } from 'vue'
+import { ref, computed, watch, useTemplateRef, nextTick, onMounted, provide, reactive } from 'vue'
 import { useResizeObserver } from '@vueuse/core'
 
 import SnapGuides from '@/components/SnapGuides.vue'
@@ -62,7 +55,6 @@ const props = defineProps({
 })
 
 const slideContainerRef = useTemplateRef('slideContainer')
-const slideTargetRef = useTemplateRef('target')
 const slideRef = useTemplateRef('slideRef')
 const selectionBoxRef = useTemplateRef('selectionBox')
 
@@ -72,13 +64,18 @@ const { dimensionDelta, currentResizer, resizeCursor, startResize } = useResizer
 
 const { visibilityMap, resistanceMap, handleSnapping } = useSnapping(selectionBoxRef, slideRef)
 
-const { allowPanAndZoom, transform, transformOrigin } = usePanAndZoom(
-	slideContainerRef,
-	slideTargetRef,
-)
+const { allowPanAndZoom, transform, transformOrigin } = usePanAndZoom(slideContainerRef, slideRef)
 
 const slideClasses = computed(() => {
-	const classes = ['slide', 'h-[540px]', 'w-[960px]', 'shadow-2xl', 'shadow-gray-400']
+	const classes = [
+		'absolute',
+		'left-[calc(50%-512px)]',
+		'top-[calc(50%-270px)]',
+		'h-[540px]',
+		'w-[960px]',
+		'shadow-2xl',
+		'shadow-gray-400',
+	]
 
 	const outlineClasses =
 		props.highlight || mediaDragOver.value ? ['outline', 'outline-2', 'outline-blue-400'] : []
@@ -86,12 +83,9 @@ const slideClasses = computed(() => {
 	return [...classes, outlineClasses]
 })
 
-const targetStyles = computed(() => ({
+const slideStyles = computed(() => ({
 	transformOrigin: transformOrigin.value,
 	transform: transform.value,
-}))
-
-const slideStyles = computed(() => ({
 	backgroundColor: slide.value.background || '#ffffff',
 	cursor: isDragging.value ? 'move' : resizeCursor.value || 'default',
 }))
@@ -235,8 +229,17 @@ const getTotalPositionDelta = (delta) => {
 	}
 }
 
+const elementOffset = reactive({
+	left: 0,
+	top: 0,
+})
+
 const handlePositionChange = (delta) => {
 	const totalDelta = getTotalPositionDelta(delta)
+
+	elementOffset.left += totalDelta.left / scale.value
+	elementOffset.top += totalDelta.top / scale.value
+
 	updateSelectionBounds({
 		left: selectionBounds.left + totalDelta.left / scale.value,
 		top: selectionBounds.top + totalDelta.top / scale.value,
@@ -333,4 +336,23 @@ provide('resizer', {
 defineExpose({
 	togglePanZoom,
 })
+
+watch(
+	() => isDragging.value,
+	(isDragging) => {
+		if (!isDragging) {
+			requestAnimationFrame(() => {
+				activeElementIds.value.forEach((id) => {
+					const element = slide.value.elements.find((el) => el.id === id)
+					if (element) {
+						element.left += elementOffset.left
+						element.top += elementOffset.top
+					}
+				})
+				elementOffset.left = 0
+				elementOffset.top = 0
+			})
+		}
+	},
+)
 </script>

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -244,6 +244,8 @@ const elementOffset = reactive({
 })
 
 const handlePositionChange = (delta) => {
+	if (!delta.x && !delta.y) return
+
 	const totalDelta = getTotalPositionDelta(delta)
 
 	applyPositionDelta(totalDelta)

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -34,7 +34,13 @@ import SlideElement from '@/components/SlideElement.vue'
 import DropTargetOverlay from '@/components/DropTargetOverlay.vue'
 import OverflowContentOverlay from '@/components/OverflowContentOverlay.vue'
 
-import { slide, slideBounds, selectionBounds, updateSelectionBounds } from '@/stores/slide'
+import {
+	slide,
+	slideBounds,
+	selectionBounds,
+	updateSelectionBounds,
+	setSlideRef,
+} from '@/stores/slide'
 import {
 	activeElementIds,
 	activeElement,
@@ -319,6 +325,8 @@ watch(
 
 onMounted(() => {
 	if (!slideRef.value) return
+
+	setSlideRef(slideRef.value)
 
 	updateSlideBounds()
 

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -60,6 +60,8 @@ const props = defineProps({
 	highlight: Boolean,
 })
 
+const emit = defineEmits(['update:hasOngoingInteraction'])
+
 const slideContainerRef = useTemplateRef('slideContainer')
 const slideRef = useTemplateRef('slideRef')
 const selectionBoxRef = useTemplateRef('selectionBox')
@@ -352,7 +354,7 @@ defineExpose({
 	togglePanZoom,
 })
 
-const isInteracting = computed(() => isDragging.value || isResizing.value)
+const hasOngoingInteraction = computed(() => isDragging.value || isResizing.value)
 
 const applyInteractionOffset = () => {
 	requestAnimationFrame(() => {
@@ -369,9 +371,10 @@ const applyInteractionOffset = () => {
 }
 
 watch(
-	() => isInteracting.value,
+	() => hasOngoingInteraction.value,
 	(newVal, oldVal) => {
 		if (oldVal && !newVal) applyInteractionOffset()
+		emit('update:hasOngoingInteraction', newVal)
 	},
 )
 </script>

--- a/frontend/src/components/SlideElement.vue
+++ b/frontend/src/components/SlideElement.vue
@@ -41,9 +41,17 @@ const props = defineProps({
 		type: Boolean,
 		default: false,
 	},
+	elementOffset: {
+		type: Object,
+		default: () => ({ left: 0, top: 0 }),
+	},
 })
 
 const emit = defineEmits(['clearTimeouts'])
+
+const isActive = computed(() => {
+	return activeElementIds.value.includes(element.value.id)
+})
 
 const element = defineModel('element', {
 	type: Object,
@@ -63,14 +71,21 @@ const outline = computed(() => {
 	}
 })
 
-const elementStyle = computed(() => ({
-	position: activeElementIds.value.includes(element.value.id) ? 'absolute' : 'fixed',
-	width: `${element.value.width}px` || 'auto',
-	left: `${element.value.left}px`,
-	top: `${element.value.top}px`,
-	outline: outline.value,
-	boxSizing: 'border-box',
-}))
+const elementStyle = computed(() => {
+	const offsetLeft = isActive.value ? props.elementOffset.left : 0
+	const offsetTop = isActive.value ? props.elementOffset.top : 0
+	const elementLeft = element.value.left + offsetLeft
+	const elementTop = element.value.top + offsetTop
+	return {
+		position: 'absolute',
+		width: `${element.value.width}px` || 'auto',
+		height: 'auto',
+		left: `${elementLeft}px`,
+		top: `${elementTop}px`,
+		outline: outline.value,
+		boxSizing: 'border-box',
+	}
+})
 
 const getDynamicComponent = (type) => {
 	switch (type) {

--- a/frontend/src/components/SnapGuides.vue
+++ b/frontend/src/components/SnapGuides.vue
@@ -20,9 +20,8 @@ const props = defineProps({
 })
 
 const commonStyles = {
-	backgroundColor: '#70b6f080',
 	position: 'absolute',
-	zIndex: 1000,
+	zIndex: 5,
 }
 
 const isVisible = (axis) => {
@@ -34,6 +33,7 @@ const isVisible = (axis) => {
 const getCenterStyles = (axis) => {
 	return {
 		...commonStyles,
+		backgroundColor: '#70b6f080',
 		width: axis === 'centerY' ? '1px' : '100%',
 		height: axis === 'centerX' ? '1px' : '100%',
 		left: axis === 'centerY' ? '50%' : '0',
@@ -78,7 +78,7 @@ const getVerticalStyles = (direction) => {
 	const height = Math.abs(pairedBounds.top - selectionBounds.top) + lastElementHeight
 
 	return {
-		position: 'absolute',
+		...commonStyles,
 		borderColor: '#70b6f080',
 		borderStyle: 'dashed',
 		borderWidth: '0 0 0 1px',
@@ -103,7 +103,7 @@ const getHorizontalStyles = (direction) => {
 	const width = Math.abs(pairedBounds.left - selectionBounds.left) + lastElementWidth
 
 	return {
-		position: 'absolute',
+		...commonStyles,
 		borderColor: '#70b6f080',
 		borderStyle: 'dashed',
 		borderWidth: '1px 0 0 0',

--- a/frontend/src/components/SnapGuides.vue
+++ b/frontend/src/components/SnapGuides.vue
@@ -21,7 +21,7 @@ const props = defineProps({
 
 const commonStyles = {
 	backgroundColor: '#70b6f080',
-	position: 'fixed',
+	position: 'absolute',
 	zIndex: 1000,
 }
 
@@ -78,7 +78,7 @@ const getVerticalStyles = (direction) => {
 	const height = Math.abs(pairedBounds.top - selectionBounds.top) + lastElementHeight
 
 	return {
-		position: 'fixed',
+		position: 'absolute',
 		borderColor: '#70b6f080',
 		borderStyle: 'dashed',
 		borderWidth: '0 0 0 1px',
@@ -102,7 +102,7 @@ const getHorizontalStyles = (direction) => {
 	const width = Math.abs(pairedBounds.left - selectionBounds.left) + lastElementWidth
 
 	return {
-		position: 'fixed',
+		position: 'absolute',
 		borderColor: '#70b6f080',
 		borderStyle: 'dashed',
 		borderWidth: '1px 0 0 0',

--- a/frontend/src/components/SnapGuides.vue
+++ b/frontend/src/components/SnapGuides.vue
@@ -85,6 +85,7 @@ const getVerticalStyles = (direction) => {
 		left: `${left}px`,
 		top: `${top}px`,
 		height: `${height}px`,
+		display: isVisible(direction) ? 'block' : 'none',
 	}
 }
 
@@ -109,6 +110,7 @@ const getHorizontalStyles = (direction) => {
 		top: `${top}px`,
 		left: `${left}px`,
 		width: `${width}px`,
+		display: isVisible(direction) ? 'block' : 'none',
 	}
 }
 

--- a/frontend/src/components/Toolbar.vue
+++ b/frontend/src/components/Toolbar.vue
@@ -1,6 +1,6 @@
 <template>
 	<div
-		class="fixed bottom-10 left-[calc(50%-128px)] flex h-10 w-48 items-center justify-center gap-1 rounded-lg bg-white p-1 shadow-xl"
+		class="absolute bottom-10 left-[calc(50%-128px)] flex h-10 w-48 items-center justify-center gap-1 rounded-lg bg-white p-1 shadow-xl"
 	>
 		<Tooltip text="Text" :hover-delay="0.7" placement="bottom">
 			<div class="cursor-pointer rounded p-2 hover:bg-gray-100" @click="addTextElement(null)">

--- a/frontend/src/components/Toolbar.vue
+++ b/frontend/src/components/Toolbar.vue
@@ -88,12 +88,12 @@ const handleUploadSuccess = (file) => {
 	const imageTypes = allowedImageFileTypes.map((type) => type.split('/')[1].toUpperCase())
 	const fileType = imageTypes.includes(file.file_type) ? 'image' : 'video'
 
-	addMediaElement(file, fileType)
+	const toastProps = {
+		loading: `Uploading: ${file.file_name}`,
+		success: (data) => `Uploaded: ${file.file_name}`,
+		error: (data) => 'Upload failed. Please try again.',
+	}
 
-	toast.success('Uploaded: ' + file.file_name)
-}
-
-const handleUploadFailure = () => {
-	toast.error('Upload failed. Please try again.')
+	toast.promise(addMediaElement(file, fileType), toastProps)
 }
 </script>

--- a/frontend/src/components/Toolbar.vue
+++ b/frontend/src/components/Toolbar.vue
@@ -1,6 +1,7 @@
 <template>
 	<div
 		class="absolute bottom-10 left-[calc(50%-128px)] flex h-10 w-48 items-center justify-center gap-1 rounded-lg bg-white p-1 shadow-xl"
+		@wheel="handleScrollBarWheelEvent"
 	>
 		<Tooltip text="Text" :hover-delay="0.7" placement="bottom">
 			<div class="cursor-pointer rounded p-2 hover:bg-gray-100" @click="addTextElement(null)">
@@ -54,6 +55,8 @@ import { Tooltip, FileUploader, toast } from 'frappe-ui'
 import { presentationId } from '@/stores/presentation'
 import { addTextElement, addMediaElement } from '@/stores/element'
 import { allowedImageFileTypes } from '@/utils/constants'
+
+import { handleScrollBarWheelEvent } from '@/utils/helpers'
 
 const emit = defineEmits(['openLayoutDialog', 'delete', 'duplicate', 'setHighlight'])
 

--- a/frontend/src/components/VideoElement.vue
+++ b/frontend/src/components/VideoElement.vue
@@ -16,7 +16,7 @@
 		</video>
 		<div
 			ref="overlay"
-			class="absolute left-0 top-0 size-full overflow-hidden transition-opacity duration-500 ease-in-out"
+			class="overlay absolute left-0 top-0 size-full overflow-hidden transition-opacity duration-500 ease-in-out"
 			:style="gradientOverlayStyles"
 		>
 			<div v-if="showProgressBar" :class="toggleButtonClasses">

--- a/frontend/src/composables/useDragAndDrop.js
+++ b/frontend/src/composables/useDragAndDrop.js
@@ -44,6 +44,8 @@ export const useDragAndDrop = () => {
 
 		isDragging.value = false
 
+		positionDelta.value = { x: 0, y: 0 }
+
 		window.removeEventListener('mousemove', drag)
 		window.removeEventListener('mouseup', stopDragging)
 	}

--- a/frontend/src/composables/useResizer.js
+++ b/frontend/src/composables/useResizer.js
@@ -92,5 +92,5 @@ export const useResizer = () => {
 		window.removeEventListener('mouseup', stopResize)
 	}
 
-	return { dimensionDelta, currentResizer, startResize, resizeCursor }
+	return { isResizing, dimensionDelta, currentResizer, startResize, resizeCursor }
 }

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="fixed flex h-screen w-screen flex-col">
+	<div class="flex h-screen w-screen flex-col">
 		<Navbar
 			:primaryButton="{
 				label: 'New',

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -117,6 +117,11 @@ const handleArrowKeys = (key) => {
 		left: selectionBounds.left + dx,
 		top: selectionBounds.top + dy,
 	})
+
+	activeElements.value.forEach((element) => {
+		element.left += dx
+		element.top += dy
+	})
 }
 
 const saveSlide = (e) => {

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -6,7 +6,11 @@
 			</template>
 		</Navbar>
 		<div class="relative flex h-screen bg-gray-300">
-			<SlideContainer ref="slideContainer" :highlight="slideHighlight" />
+			<SlideContainer
+				ref="slideContainer"
+				:highlight="slideHighlight"
+				v-model:hasOngoingInteraction="hasOngoingInteraction"
+			/>
 
 			<NavigationPanel
 				class="absolute bottom-0 top-0"
@@ -94,6 +98,7 @@ const dropTargetRef = useTemplateRef('dropTarget')
 
 const showNavigator = ref(true)
 const slideHighlight = ref(false)
+const hasOngoingInteraction = ref(false)
 
 const setHighlight = (value) => {
 	slideHighlight.value = value
@@ -212,7 +217,7 @@ const startSlideShow = () => {
 }
 
 const handleAutoSave = () => {
-	if (activeElementIds.value.length || focusElementId.value != null) return
+	if (hasOngoingInteraction.value || focusElementId.value != null) return
 	saveChanges()
 }
 

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -6,14 +6,14 @@
 			</template>
 		</Navbar>
 		<div class="relative flex h-screen bg-gray-300">
+			<SlideContainer ref="slideContainer" :highlight="slideHighlight" />
+
 			<NavigationPanel
-				class="absolute bottom-0 top-0 z-10"
+				class="absolute bottom-0 top-0"
 				:showNavigator="showNavigator"
 				@changeSlide="changeSlide"
 				@openLayoutDialog="openLayoutDialog('insert')"
 			/>
-
-			<SlideContainer ref="slideContainer" :highlight="slideHighlight" />
 
 			<Toolbar
 				@setHighlight="setHighlight"
@@ -23,7 +23,7 @@
 			/>
 
 			<PropertiesPanel
-				class="absolute bottom-0 right-0 top-0 z-10"
+				class="absolute bottom-0 right-0 top-0"
 				@openLayoutDialog="openLayoutDialog('replace')"
 			/>
 		</div>

--- a/frontend/src/pages/Slideshow.vue
+++ b/frontend/src/pages/Slideshow.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="fixed left-0 top-0 h-full w-full bg-black">
+	<div class="absolute left-0 top-0 h-full w-full bg-black">
 		<div
 			ref="slideContainer"
 			class="flex h-screen w-full items-center justify-center"

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -52,10 +52,16 @@ const selectAndCenterElement = (elementId) => {
 			const elementWidth = elementRect.width / slideBounds.scale
 			const elementHeight = elementRect.height / slideBounds.scale
 
+			const elementLeft = (slideWidth - elementWidth) / 2
+			const elementTop = (slideHeight - elementHeight) / 2
+
 			updateSelectionBounds({
-				left: (slideWidth - elementWidth) / 2,
-				top: (slideHeight - elementHeight) / 2,
+				left: elementLeft,
+				top: elementTop,
 			})
+
+			activeElement.value.left = elementLeft
+			activeElement.value.top = elementTop
 		})
 	})
 }

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -7,6 +7,10 @@ import { activeElementIds } from './element'
 import { isEqual } from 'lodash'
 import html2canvas from 'html2canvas'
 
+const slideRef = ref(null)
+
+const setSlideRef = (ref) => (slideRef.value = ref)
+
 const slideIndex = ref(0)
 
 const slide = ref({
@@ -53,9 +57,7 @@ const isSlideDirty = () => {
 }
 
 const getThumbnailHtml = () => {
-	const slideRef = document.querySelector('.slide')
-
-	const clone = slideRef.cloneNode(true)
+	const clone = slideRef.value.cloneNode(true)
 
 	clone.style.position = 'absolute'
 	clone.style.left = '-9999px'
@@ -166,4 +168,5 @@ export {
 	saveChanges,
 	updateSelectionBounds,
 	updateSlideThumbnail,
+	setSlideRef,
 }

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -92,6 +92,15 @@ const getThumbnailHtml = async () => {
 		if (element.tagName == 'VIDEO') {
 			await replaceVideoWithPoster(element)
 		}
+
+		const isEmpty =
+			element.tagName == 'DIV' &&
+			element.textContent.trim() == '' &&
+			element.children.length == 0
+		const removeDiv = isEmpty || element.classList.contains('overlay')
+		if (removeDiv) {
+			element.remove()
+		}
 	})
 
 	return clone

--- a/frontend/src/utils/mediaUploads.js
+++ b/frontend/src/utils/mediaUploads.js
@@ -66,7 +66,6 @@ export const handleUploadedMedia = (files) => {
 			error: (data) => 'Upload failed. Please try again.',
 		}
 
-		// run after current call stack so toast's expand animation works
-		setTimeout(() => toast.promise(uploadMedia(file, fileType), toastProps), 0)
+		toast.promise(uploadMedia(file, fileType), toastProps)
 	})
 }


### PR DESCRIPTION
### Changes

#### Separate out selection box layer

- Separate out the selection box layer from the slide elements. Previously when a selection was made all elements in the selection were placed nested to the selection box with left and top values calculated with respect to the selection box. This mixes the state and UI-only offsets which leads to inconsistent state while taking snapshots of the data. 

- In order to solve this, now selection box is a separate layer and the drag and snap offsets are applied to the elements when dragging them. These offsets are added to the left and top values when dragging stops. 

- Now elements are always placed with respect to the slide. Also autosave does not depend on selection now, instead it checks if any interaction like dragging or resizing is taking place and guards against saving while interacting otherwise triggers normally.


### Other fixes

- Eliminate fixed position elements wherever not required.
- Fix stacking context for side panels and toolbar.
- Remove overlay and helper divs from the HTML that is used to generate thumbnails.