### PR TITLE
feat: play unplayed video as next step in slideshow

### DIFF
--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -449,9 +449,15 @@ const initIntervals = () => {
 	}, 1500)
 }
 
+const setSlideIndex = (index) => {
+	index = parseInt(index) - 1 || 0
+	slideIndex.value = Math.min(index, slides.value.length - 1)
+}
+
 const loadPresentation = async (id) => {
 	initHistory()
 	presentationDoc.value = await initPresentationDoc(id)
+	setSlideIndex(props.activeSlideId)
 	updateRoute(presentationDoc.value.slug)
 	layoutResource.fetch({ theme: presentationDoc.value.theme })
 	initIntervals()
@@ -542,9 +548,8 @@ watch(
 watch(
 	() => props.activeSlideId,
 	(index) => {
-		if (inSlideShow.value) return
-		index = parseInt(index) - 1 || 0
-		slideIndex.value = Math.min(index, slides.value.length - 1)
+		if (!slides.value.length) return
+		setSlideIndex(index)
 	},
 	{ immediate: true },
 )

--- a/frontend/src/pages/Slideshow.vue
+++ b/frontend/src/pages/Slideshow.vue
@@ -212,11 +212,30 @@ const handleFullScreenChange = () => {
 	}
 }
 
+const performPreviousStep = () => {
+	const videoEl = document.querySelector('video')
+	if (videoEl && videoEl.currentTime > 0) {
+		videoEl.currentTime = 0
+		videoEl.pause()
+		return
+	}
+	changeSlide(slideIndex.value - 1)
+}
+
+const performNextStep = () => {
+	const videoEl = document.querySelector('video')
+	if (videoEl && videoEl.currentTime == 0 && videoEl.paused) {
+		videoEl.play()
+		return
+	}
+	changeSlide(slideIndex.value + 1)
+}
+
 const handleKeyDown = (e) => {
 	if (e.key == 'ArrowRight' || e.key == 'ArrowDown') {
-		changeSlide(slideIndex.value + 1)
+		performNextStep()
 	} else if (e.key == 'ArrowLeft' || e.key == 'ArrowUp') {
-		changeSlide(slideIndex.value - 1)
+		performPreviousStep()
 	} else if (e.key == 'F5') {
 		e.preventDefault()
 		changeSlide(0)

--- a/frontend/src/pages/Slideshow.vue
+++ b/frontend/src/pages/Slideshow.vue
@@ -232,7 +232,7 @@ const performNextStep = () => {
 }
 
 const handleKeyDown = (e) => {
-	if (e.key == 'ArrowRight' || e.key == 'ArrowDown') {
+	if (e.key == 'ArrowRight' || e.key == 'ArrowDown' || e.code == 'Space') {
 		performNextStep()
 	} else if (e.key == 'ArrowLeft' || e.key == 'ArrowUp') {
 		performPreviousStep()


### PR DESCRIPTION
When there's a playable video on current slide, play the video as next step instead of switching to next slide.

Add Spacebar to next step shortcuts along with right and down arrow keys.

Closes https://github.com/frappe/slides/issues/72