### PR TITLE
feat: enable pasting and uploading svgs

### DIFF
--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -290,7 +290,7 @@ const applyAspectRatio = (offset) => {
 }
 
 const validateMinWidth = (width) => {
-	const minWidth = activeElement.value.type === 'text' ? 7 : 50
+	const minWidth = activeElement.value.type === 'text' ? 7 : 29
 	return width + selectionBounds.width > minWidth
 }
 

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -420,6 +420,12 @@ const handlePastedJSON = async (json) => {
 	duplicateElements(null, json)
 }
 
+const handleSvgText = (svgText) => {
+	const svgBlob = new Blob([svgText], { type: 'image/svg+xml' })
+	const svgFile = new File([svgBlob], 'pasted-image.svg', { type: 'image/svg+xml' })
+	handleUploadedMedia([{ kind: 'file', getAsFile: () => svgFile }], !isPublicPresentation.value)
+}
+
 const handlePaste = (e) => {
 	e.preventDefault()
 
@@ -427,7 +433,11 @@ const handlePaste = (e) => {
 	if (clipboardItems) handleUploadedMedia(clipboardItems, !isPublicPresentation.value)
 
 	const clipboardText = e.clipboardData.getData('text/plain')
-	if (clipboardText && !focusElementId.value) handlePastedText(clipboardText)
+	if (clipboardText?.trim().startsWith('<svg') && clipboardText?.trim().endsWith('</svg>')) {
+		handleSvgText(clipboardText)
+	} else if (clipboardText && !focusElementId.value) {
+		handlePastedText(clipboardText)
+	}
 
 	const clipboardJSON = e.clipboardData.getData('application/json')
 	if (clipboardJSON) handlePastedJSON(JSON.parse(clipboardJSON))

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -2,6 +2,13 @@ const sectionClasses = 'flex flex-col p-3 border-b'
 const sectionTitleClasses = 'text-base font-medium text-gray-800'
 const fieldLabelClasses = 'text-sm text-gray-600'
 
-const allowedImageFileTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp']
+const allowedImageFileTypes = [
+	'image/jpeg',
+	'image/jpg',
+	'image/png',
+	'image/gif',
+	'image/webp',
+	'image/svg+xml',
+]
 
 export { sectionClasses, sectionTitleClasses, fieldLabelClasses, allowedImageFileTypes }


### PR DESCRIPTION
Parse SVG data and add as an image. 
Upload SVG files from Toolbar and dropping on slide.

Closes #94 