### PR TITLE
fix: condition for old thumbnail deletion

### DIFF
--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -543,7 +543,8 @@ watch(
 	() => props.activeSlideId,
 	(index) => {
 		if (inSlideShow.value) return
-		slideIndex.value = parseInt(index) - 1 || 0
+		index = parseInt(index) - 1 || 0
+		slideIndex.value = Math.min(index, slides.value.length - 1)
 	},
 	{ immediate: true },
 )

--- a/slides/slides/doctype/presentation/presentation.json
+++ b/slides/slides/doctype/presentation/presentation.json
@@ -55,7 +55,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-08-01 16:14:27.095749",
+ "modified": "2025-08-26 15:02:44.412226",
  "modified_by": "Administrator",
  "module": "Slides",
  "name": "Presentation",
@@ -76,7 +76,6 @@
   {
    "create": 1,
    "delete": 1,
-   "if_owner": 1,
    "read": 1,
    "role": "Slides User",
    "select": 1,

--- a/slides/slides/doctype/presentation/presentation.py
+++ b/slides/slides/doctype/presentation/presentation.py
@@ -26,21 +26,19 @@ class Presentation(Document):
 			if not old_slide:
 				continue
 			if slide.thumbnail and slide.thumbnail.startswith("data:image"):
-				old_thumbnail = old_slides[slide.idx - 1].thumbnail
-				delete_old_thumbnail(slide.name, old_thumbnail)
+				old_thumbnail = old_slide.thumbnail
+				delete_old_thumbnail(old_thumbnail)
 				slide.thumbnail = save_base64_thumbnail(slide.thumbnail, self.name, "thumbnail")
 
 	def validate(self):
 		self.update_thumbnails()
 
 
-def delete_old_thumbnail(slide_id: Document, old_thumbnail: str | None = None):
+def delete_old_thumbnail(old_thumbnail: str | None = None):
 	if old_thumbnail and old_thumbnail.startswith("/private/files/"):
-		if frappe.db.exists("Slide", {"thumbnail": old_thumbnail, "name": ["!=", slide_id]}):
-			return
 		try:
-			file_doc = frappe.db.get_value("File", {"file_url": old_thumbnail})
-			frappe.delete_doc("File", file_doc)
+			file_docname = frappe.db.get_value("File", {"file_url": old_thumbnail})
+			frappe.delete_doc("File", file_docname)
 		except Exception as e:
 			frappe.log_error(f"Failed to remove old thumbnail: {e}")
 


### PR DESCRIPTION
#### Fixes

- Since thumbnails are re-generated on losing focus on client side anyway, duplicated slides don't have same urls so skip extra check before deleting thumbnails.

- Explicitly cap the value that can be set on `slideIndex` after ending slideshow because watcher might run before `inSlideshow` is updated when escaping full screen mode.