### PR TITLE
feat: consistent media replacement irrespective of layouts

### DIFF
--- a/frontend/src/components/DropTargetOverlay.vue
+++ b/frontend/src/components/DropTargetOverlay.vue
@@ -13,6 +13,7 @@ import { nextTick, ref, useTemplateRef } from 'vue'
 
 import { presentationId } from '@/stores/presentation'
 import { handleUploadedMedia } from '@/utils/mediaUploads'
+import { currentSlide } from '@/stores/slide'
 
 const emit = defineEmits(['hideOverlay'])
 
@@ -27,12 +28,17 @@ const handleMediaDrop = async (e) => {
 	e.preventDefault()
 	emit('hideOverlay')
 	nextTick(() => {
-		let targetId = null
+		let targetElement = null
 		const target = document.elementFromPoint(e.clientX, e.clientY)
-		if (target.tagName == 'IMG') {
-			targetId = target.parentElement.parentElement.getAttribute('data-index')
+		const closestElement = target.closest('[data-index]')
+		if (closestElement) {
+			const elementId = closestElement.getAttribute('data-index')
+			const element = currentSlide.value.elements.find((el) => el.id == elementId)
+			if (element && ['image', 'video'].includes(element.type)) {
+				targetElement = element
+			}
 		}
-		handleUploadedMedia(e.dataTransfer.files, targetId)
+		handleUploadedMedia(e.dataTransfer.files, targetElement)
 	})
 }
 </script>

--- a/frontend/src/components/DropTargetOverlay.vue
+++ b/frontend/src/components/DropTargetOverlay.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script setup>
-import { nextTick, ref, useTemplateRef } from 'vue'
+import { ref, useTemplateRef, nextTick } from 'vue'
 
 import { presentationId } from '@/stores/presentation'
 import { handleUploadedMedia } from '@/utils/mediaUploads'
@@ -24,20 +24,24 @@ const handleDragLeave = (e) => {
 	emit('hideOverlay')
 }
 
+const getTargetElement = (e) => {
+	const target = document.elementFromPoint(e.clientX, e.clientY).closest('[data-index]')
+
+	if (!target) return null
+
+	const elementId = target.getAttribute('data-index')
+	const element = currentSlide.value.elements.find((el) => el.id == elementId)
+
+	if (element && ['image', 'video'].includes(element.type)) {
+		return element
+	}
+}
+
 const handleMediaDrop = async (e) => {
 	e.preventDefault()
 	emit('hideOverlay')
 	nextTick(() => {
-		let targetElement = null
-		const target = document.elementFromPoint(e.clientX, e.clientY)
-		const closestElement = target.closest('[data-index]')
-		if (closestElement) {
-			const elementId = closestElement.getAttribute('data-index')
-			const element = currentSlide.value.elements.find((el) => el.id == elementId)
-			if (element && ['image', 'video'].includes(element.type)) {
-				targetElement = element
-			}
-		}
+		const targetElement = getTargetElement(e)
 		handleUploadedMedia(e.dataTransfer.files, targetElement)
 	})
 }

--- a/frontend/src/components/DropTargetOverlay.vue
+++ b/frontend/src/components/DropTargetOverlay.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script setup>
-import { ref, useTemplateRef } from 'vue'
+import { nextTick, ref, useTemplateRef } from 'vue'
 
 import { presentationId } from '@/stores/presentation'
 import { handleUploadedMedia } from '@/utils/mediaUploads'
@@ -20,12 +20,19 @@ const overlayRef = useTemplateRef('overlay')
 
 const handleDragLeave = (e) => {
 	e.preventDefault()
-	emit('hideOverlay', false)
+	emit('hideOverlay')
 }
 
 const handleMediaDrop = async (e) => {
 	e.preventDefault()
-	emit('hideOverlay', false)
-	handleUploadedMedia(e.dataTransfer.files)
+	emit('hideOverlay')
+	nextTick(() => {
+		let targetId = null
+		const target = document.elementFromPoint(e.clientX, e.clientY)
+		if (target.tagName == 'IMG') {
+			targetId = target.parentElement.parentElement.getAttribute('data-index')
+		}
+		handleUploadedMedia(e.dataTransfer.files, targetId)
+	})
 }
 </script>

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -232,7 +232,7 @@ const addMediaElement = async (file, type) => {
 		borderColor: '',
 		shadowOffsetX: 0,
 		shadowOffsetY: 0,
-		shadowSpread: 1,
+		shadowSpread: 0,
 		shadowColor: '#000000ff',
 	}
 	if (type == 'video') {

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -248,8 +248,12 @@ const addMediaElement = async (file, type) => {
 	selectAndCenterElement(element.id)
 }
 
-const updateVideoPoster = async (element, videoUrl) => {
-	element.poster = await getVideoPoster(videoUrl)
+const replaceMediaElement = async (element, fileDoc) => {
+	element.src = fileDoc.file_url
+	element.attachmentName = fileDoc.name
+	if (element.type == 'video') {
+		element.poster = await getVideoPoster(fileDoc.file_url)
+	}
 }
 
 const duplicateElements = async (e, elements, displaceByPx = 0) => {
@@ -465,5 +469,5 @@ export {
 	addFixedWidthToElement,
 	deleteAttachments,
 	setEditableState,
-	updateVideoPoster,
+	replaceMediaElement,
 }

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -248,6 +248,10 @@ const addMediaElement = async (file, type) => {
 	selectAndCenterElement(element.id)
 }
 
+const updateVideoPoster = async (element, videoUrl) => {
+	element.poster = await getVideoPoster(videoUrl)
+}
+
 const duplicateElements = async (e, elements, displaceByPx = 0) => {
 	e?.preventDefault()
 
@@ -461,4 +465,5 @@ export {
 	addFixedWidthToElement,
 	deleteAttachments,
 	setEditableState,
+	updateVideoPoster,
 }

--- a/frontend/src/utils/mediaUploads.js
+++ b/frontend/src/utils/mediaUploads.js
@@ -55,6 +55,8 @@ const handleFile = (file, index, length, targetElement) => {
 	const fileType = file.type.split('/')[0]
 	if (!['image', 'video'].includes(fileType)) return
 
+	if (targetElement && targetElement.type != fileType) targetElement = null
+
 	const toastProps = {
 		loading: `Uploading (${index + 1}/${length}): ${file.name}`,
 		success: (data) => `Uploaded: ${file.name}`,

--- a/frontend/src/utils/mediaUploads.js
+++ b/frontend/src/utils/mediaUploads.js
@@ -6,13 +6,13 @@ import { addMediaElement } from '../stores/element'
 
 const fileUploadHandler = new FileUploadHandler()
 
-const performPostUploadActions = (fileDoc, fileType, resolve) => {
-	for (const element of currentSlide.value.elements) {
-		if (!element.useTemplateDimensions) continue
-
-		element.src = fileDoc.file_url
-		element.attachmentName = fileDoc.name
-
+const performPostUploadActions = (fileDoc, fileType, targetId, resolve) => {
+	if (targetId) {
+		const targetElement = currentSlide.value.elements.find((el) => el.id == targetId)
+		if (targetElement) {
+			targetElement.src = fileDoc.file_url
+			targetElement.attachmentName = fileDoc.name
+		}
 		resolve(fileDoc)
 		return
 	}
@@ -21,7 +21,7 @@ const performPostUploadActions = (fileDoc, fileType, resolve) => {
 	resolve(fileDoc)
 }
 
-const uploadMedia = (file, fileType) => {
+const uploadMedia = (file, fileType, targetId) => {
 	return new Promise((resolve, reject) => {
 		fileUploadHandler
 			.upload(file, {
@@ -29,7 +29,7 @@ const uploadMedia = (file, fileType) => {
 				docname: presentationId.value,
 				private: true,
 			})
-			.then((fileDoc) => performPostUploadActions(fileDoc, fileType, resolve))
+			.then((fileDoc) => performPostUploadActions(fileDoc, fileType, targetId, resolve))
 			.catch((error) => {
 				reject(error)
 			})
@@ -52,20 +52,28 @@ const getFileObject = (file) => {
 	}
 }
 
-export const handleUploadedMedia = (files) => {
+const handleFile = (file, index, length, targetId) => {
+	file = getFileObject(file)
+	if (!file) return
+
+	const fileType = file.type.split('/')[0]
+	if (!['image', 'video'].includes(fileType)) return
+
+	const toastProps = {
+		loading: `Uploading (${index + 1}/${length}): ${file.name}`,
+		success: (data) => `Uploaded: ${file.name}`,
+		error: (data) => 'Upload failed. Please try again.',
+	}
+
+	toast.promise(uploadMedia(file, fileType, targetId), toastProps)
+}
+
+export const handleUploadedMedia = (files, targetId) => {
+	if (files.length == 1) {
+		return handleFile(files[0], 0, 1, targetId)
+	}
+
 	files.forEach((file, index) => {
-		file = getFileObject(file)
-		if (!file) return
-
-		const fileType = file.type.split('/')[0]
-		if (!['image', 'video'].includes(fileType)) return
-
-		const toastProps = {
-			loading: `Uploading (${index + 1}/${files.length}): ${file.name}`,
-			success: (data) => `Uploaded: ${file.name}`,
-			error: (data) => 'Upload failed. Please try again.',
-		}
-
-		toast.promise(uploadMedia(file, fileType), toastProps)
+		handleFile(file, index, files.length)
 	})
 }

--- a/frontend/src/utils/mediaUploads.js
+++ b/frontend/src/utils/mediaUploads.js
@@ -48,7 +48,7 @@ const getFileObject = (file) => {
 	}
 }
 
-const handleFile = (file, index, length, targetElement) => {
+const handleFile = (file, toastProps, targetElement) => {
 	file = getFileObject(file)
 	if (!file) return
 
@@ -57,21 +57,27 @@ const handleFile = (file, index, length, targetElement) => {
 
 	if (targetElement && targetElement.type != fileType) targetElement = null
 
-	const toastProps = {
+	toast.promise(uploadMedia(file, fileType, targetElement), toastProps)
+}
+
+const getToastProps = (file, index, length) => {
+	return {
 		loading: `Uploading (${index + 1}/${length}): ${file.name}`,
 		success: (data) => `Uploaded: ${file.name}`,
 		error: (data) => 'Upload failed. Please try again.',
 	}
-
-	toast.promise(uploadMedia(file, fileType, targetElement), toastProps)
 }
 
 export const handleUploadedMedia = (files, targetElement) => {
+	let toastProps = {}
+
 	if (files.length == 1) {
-		return handleFile(files[0], 0, 1, targetElement)
+		toastProps = getToastProps(files[0], 0, 1)
+		return handleFile(files[0], toastProps, targetElement)
 	}
 
 	files.forEach((file, index) => {
-		handleFile(file, index, files.length)
+		toastProps = getToastProps(file, index, files.length)
+		handleFile(file, toastProps)
 	})
 }

--- a/frontend/src/utils/mediaUploads.js
+++ b/frontend/src/utils/mediaUploads.js
@@ -2,17 +2,13 @@ import { FileUploadHandler, toast } from 'frappe-ui'
 
 import { presentationId } from '../stores/presentation'
 import { currentSlide } from '../stores/slide'
-import { addMediaElement, updateVideoPoster } from '../stores/element'
+import { addMediaElement, replaceMediaElement } from '../stores/element'
 
 const fileUploadHandler = new FileUploadHandler()
 
 const performPostUploadActions = (fileDoc, fileType, targetElement, resolve) => {
 	if (targetElement) {
-		targetElement.src = fileDoc.file_url
-		targetElement.attachmentName = fileDoc.name
-		if (fileType == 'video') {
-			updateVideoPoster(targetElement, fileDoc.file_url)
-		}
+		replaceMediaElement(targetElement, fileDoc, fileType)
 		resolve(fileDoc)
 		return
 	}


### PR DESCRIPTION
Made the replacement and creation of media elements on dropping them on the slide more explicit and consistent. This was previously handled differently for layout media and other media. There was no way of replacing the media within an element if it didn't belong to a layout. Now, all media elements work in a consistent way where -

- Dropping an image / video over the same type of element now replaces them. 
- Dropping media anywhere other than that leads to creating a new element and adding it to the slide.

Closes #73 