### PR TITLE
feat: delete slide after explicit selection

### DIFF
--- a/frontend/src/components/MediaProperties.vue
+++ b/frontend/src/components/MediaProperties.vue
@@ -61,6 +61,14 @@
 			</div>
 
 			<SliderInput
+				label="Spread"
+				:rangeStart="0"
+				:rangeEnd="500"
+				:modelValue="parseFloat(activeElement.shadowSpread)"
+				@update:modelValue="(value) => setProperty('shadowSpread', value)"
+			/>
+
+			<SliderInput
 				label="Offset X"
 				:rangeStart="-50"
 				:rangeEnd="50"
@@ -74,14 +82,6 @@
 				:rangeEnd="50"
 				:modelValue="parseFloat(activeElement.shadowOffsetY)"
 				@update:modelValue="(value) => setProperty('shadowOffsetY', value)"
-			/>
-
-			<SliderInput
-				label="Spread"
-				:rangeStart="1"
-				:rangeEnd="500"
-				:modelValue="parseFloat(activeElement.shadowSpread)"
-				@update:modelValue="(value) => setProperty('shadowSpread', value)"
 			/>
 		</template>
 	</CollapsibleSection>

--- a/frontend/src/components/NavigationPanel.vue
+++ b/frontend/src/components/NavigationPanel.vue
@@ -125,7 +125,7 @@ const getThumbnailClasses = (slide) => {
 	if (isFocused) {
 		outlineClasses += 'ring-blue-300 ring-2 ring-offset-1'
 	} else if (isActive && props.recentlyRestored) {
-		outlineClasses += 'ring-blue-200 ring-[2px] ring-offset-2 scale-[1.01]'
+		outlineClasses += 'ring-blue-300 ring-[2px] ring-offset-2 scale-[1.01]'
 	} else if (isActive) {
 		outlineClasses += 'ring-gray-400 ring-[1.5px] ring-offset-1'
 	} else {

--- a/frontend/src/components/NavigationPanel.vue
+++ b/frontend/src/components/NavigationPanel.vue
@@ -17,7 +17,7 @@
 					<div
 						:class="getThumbnailClasses(slide)"
 						:style="getThumbnailStyles(slide)"
-						@click="emit('changeSlide', slides.indexOf(slide))"
+						@click="handleSlideClick(slide)"
 						:ref="(el) => (slideThumbnailsRef[slides.indexOf(slide)] = el)"
 					></div>
 				</template>
@@ -53,7 +53,7 @@ import { call } from 'frappe-ui'
 
 import Draggable from 'vuedraggable'
 
-import { slides, slideIndex, currentSlide } from '@/stores/slide'
+import { slides, slideIndex, currentSlide, focusedSlide } from '@/stores/slide'
 import { handleScrollBarWheelEvent } from '@/utils/helpers'
 
 import { useAttrs } from 'vue'
@@ -100,17 +100,32 @@ const panelClasses = computed(() => {
 	return [...baseClasses, positionClass]
 })
 
+const isSlideActive = (slide) => {
+	return slideIndex.value == slides.value.indexOf(slide)
+}
+
+const handleSlideClick = async (slide) => {
+	if (isSlideActive(slide)) {
+		focusedSlide.value = slideIndex.value
+		return
+	}
+	emit('changeSlide', slides.value.indexOf(slide))
+}
+
 const getThumbnailClasses = (slide) => {
 	const baseClasses =
 		'my-4 first:mt-0 w-full aspect-video cursor-pointer rounded bg-center bg-no-repeat bg-cover border transition-all duration-400 ease-in-out'
 
-	const isActiveSlide = slideIndex.value == slides.value.indexOf(slide)
+	const isActive = isSlideActive(slide)
+	const isFocused = focusedSlide.value == slides.value.indexOf(slide)
 
 	let outlineClasses = ''
-	if (isActiveSlide && props.recentlyRestored) {
+	if (isFocused) {
+		outlineClasses += 'ring-blue-300 ring-2 ring-offset-1'
+	} else if (isActive && props.recentlyRestored) {
 		outlineClasses += 'ring-blue-200 ring-[2px] ring-offset-2 scale-[1.01]'
-	} else if (isActiveSlide) {
-		outlineClasses += 'ring-blue-300 ring-[1.5px] ring-offset-1'
+	} else if (isActive) {
+		outlineClasses += 'ring-gray-400 ring-[1.5px] ring-offset-1'
 	} else {
 		outlineClasses += 'ring-white hover:border-gray-300'
 	}

--- a/frontend/src/components/NavigationPanel.vue
+++ b/frontend/src/components/NavigationPanel.vue
@@ -13,7 +13,7 @@
 			class="flex h-full flex-col overflow-y-auto p-4 pb-14 custom-scrollbar"
 			:style="scrollbarStyles"
 		>
-			<Draggable v-model="slides" item-key="name" @end="handleSortEnd">
+			<Draggable v-model="slides" item-key="name" @start="resetFocus" @end="handleSortEnd">
 				<template #item="{ element: slide }">
 					<div
 						:class="getThumbnailClasses(slide)"
@@ -59,6 +59,7 @@ import { handleScrollBarWheelEvent } from '@/utils/helpers'
 
 import { useAttrs } from 'vue'
 import { ignoreUpdates } from '@/stores/presentation'
+import { resetFocus } from '@/stores/element'
 
 const attrs = useAttrs()
 

--- a/frontend/src/components/NavigationPanel.vue
+++ b/frontend/src/components/NavigationPanel.vue
@@ -5,6 +5,7 @@
 		@mouseenter="handleHoverChange"
 		@mouseleave="handleHoverChange"
 		@wheel="handleScrollBarWheelEvent"
+		@click.stop
 	>
 		<div
 			ref="scrollableArea"

--- a/frontend/src/components/PresentationActionDialog.vue
+++ b/frontend/src/components/PresentationActionDialog.vue
@@ -1,5 +1,5 @@
 <template>
-	<Dialog class="pb-0" :options="{ size: 'sm' }">
+	<Dialog class="pb-0" :options="{ size: 'sm' }" @close="handleDialogClose">
 		<template #body-title>
 			<div class="font-semibold">{{ dialogAction }} Presentation</div>
 		</template>
@@ -75,7 +75,7 @@ const performAction = async () => {
 
 	if (!props.dialogAction || !props.presentation) return
 
-	emit('closeDialog')
+	handleDialogClose()
 
 	let newPresentationId
 	switch (action) {
@@ -132,9 +132,27 @@ watch(
 		}
 
 		newPresentationTitle.value = newTitle
-		nextTick(() => {
-			document.querySelector('input')?.focus()
-		})
+		handleDialogOpen()
 	},
 )
+
+const handleEnterKey = (e) => {
+	if (e.key === 'Enter') {
+		e.preventDefault()
+		performAction()
+	}
+}
+
+const handleDialogOpen = () => {
+	document.addEventListener('keydown', handleEnterKey)
+
+	nextTick(() => {
+		document.querySelector('input')?.focus()
+	})
+}
+
+const handleDialogClose = () => {
+	document.removeEventListener('keydown', handleEnterKey)
+	emit('closeDialog')
+}
 </script>

--- a/frontend/src/components/PresentationHeader.vue
+++ b/frontend/src/components/PresentationHeader.vue
@@ -18,7 +18,7 @@ import { useRoute, useRouter } from 'vue-router'
 
 import { call } from 'frappe-ui'
 
-import { updatePresentationTitle } from '@/stores/presentation'
+import { unsyncedPresentationRecord, updatePresentationTitle } from '@/stores/presentation'
 import { setCursorPositionAtEnd } from '@/utils/helpers'
 
 const props = defineProps({
@@ -66,6 +66,7 @@ const saveTitle = async (e) => {
 
 	if (newTitle != props.title) {
 		const slug = await updatePresentationTitle(route.params.presentationId, newTitle)
+		unsyncedPresentationRecord.value.title = newTitle
 		router.replace({
 			name: 'PresentationEditor',
 			params: { presentationId: route.params.presentationId, slug: slug },

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -53,7 +53,7 @@ import {
 	handlePaste,
 	focusElementId,
 	pairElementId,
-	updateElementWidth,
+	addFixedWidthToElement,
 	setEditableState,
 } from '@/stores/element'
 
@@ -310,6 +310,8 @@ const handleDimensionChange = (delta) => {
 	delta.top = applyAspectRatio(delta.top)
 
 	applyPositionDelta(delta)
+
+	if (!activeElement.value.width) addFixedWidthToElement()
 
 	applyDimensionDelta(delta)
 }

--- a/frontend/src/components/SlideElement.vue
+++ b/frontend/src/components/SlideElement.vue
@@ -20,12 +20,7 @@ import ImageElement from '@/components/ImageElement.vue'
 import VideoElement from '@/components/VideoElement.vue'
 import Resizer from '@/components/Resizer.vue'
 
-import {
-	activeElement,
-	activeElementIds,
-	focusElementId,
-	updateElementWidth,
-} from '@/stores/element'
+import { activeElement, activeElementIds, focusElementId } from '@/stores/element'
 
 import { selectionBounds, slideBounds } from '@/stores/slide'
 
@@ -77,11 +72,17 @@ const elementStyle = computed(() => {
 
 	const elementLeft = element.value.left + offsetLeft
 	const elementTop = element.value.top + offsetTop
-	const elementWidth = element.value.width + offsetWidth
+
+	let elementWidth = element.value.width
+	if (elementWidth) {
+		elementWidth = `${elementWidth + offsetWidth}px`
+	} else {
+		elementWidth = 'auto'
+	}
 
 	return {
 		position: 'absolute',
-		width: `${elementWidth}px` || 'auto',
+		width: elementWidth,
 		height: 'auto',
 		left: `${elementLeft}px`,
 		top: `${elementTop}px`,

--- a/frontend/src/components/TextElement.vue
+++ b/frontend/src/components/TextElement.vue
@@ -9,7 +9,7 @@
 	<div
 		v-else
 		v-html="element.content"
-		class="textElement select-none"
+		class="textElement select-none break-words"
 		:style="element.editorMetadata"
 		@dblclick="handleDoubleClick"
 	></div>

--- a/frontend/src/components/TextProperties.vue
+++ b/frontend/src/components/TextProperties.vue
@@ -241,7 +241,7 @@ const applyPresetTextStyles = (textStyle) => {
 		.focus()
 		.selectAll()
 		.setMark('textStyle', {
-			fontFamily: 'Arial',
+			fontFamily: 'Inter',
 			fontSize: presetStyles.fontSize,
 			lineHeight: presetStyles.lineHeight,
 			letterSpacing: 0,

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,7 +1,7 @@
 import './index.css'
 
 import { createApp } from 'vue'
-import router from './router'
+import { router } from './router'
 import App from './App.vue'
 
 import { Button, setConfig, frappeRequest, resourcesPlugin } from 'frappe-ui'

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -75,6 +75,7 @@ import {
 	initHistory,
 	ignoreUpdates,
 	unsyncedPresentationRecord,
+	inSlideShow,
 } from '@/stores/presentation'
 import {
 	slides,
@@ -541,6 +542,7 @@ watch(
 watch(
 	() => props.activeSlideId,
 	(index) => {
+		if (inSlideShow.value) return
 		slideIndex.value = parseInt(index) - 1 || 0
 	},
 	{ immediate: true },

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -321,9 +321,9 @@ const changeSlide = async (index) => {
 
 	const oldIndex = slideIndex.value
 
-	await resetFocus()
-
 	focusedSlide.value = null
+
+	await resetFocus()
 
 	await router.replace({
 		query: { slide: index + 1 },
@@ -445,7 +445,7 @@ const initIntervals = () => {
 	autosaveInterval = setInterval(handleAutoSave, 500)
 	thumbnailInterval = setInterval(() => {
 		handleThumbnailGeneration(slideIndex.value)
-	}, 1000)
+	}, 1500)
 }
 
 const loadPresentation = async (id) => {

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -74,6 +74,7 @@ import {
 	historyState,
 	initHistory,
 	ignoreUpdates,
+	unsyncedPresentationRecord,
 } from '@/stores/presentation'
 import {
 	slides,
@@ -463,7 +464,16 @@ onActivated(() => {
 	document.addEventListener('keydown', handleKeyDown)
 })
 
+const updateUnsyncedRecord = () => {
+	unsyncedPresentationRecord.value = {
+		...unsyncedPresentationRecord.value,
+		modified: presentationDoc.value.modified,
+		thumbnail: slides.value[0]?.thumbnail,
+	}
+}
+
 onDeactivated(async () => {
+	updateUnsyncedRecord()
 	clearInterval(autosaveInterval)
 	clearInterval(thumbnailInterval)
 	await resetFocus()

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -1,5 +1,8 @@
 <template>
-	<div class="flex h-screen w-screen select-none flex-col overflow-hidden">
+	<div
+		class="flex h-screen w-screen select-none flex-col overflow-hidden"
+		@click="focusedSlide = null"
+	>
 		<Navbar :primaryButton="primaryButtonProps">
 			<template #default>
 				<PresentationHeader :title="presentationDoc?.title" />

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -80,6 +80,7 @@ import {
 	updateSelectionBounds,
 	getSlideThumbnail,
 	getThumbnailHtml,
+	focusedSlide,
 } from '@/stores/slide'
 import {
 	resetFocus,
@@ -323,6 +324,7 @@ const changeSlide = async (index) => {
 	if (index < 0 || index >= slides.value.length) return
 
 	resetFocus()
+	focusedSlide.value = null
 
 	await router.replace({
 		query: { slide: index + 1 },
@@ -373,24 +375,32 @@ const insertSlide = (index, layoutId, toDuplicate) => {
 }
 
 const deleteSlide = () => {
+	if (focusedSlide.value == null) return
+
+	const deleteIndex = focusedSlide.value
+
 	// if there is only one slide, reset the slide state instead of deleting
 	const totalLength = slides.value.length
 
 	if (totalLength == 1) {
 		slides.value[0].elements = []
+		focusedSlide.value = null
 		return
 	}
 
-	if (slideIndex.value == totalLength - 1) {
-		// if last slide is deleted, switch to previous slide since no slide at current index
-		changeSlide(slideIndex.value - 1)
-	}
-
 	// delete the current slide
-	slides.value = slides.value.filter((slide, i) => i != slideIndex.value)
+	slides.value = slides.value.filter((slide, i) => {
+		return i != deleteIndex
+	})
 	slides.value.forEach((slide, index) => {
 		slide.idx = index + 1
 	})
+
+	if (deleteIndex == totalLength - 1) {
+		// if last slide is deleted, switch to previous slide since no slide at current index
+		changeSlide(deleteIndex - 1)
+		focusedSlide.value = deleteIndex - 1
+	}
 }
 
 const duplicateSlide = (e) => {

--- a/frontend/src/pages/Slideshow.vue
+++ b/frontend/src/pages/Slideshow.vue
@@ -2,7 +2,7 @@
 	<div class="absolute left-0 top-0 h-full w-full bg-black">
 		<div
 			ref="slideContainer"
-			class="flex h-screen w-full items-center justify-center"
+			class="flex h-screen w-full items-center justify-center bg-white"
 			:style="{
 				clipPath: clipPath,
 			}"

--- a/frontend/src/pages/Slideshow.vue
+++ b/frontend/src/pages/Slideshow.vue
@@ -7,7 +7,10 @@
 				clipPath: clipPath,
 			}"
 		>
-			<div v-if="slideshowEnded" class="flex flex-col items-center gap-8">
+			<div
+				v-if="slideshowEnded"
+				class="flex h-full w-full items-center justify-center bg-black"
+			>
 				<div class="flex gap-8">
 					<Button
 						label="Back"

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -62,7 +62,11 @@ const hasAccess = async (presentationId: string) => {
 	}
 }
 
-router.beforeEach(async (to, _, next) => {
+let previousRoute = null
+
+
+router.beforeEach(async (to, from, next) => {
+	previousRoute = from
 	const isLoggedIn = session.isLoggedIn
 
 	if (!isLoggedIn) {
@@ -94,4 +98,4 @@ router.beforeEach(async (to, _, next) => {
 	}
 })
 
-export default router
+export { router, previousRoute }

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -1,7 +1,14 @@
 import { ref, computed, nextTick, watch } from 'vue'
 import { call, createResource } from 'frappe-ui'
 
-import { selectionBounds, slides, slideBounds, updateSelectionBounds, currentSlide } from './slide'
+import {
+	selectionBounds,
+	slides,
+	slideBounds,
+	updateSelectionBounds,
+	currentSlide,
+	focusedSlide,
+} from './slide'
 import { useTextEditor } from '@/composables/useTextEditor'
 
 import { generateUniqueId } from '../utils/helpers'
@@ -296,6 +303,7 @@ const resetFocus = () => {
 	activeElementIds.value = []
 	focusElementId.value = null
 	pairElementId.value = null
+	focusedSlide.value = null
 }
 
 const getElementPosition = (elementId) => {

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -8,6 +8,8 @@ import {
 	updateSelectionBounds,
 	currentSlide,
 	focusedSlide,
+	slideIndex,
+	updateThumbnail,
 } from './slide'
 import { useTextEditor } from '@/composables/useTextEditor'
 
@@ -286,11 +288,9 @@ const deleteAttachments = async (elements) => {
 
 const deleteElements = async (e, ids) => {
 	const idsToDelete = ids || activeElementIds.value
-	resetFocus()
-	nextTick(() => {
-		currentSlide.value.elements = currentSlide.value.elements.filter((element) => {
-			return !idsToDelete.includes(element.id)
-		})
+	await resetFocus()
+	currentSlide.value.elements = currentSlide.value.elements.filter((element) => {
+		return !idsToDelete.includes(element.id)
 	})
 }
 
@@ -299,10 +299,16 @@ const selectAllElements = (e) => {
 	activeElementIds.value = currentSlide.value.elements.map((element) => element.id)
 }
 
-const resetFocus = () => {
+const resetFocus = async () => {
+	const index = slideIndex.value
+
 	activeElementIds.value = []
 	focusElementId.value = null
 	pairElementId.value = null
+
+	await nextTick()
+
+	await updateThumbnail(index)
 }
 
 const getElementPosition = (elementId) => {
@@ -342,8 +348,8 @@ const handleCopy = (e) => {
 	copiedFromId.value = presentationId.value
 }
 
-const handlePastedText = (clipboardText) => {
-	resetFocus()
+const handlePastedText = async (clipboardText) => {
+	await resetFocus()
 	addTextElement(clipboardText)
 }
 

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -303,7 +303,6 @@ const resetFocus = () => {
 	activeElementIds.value = []
 	focusElementId.value = null
 	pairElementId.value = null
-	focusedSlide.value = null
 }
 
 const getElementPosition = (elementId) => {

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -378,16 +378,11 @@ const handlePaste = (e) => {
 	if (clipboardJSON) handlePastedJSON(JSON.parse(clipboardJSON))
 }
 
-const updateElementWidth = (deltaWidth) => {
-	const element = activeElement.value
-
-	if (element.width) {
-		element.width += deltaWidth
-	} else {
-		const elementDiv = document.querySelector(`[data-index="${element.id}"]`)
-		const width = elementDiv.getBoundingClientRect().width
-
-		element.width = width + deltaWidth
+const addFixedWidthToElement = (deltaWidth) => {
+	const elementDiv = document.querySelector(`[data-index="${activeElement.value.id}"]`)
+	if (elementDiv) {
+		const rect = elementDiv.getBoundingClientRect()
+		activeElement.value.width = rect.width
 	}
 }
 
@@ -463,7 +458,7 @@ export {
 	getElementPosition,
 	handleCopy,
 	handlePaste,
-	updateElementWidth,
+	addFixedWidthToElement,
 	deleteAttachments,
 	setEditableState,
 }

--- a/frontend/src/stores/presentation.js
+++ b/frontend/src/stores/presentation.js
@@ -193,6 +193,8 @@ const initHistory = () => {
 	})
 }
 
+const unsyncedPresentationRecord = ref({})
+
 export {
 	presentationId,
 	inSlideShow,
@@ -209,4 +211,5 @@ export {
 	historyState,
 	initHistory,
 	ignoreUpdates,
+	unsyncedPresentationRecord,
 }

--- a/frontend/src/stores/presentation.js
+++ b/frontend/src/stores/presentation.js
@@ -167,7 +167,7 @@ const updateHistoryState = (slides, activeSlide, elementIds) => {
 
 	historyState.value = {
 		elementIds: elementIds,
-		activeSlide: Number(activeSlide),
+		activeSlide: activeSlide,
 		slides: slidesClone,
 	}
 }
@@ -185,6 +185,7 @@ const { ignoreUpdates } = watchIgnorable(
 )
 
 const initHistory = () => {
+	historyState.value.activeSlide = slideIndex.value
 	historyControl = useManualRefHistory(historyState, {
 		capacity: 25,
 		clone: true,

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -1,3 +1,4 @@
+import { ignoreUpdates } from '@/stores/presentation'
 import { ref, computed, reactive } from 'vue'
 
 import html2canvas from 'html2canvas'
@@ -123,6 +124,22 @@ const getSlideThumbnail = async (thumbnailHtml) => {
 	return canvas.toDataURL('image/png')
 }
 
+const lastThumbnailTime = ref(0)
+
+const updateThumbnail = async (index) => {
+	const thumbnailHtml = await getThumbnailHtml()
+	if (!thumbnailHtml) return
+
+	const thumbnail = await getSlideThumbnail(thumbnailHtml)
+
+	ignoreUpdates(() => {
+		if (!slides.value[index]) return
+		slides.value[index].thumbnail = thumbnail
+	})
+
+	lastThumbnailTime.value = Date.now()
+}
+
 const slideBounds = reactive({})
 
 const updateSelectionBounds = (newBounds) => {
@@ -147,7 +164,7 @@ export {
 	guideVisibilityMap,
 	updateSelectionBounds,
 	setSlideRef,
-	getSlideThumbnail,
-	getThumbnailHtml,
+	updateThumbnail,
 	focusedSlide,
+	lastThumbnailTime,
 }

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -9,6 +9,7 @@ const setSlideRef = (ref) => (slideRef.value = ref)
 const slides = ref([])
 
 const slideIndex = ref()
+const focusedSlide = ref(null)
 
 const currentSlide = computed(() => slides.value[slideIndex.value])
 
@@ -148,4 +149,5 @@ export {
 	setSlideRef,
 	getSlideThumbnail,
 	getThumbnailHtml,
+	focusedSlide,
 }

--- a/slides/slides/doctype/presentation/presentation.py
+++ b/slides/slides/doctype/presentation/presentation.py
@@ -143,6 +143,10 @@ def create_new_slide(parent, ref_id):
 def get_slides_from_ref(parent, theme, duplicate_from):
 	ref_name = duplicate_from or theme or "Light"
 	ref_presentation = frappe.get_doc("Presentation", ref_name)
+
+	if ref_presentation and not frappe.has_permission("Presentation", "read", ref_presentation):
+		return []
+
 	slides = []
 
 	if duplicate_from:
@@ -214,7 +218,10 @@ def get_updated_json(presentation, json):
 
 @frappe.whitelist()
 def get_layouts(theme):
-	return frappe.get_doc("Presentation", theme).slides if frappe.db.exists("Presentation", theme) else []
+	layout_doc = frappe.get_doc("Presentation", theme) if frappe.db.exists("Presentation", theme) else None
+	if layout_doc and layout_doc.is_template and frappe.has_permission("Presentation", "read", layout_doc):
+		return layout_doc.slides
+	return []
 
 
 def get_permission_query_conditions(user):


### PR DESCRIPTION
Add an intermediate stage before deleting the current slide. Before if nothing on the slide was selected, focus was assumed on the slide and clicking delete would directly remove the slide.

Now, the user has to explicitly click on the slide before the delete shortcut works for the slide context.


#### Misc

- Fix thumbnail generation for the case when user is still in editable mode for a text element and directly clicks on some other slide to switch to that slide.
- Fix thumbnail generation after history operations so updated thumbnail is correctly visible irrespective of index or re-ordering.