### PR TITLE
fix: make editor and slideshow switching to next slide a little bit better

### DIFF
--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -551,8 +551,11 @@ onDeactivated(async () => {
 		updateUnsyncedRecord()
 		clearInterval(autosaveInterval)
 		clearInterval(thumbnailInterval)
-		await resetFocus()
-		savePresentation()
+
+		if (router.currentRoute.value.name !== 'Slideshow') {
+			await resetFocus()
+			savePresentation()
+		}
 
 		document.removeEventListener('keydown', handleKeyDown)
 		window.removeEventListener('beforeunload', handleBeforeUnload)

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -86,6 +86,7 @@ const isPublicPresentation = async (presentationId: string) => {
 }
 
 let previousRoute = null
+let canAccess = false
 
 
 router.beforeEach(async (to, from, next) => {
@@ -103,7 +104,11 @@ router.beforeEach(async (to, from, next) => {
 	}
 
 	if (['Slideshow', 'PresentationView', 'PresentationEditor'].includes(to.name as string)) {
-		const canAccess = await hasAccess(to.params.presentationId as string)
+
+		if (from.name != to.name || from.params.presentationId != to.params.presentationId) {
+			canAccess = await hasAccess(to.params.presentationId as string)
+		}
+
 		if (canAccess && ['PresentationEditor', 'Slideshow'].includes(to.name as string)) {
 			if (to.name === 'Slideshow' && !from.name) {
 				return next({ name: 'PresentationEditor', params: to.params, query: to.query } )

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -320,6 +320,8 @@ const selectAllElements = (e) => {
 const resetFocus = async () => {
 	const index = slideIndex.value
 
+	if (!activeElementIds.value.length) return
+
 	activeElementIds.value = []
 	focusElementId.value = null
 	pairElementId.value = null


### PR DESCRIPTION
### Changes

- Avoid repeated calls for has_permission check for new routes for every slide.
- Avoid save call while de-activating editor if not necessary.
- Avoid resetting focus before switching to next slide if not necessary.