### PR TITLE
feat: convert text element to plain text if in editable mode

### DIFF
--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -347,13 +347,16 @@ const getCopiedJSON = () => {
 	return JSON.stringify(elementsCopy)
 }
 
-const copiedFromId = ref(null)
+const copiedFrom = ref({})
 
 const handleCopy = (e) => {
 	e.preventDefault()
 	const clipboardJSON = getCopiedJSON()
 	e.clipboardData.setData('application/json', clipboardJSON)
-	copiedFromId.value = presentationId.value
+	copiedFrom.value = {
+		srcPresentation: presentationId.value,
+		srcSlide: slideIndex.value,
+	}
 }
 
 const handlePastedText = async (clipboardText) => {
@@ -362,7 +365,9 @@ const handlePastedText = async (clipboardText) => {
 }
 
 const handlePastedJSON = async (json) => {
-	if (copiedFromId.value !== presentationId.value) {
+	const { srcPresentation, srcSlide } = copiedFrom.value
+
+	if (srcPresentation !== presentationId.value) {
 		// if pasted elements are from a different presentation
 		// add file attachments correctly to current presentation + update docnames in json
 		json = await call('slides.slides.doctype.presentation.presentation.get_updated_json', {
@@ -370,6 +375,12 @@ const handlePastedJSON = async (json) => {
 			json: json,
 		})
 	}
+
+	if (srcSlide == slideIndex.value) {
+		duplicateElements(null, json, 40)
+		return
+	}
+
 	duplicateElements(null, json)
 }
 

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -365,6 +365,17 @@ const handlePastedText = async (clipboardText) => {
 }
 
 const handlePastedJSON = async (json) => {
+	const pastedArray = Array.isArray(json) ? json : []
+
+	if (
+		pastedArray[0]?.type == 'text' &&
+		focusElementId.value &&
+		focusElementId.value != pastedArray[0].id
+	) {
+		activeEditor.value.commands.insertContent(pastedArray[0].content)
+		return
+	}
+
 	const { srcPresentation, srcSlide } = copiedFrom.value
 
 	if (srcPresentation !== presentationId.value) {


### PR DESCRIPTION
If a single text element is copied and the user pastes it's content while another text element is focused, paste the content of the element into the current editor instead of creating a separate element for it.

Small fix - If elements are pasted on same slide displace them even for ⌘ C + ⌘ V as well as duplicate.



https://github.com/user-attachments/assets/14f9bc1b-f36b-41c3-a63a-4b56400c958a

