### PR TITLE
fix: alignment controls, theme in presentation duplication, perms

### DIFF
--- a/frontend/src/components/AlignmentControls.vue
+++ b/frontend/src/components/AlignmentControls.vue
@@ -53,6 +53,7 @@ import CollapsibleSection from '@/components/controls/CollapsibleSection.vue'
 
 import { slideBounds, selectionBounds, guideVisibilityMap } from '@/stores/slide'
 import { fieldLabelClasses } from '@/utils/constants'
+import { activeElements } from '@/stores/element'
 
 const horizontalAlignmentOptions = [
 	{
@@ -141,10 +142,16 @@ const getAlignmentButtonClasses = (direction) => {
 
 const alignHorizontally = (direction) => {
 	selectionBounds.left = Math.round(alignmentPositions.value[direction])
+	activeElements.value.forEach((element) => {
+		element.left = selectionBounds.left
+	})
 }
 
 const alignVertically = (direction) => {
 	selectionBounds.top = Math.round(alignmentPositions.value[direction])
+	activeElements.value.forEach((element) => {
+		element.top = selectionBounds.top
+	})
 }
 
 const performAlignment = (direction) => {

--- a/frontend/src/components/PresentationHeader.vue
+++ b/frontend/src/components/PresentationHeader.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import { call } from 'frappe-ui'
@@ -26,16 +26,21 @@ const router = useRouter()
 
 const editingTitle = ref(false)
 
-const inputClasses = [
-	'max-w-42',
-	'w-fit',
-	'p-1',
-	'text-base',
-	'outline-none',
-	'font-medium',
-	'text-gray-800',
-	'cursor-text',
-]
+const inputClasses = computed(() => {
+	const baseClasses = [
+		'p-1 px-2',
+		'text-base font-medium cursor-text',
+		'outline-none rounded-sm',
+		'focus:ring-1 focus:ring-gray-400',
+		'transition ease-in-out duration-400',
+		'whitespace-nowrap',
+	]
+	if (editingTitle.value) {
+		return [...baseClasses, 'text-gray-800', 'max-w-[500px]']
+	} else {
+		return [...baseClasses, 'truncate', 'max-w-[500px]']
+	}
+})
 
 const makeTitleEditable = (e) => {
 	if (editingTitle.value) return
@@ -50,7 +55,12 @@ const saveTitle = async (e) => {
 
 	const newTitle = e.target.innerText.trim()
 
-	if (newTitle && newTitle != presentation.data.title) {
+	if (!newTitle) {
+		e.target.innerText = presentation.data.title
+		return
+	}
+
+	if (newTitle != presentation.data.title) {
 		const slug = await updatePresentationTitle(route.params.presentationId, newTitle)
 		router.replace({
 			name: 'PresentationEditor',

--- a/frontend/src/components/TextElement.vue
+++ b/frontend/src/components/TextElement.vue
@@ -118,6 +118,10 @@ watch(
 </script>
 
 <style>
+.ProseMirror {
+	caret-color: currentColor;
+}
+
 .tiptap > ul {
 	list-style: none;
 	padding-left: 0;

--- a/frontend/src/pages/errorPages/NotPermitted.vue
+++ b/frontend/src/pages/errorPages/NotPermitted.vue
@@ -2,8 +2,12 @@
 	<div class="flex h-screen w-full flex-col items-center justify-center gap-2 bg-gray-100">
 		<div class="text-2xl font-semibold">Access Denied</div>
 		<div class="text-base text-gray-700">You do not have permission to access this page.</div>
-		<router-link to="/">
+		<router-link to="/" v-if="session.isSlidesUser">
 			<Button :variant="'solid'" size="md" label="Go back to Home" class="my-6" />
 		</router-link>
 	</div>
 </template>
+
+<script setup>
+import { session } from '@/stores/session'
+</script>

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -56,6 +56,15 @@ router.beforeEach(async (to, _, next) => {
 		if (to.path !== '/login') window.location.href = '/login?redirect-to=' + to.path
 		next()
 	} else {
+		if (session.isSlidesUser === null) {
+			await session.setIsSlidesUser()
+		}
+
+		if (!session.isSlidesUser && to.name !== 'NotPermitted') {
+			next({ name: 'NotPermitted' })
+			return
+		}
+
 		if (to.path === '/login') {
 			next({ name: 'Home' })
 		} else if (['PresentationEditor', 'Slideshow'].includes(to.name as string)) {

--- a/frontend/src/stores/session.ts
+++ b/frontend/src/stores/session.ts
@@ -1,5 +1,7 @@
 import { computed, reactive } from 'vue'
 
+import { call } from 'frappe-ui'
+
 const sessionUser = () => {
 	const cookies = new URLSearchParams(document.cookie.split('; ').join('&'))
 	let _sessionUser = cookies.get('user_id')
@@ -9,7 +11,21 @@ const sessionUser = () => {
 	return _sessionUser
 }
 
+const setIsSlidesUser = async () => {
+	if (!session.user || session.isSlidesUser !== null) return
+
+	try {
+		const response = await call('slides.api.is_slides_user')
+		session.isSlidesUser = response == true
+	} catch (error) {
+		console.error('Failed to check Slides User role:', error)
+		session.isSlidesUser = false
+	}
+}
+
 export const session = reactive({
 	user: sessionUser(),
 	isLoggedIn: computed((): boolean => !!session.user),
+	isSlidesUser: null as boolean | null,
+	setIsSlidesUser,
 })

--- a/slides/api/__init__.py
+++ b/slides/api/__init__.py
@@ -6,3 +6,12 @@ def check_app_permission():
 		return True
 
 	return frappe.has_permission("Presentation", ptype="write")
+
+
+@frappe.whitelist()
+def is_slides_user():
+	user = frappe.session.user
+	if user == "Guest":
+		return False
+
+	return "Slides User" in frappe.get_roles(user)

--- a/slides/hooks.py
+++ b/slides/hooks.py
@@ -116,13 +116,13 @@ website_route_rules = [
 # -----------
 # Permissions evaluated in scripted ways
 
-# permission_query_conditions = {
-# 	"Event": "frappe.desk.doctype.event.event.get_permission_query_conditions",
-# }
-#
-# has_permission = {
-# 	"Event": "frappe.desk.doctype.event.event.has_permission",
-# }
+permission_query_conditions = {
+	"Presentation": "slides.slides.doctype.presentation.presentation.get_permission_query_conditions",
+}
+
+has_permission = {
+	"Presentation": "slides.slides.doctype.presentation.presentation.has_permission",
+}
 
 # DocType Class
 # ---------------

--- a/slides/slides/doctype/presentation/presentation.py
+++ b/slides/slides/doctype/presentation/presentation.py
@@ -247,3 +247,23 @@ def get_updated_json(presentation, json):
 @frappe.whitelist()
 def get_layouts(theme):
 	return frappe.get_doc("Presentation", theme).slides if frappe.db.exists("Presentation", theme) else []
+
+
+def get_permission_query_conditions(user):
+	if user == "Administrator":
+		return ""
+
+	if frappe.has_permission("Presentation", "read", user=user):
+		return f"`tabPresentation`.owner = '{user}' OR `tabPresentation`.is_template = 1"
+
+
+def has_permission(doc, ptype="read", user=None):
+	if user == "Administrator":
+		return True
+
+	user_roles = set(frappe.get_roles(user))
+
+	if "Slides User" in user_roles:
+		return doc.owner == user or (doc.is_template and ptype == "read")
+
+	return False

--- a/slides/slides/doctype/presentation/presentation.py
+++ b/slides/slides/doctype/presentation/presentation.py
@@ -183,15 +183,17 @@ def duplicate_slide(name, index):
 
 
 @frappe.whitelist()
-def create_presentation(title, theme, duplicate_from=None):
+def create_presentation(title, theme=None, duplicate_from=None):
 	new_presentation = frappe.new_doc("Presentation")
 	new_presentation.title = title
 	new_presentation.theme = theme
 	new_presentation.insert()
 	if duplicate_from:
 		presentation = frappe.get_doc("Presentation", duplicate_from)
-		new_presentation.name = None
 		new_presentation.slides = presentation.slides
+		new_presentation.theme = presentation.theme
+		for slide in new_presentation.slides:
+			slide.parent = new_presentation.name
 	else:
 		template = frappe.get_doc("Presentation", theme)
 		first_slide_layout = template.slides[2].name

--- a/slides/slides/doctype/slide/slide.json
+++ b/slides/slides/doctype/slide/slide.json
@@ -17,11 +17,13 @@
   {
    "fieldname": "background",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Background"
   },
   {
    "fieldname": "elements",
    "fieldtype": "JSON",
+   "in_list_view": 1,
    "label": "Elements"
   },
   {
@@ -31,6 +33,7 @@
   {
    "fieldname": "thumbnail",
    "fieldtype": "Long Text",
+   "in_list_view": 1,
    "label": "Thumbnail"
   },
   {
@@ -50,7 +53,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-07-30 17:21:17.635084",
+ "modified": "2025-08-09 20:18:36.388809",
  "modified_by": "Administrator",
  "module": "Slides",
  "name": "Slide",


### PR DESCRIPTION
### Changes

- Fix alignment controls.
- Fix missing theme while duplicating presentation.
- Fix overridden caret color by ProseMirror.
- Add border to presentation title while editing.
- Add `permission_query_conditions` and `has_permission` hooks for allowing templates as well as owned documents for all users.