### PR TITLE
fix: focus issue while duplicating without resetting focus + tiptap fixes

### DIFF
--- a/frontend/src/components/NavigationPanel.vue
+++ b/frontend/src/components/NavigationPanel.vue
@@ -108,6 +108,7 @@ const isSlideActive = (slide) => {
 
 const handleSlideClick = async (slide) => {
 	if (isSlideActive(slide)) {
+		resetFocus()
 		focusedSlide.value = slideIndex.value
 		return
 	}

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -101,7 +101,9 @@ import {
 
 import { generateUniqueId } from '@/utils/helpers'
 
-import { activeEditor } from '@/composables/useTextEditor'
+import { useTextEditor } from '@/composables/useTextEditor'
+
+const { activeEditor, toggleMark } = useTextEditor()
 
 let autosaveInterval = null
 let thumbnailInterval = null
@@ -179,6 +181,15 @@ const handleElementShortcuts = (e) => {
 			break
 		case 'd':
 			if (e.metaKey) duplicateElements(e, activeElements.value, 40)
+			break
+		case 'b':
+			if (activeEditor.value) toggleMark('bold')
+			break
+		case 'i':
+			if (activeEditor.value) toggleMark('italic')
+			break
+		case 'u':
+			if (activeEditor.value) toggleMark('underline')
 			break
 	}
 }


### PR DESCRIPTION
### Fixes

- Correctly reset focus before focusing on slide so duplication for slide triggers instead of element duplication.
- If tiptap editor is not editable toggle marks like bold, underline and italic through shortcuts correctly.
- Remove the implementation for applying styles to list items with an additional transaction. Instead set the styles for the li during rendering with a custom extension. Correctly set them for the sidebar.

   <details>
   <summary>Before</summary>

   <br>

   https://github.com/user-attachments/assets/6e82815d-d597-4aa4-9506-98222b717a8b

   </details>

   <details>
   <summary>After</summary>

   <br>

   https://github.com/user-attachments/assets/42c5945c-4492-4110-b64a-785a41cf2512

   </details>

- Save styles changed with shortcuts within the editor correctly in cases where nothing else changed.