### PR TITLE
feat: wireless presenter shortcuts + fixes

### DIFF
--- a/frontend/src/components/NavigationPanel.vue
+++ b/frontend/src/components/NavigationPanel.vue
@@ -193,14 +193,17 @@ const slideThumbnailsRef = ref([])
 const scrollThumbnailToView = (element) => {
 	if (!scrollableArea.value) return
 
-	const isScrollable = scrollableArea.value.scrollHeight > scrollableArea.value.clientHeight
+	const areaTop = scrollableArea.value.scrollTop
+	const areaHeight = scrollableArea.value.clientHeight
+	const thumbnailTop = element.offsetTop - scrollableArea.value.offsetTop
+	const thumbnailHeight = element.offsetHeight
+	const thumbnailBottom = thumbnailTop + thumbnailHeight
 
-	if (isScrollable) {
-		// adjust offset for top padding - 16px
-		const offset = element.offsetTop - scrollableArea.value.offsetTop - 16
-
+	// Only scroll if thumbnail is partially visible
+	if (thumbnailTop < areaTop || thumbnailBottom > areaTop + areaHeight) {
+		const targetScroll = thumbnailTop - areaHeight / 2 + thumbnailHeight / 2
 		scrollableArea.value.scrollTo({
-			top: offset,
+			top: targetScroll,
 			behavior: 'smooth',
 		})
 	}

--- a/frontend/src/components/NavigationPanel.vue
+++ b/frontend/src/components/NavigationPanel.vue
@@ -55,7 +55,7 @@
 		>
 			<div class="text-2xs text-gray-500">Toggle Sidebar</div>
 			<div class="flex h-5 w-1/3 items-center justify-center rounded-sm border bg-gray-100">
-				<div class="text-xs text-gray-500">⌘ + B</div>
+				<span class="text-xs text-gray-500">{{ getMetaKey() }} + B</span>
 			</div>
 		</div>
 	</div>
@@ -233,6 +233,16 @@ watch(
 		})
 	},
 )
+
+const getMetaKey = () => {
+	const platform = navigator?.platform?.toLowerCase()
+
+	if (platform.includes('mac')) {
+		return '⌘'
+	}
+
+	return 'Ctrl'
+}
 </script>
 
 <style scoped>

--- a/frontend/src/components/NavigationPanel.vue
+++ b/frontend/src/components/NavigationPanel.vue
@@ -47,17 +47,6 @@
 				</div>
 			</template>
 		</div>
-
-		<div
-			v-if="showNavigator && showCollapseShortcut"
-			:class="toggleButtonClasses"
-			@click="toggleNavigator"
-		>
-			<div class="text-2xs text-gray-500">Toggle Sidebar</div>
-			<div class="flex h-5 w-1/3 items-center justify-center rounded-sm border bg-gray-100">
-				<span class="text-xs text-gray-500">{{ getMetaKey() }} + B</span>
-			</div>
-		</div>
 	</div>
 
 	<!-- Slide Navigator Toggle -->
@@ -233,16 +222,6 @@ watch(
 		})
 	},
 )
-
-const getMetaKey = () => {
-	const platform = navigator?.platform?.toLowerCase()
-
-	if (platform.includes('mac')) {
-		return '⌘'
-	}
-
-	return 'Ctrl'
-}
 </script>
 
 <style scoped>

--- a/frontend/src/components/SharePopover.vue
+++ b/frontend/src/components/SharePopover.vue
@@ -38,7 +38,7 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, inject } from 'vue'
 import { Popover, Switch, call, toast } from 'frappe-ui'
 import {
 	presentationId,
@@ -48,6 +48,8 @@ import {
 } from '@/stores/presentation'
 import { resetFocus } from '@/stores/element'
 import { copyToClipboard } from '@/utils/helpers'
+
+const savePresentation = inject('savePresentation', async () => {})
 
 const publicPresentation = ref()
 
@@ -61,6 +63,8 @@ const updateAccessLevel = async (isPublic) => {
 	if (!presentationId.value) return
 
 	publicPresentation.value = isPublic
+
+	await savePresentation()
 
 	call('slides.slides.doctype.presentation.presentation.set_public', {
 		name: presentationId.value,

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -41,6 +41,8 @@ import {
 	onBeforeUnmount,
 	provide,
 	reactive,
+	onActivated,
+	onDeactivated,
 } from 'vue'
 import { useResizeObserver } from '@vueuse/core'
 
@@ -373,7 +375,7 @@ watch(
 	},
 )
 
-onMounted(() => {
+const initSlideAndListeners = () => {
 	if (!slideRef.value) return
 
 	setSlideRef(slideRef.value)
@@ -383,13 +385,21 @@ onMounted(() => {
 	document.addEventListener('copy', handleCopy)
 	document.addEventListener('paste', handlePaste)
 	window.addEventListener('resize', updateSlideBounds)
-})
+}
 
-onBeforeUnmount(() => {
+const clearListeners = () => {
 	document.removeEventListener('copy', handleCopy)
 	document.removeEventListener('paste', handlePaste)
 	window.removeEventListener('resize', updateSlideBounds)
-})
+}
+
+onMounted(() => initSlideAndListeners())
+
+onActivated(() => initSlideAndListeners())
+
+onDeactivated(() => clearListeners())
+
+onBeforeUnmount(() => clearListeners())
 
 provide('slideDiv', slideRef)
 provide('slideContainerDiv', slideContainerRef)

--- a/frontend/src/components/TextElement.vue
+++ b/frontend/src/components/TextElement.vue
@@ -105,7 +105,7 @@ onBeforeMount(() => normalizeContent())
 
 .tiptap > ul li::before,
 .textElement > ul li::before {
-	content: '•';
+	content: '\2022';
 	position: absolute;
 	left: 0;
 	top: 0;

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -49,7 +49,16 @@
 </template>
 
 <script setup>
-import { ref, watch, computed, useTemplateRef, nextTick, onDeactivated, onActivated } from 'vue'
+import {
+	ref,
+	watch,
+	computed,
+	useTemplateRef,
+	nextTick,
+	onDeactivated,
+	onActivated,
+	provide,
+} from 'vue'
 import { useRoute, useRouter, onBeforeRouteLeave } from 'vue-router'
 import { useDebouncedRefHistory, watchIgnorable } from '@vueuse/core'
 
@@ -623,4 +632,6 @@ const handleBeforeUnload = (e) => {
 		e.returnValue = ''
 	}
 }
+
+provide('savePresentation', savePresentation)
 </script>

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -170,6 +170,10 @@ const toggleSlideNavigator = () => {
 	}
 }
 
+const isCmdOrCtrl = (e) => {
+	return e.metaKey || e.ctrlKey
+}
+
 const handleElementShortcuts = (e) => {
 	switch (e.key) {
 		case 'ArrowLeft':
@@ -183,7 +187,7 @@ const handleElementShortcuts = (e) => {
 			deleteElements(e)
 			break
 		case 'd':
-			if (e.metaKey) duplicateElements(e, activeElements.value, 40)
+			if (isCmdOrCtrl(e)) duplicateElements(e, activeElements.value, 40)
 			break
 		case 'b':
 			if (activeEditor.value) toggleMark('bold')
@@ -210,13 +214,13 @@ const handleSlideShortcuts = (e) => {
 			deleteSlide()
 			break
 		case 'd':
-			if (e.metaKey) duplicateSlide(e)
+			if (isCmdOrCtrl(e)) duplicateSlide(e)
 			break
 	}
 }
 
 const handleGlobalShortcuts = (e) => {
-	if (e.code === 'KeyP' && e.metaKey) {
+	if (isCmdOrCtrl(e) && e.code === 'KeyP') {
 		e.preventDefault()
 		startSlideShow()
 		return
@@ -230,13 +234,13 @@ const handleGlobalShortcuts = (e) => {
 			addTextElement()
 			break
 		case 'b':
-			if (e.metaKey) toggleSlideNavigator()
+			if (isCmdOrCtrl(e)) toggleSlideNavigator()
 			break
 		case 'a':
-			if (e.metaKey) selectAllElements(e)
+			if (isCmdOrCtrl(e)) selectAllElements(e)
 			break
 		case 's':
-			if (e.metaKey) saveSlide(e)
+			if (isCmdOrCtrl(e)) saveSlide(e)
 			break
 		case 'n':
 			if (e.ctrlKey) {
@@ -289,10 +293,10 @@ const handleUndoRedo = (e) => {
 		return
 	}
 
-	if (historyControl.canRedo.value && e.shiftKey && e.metaKey) {
+	if (isCmdOrCtrl(e) && e.shiftKey && historyControl.canRedo.value) {
 		e.preventDefault()
 		handleHistoryOperation('redo')
-	} else if (historyControl.undoStack.value.length > 1 && e.metaKey) {
+	} else if (isCmdOrCtrl(e) && historyControl.undoStack.value.length > 1) {
 		e.preventDefault()
 		handleHistoryOperation('undo')
 	}
@@ -324,7 +328,7 @@ const handleKeyDownForReadonly = (e) => {
 			startSlideShow()
 			break
 		case 'b':
-			if (e.metaKey) toggleSlideNavigator()
+			if (isCmdOrCtrl(e)) toggleSlideNavigator()
 			break
 	}
 }

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -207,6 +207,12 @@ const handleSlideShortcuts = (e) => {
 }
 
 const handleGlobalShortcuts = (e) => {
+	if (e.code === 'KeyP' && e.metaKey) {
+		e.preventDefault()
+		startSlideShow()
+		return
+	}
+
 	switch (e.key) {
 		case 'Escape':
 			resetFocus()

--- a/frontend/src/pages/Slideshow.vue
+++ b/frontend/src/pages/Slideshow.vue
@@ -233,9 +233,9 @@ const performNextStep = () => {
 }
 
 const handleKeyDown = (e) => {
-	if (e.key == 'ArrowRight' || e.key == 'ArrowDown' || e.code == 'Space') {
+	if (e.key == 'ArrowRight' || e.key == 'ArrowDown' || e.code == 'Space' || e.key == 'PageDown') {
 		performNextStep()
-	} else if (e.key == 'ArrowLeft' || e.key == 'ArrowUp') {
+	} else if (e.key == 'ArrowLeft' || e.key == 'ArrowUp' || e.key == 'PageUp') {
 		performPreviousStep()
 	} else if (e.key == 'F5') {
 		e.preventDefault()

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -70,6 +70,7 @@ const setCloneStyles = (clone) => {
 	clone.style.left = '-9999px'
 	clone.style.top = '0'
 	clone.style.transform = 'scale(1)'
+	clone.style.boxShadow = 'none'
 }
 
 const canRemoveDiv = (element) => {
@@ -116,15 +117,27 @@ const getThumbnailHtml = async () => {
 }
 
 const getSlideThumbnail = async (thumbnailHtml) => {
-	document.body.appendChild(thumbnailHtml)
+	return new Promise((resolve, reject) => {
+		document.body.appendChild(thumbnailHtml)
 
-	const canvas = await html2canvas(thumbnailHtml, {
-		scale: window.devicePixelRatio,
+		document.fonts.ready.then(() => {
+			requestAnimationFrame(async () => {
+				try {
+					const canvas = await html2canvas(thumbnailHtml, {
+						scale: window.devicePixelRatio,
+						useCORS: true,
+					})
+
+					document.body.removeChild(thumbnailHtml)
+
+					const dataUrl = canvas.toDataURL('image/png')
+					resolve(dataUrl)
+				} catch (error) {
+					reject(error)
+				}
+			})
+		})
 	})
-
-	document.body.removeChild(thumbnailHtml)
-
-	return canvas.toDataURL('image/png')
 }
 
 const lastThumbnailTime = ref(0)

--- a/slides/slides/doctype/presentation/presentation.py
+++ b/slides/slides/doctype/presentation/presentation.py
@@ -258,7 +258,7 @@ def create_attachment_with_unique_name(doc):
 	file_name = doc.file_name
 	file_extension = os.path.splitext(file_name)[1]
 	base_name = os.path.splitext(file_name)[0]
-	unique_name = f"{base_name}_{uuid.uuid4().hex}{file_extension}"
+	unique_name = f"{base_name}_{uuid.uuid4().hex[:6]}{file_extension}"
 
 	file_content = doc.get_content()
 	new_file_doc = frappe.get_doc(


### PR DESCRIPTION
### Changes

- Add wireless clicker shortcuts for entering and exiting Slideshow and going to next step of the slide show.
- Remove Navigation Panel shortcut description and fix scroll behaviour.
- Fix ctrl key shortcuts for windows and linux.
- Fix incorrect overlay position after exiting slideshow.
- Remove box shadow from slide before capturing html2canvas image.
- Use fewer uuid characters for smaller file name for uniquely creating public files.

Closes https://github.com/frappe/slides/issues/89
