### PR TITLE
feat: convert images and video posters to webp on upload

### DIFF
--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -158,7 +158,7 @@ const generatePoster = async (video) => {
 	const context = canvas.getContext('2d')
 	// draw the current frame of the video onto the canvas
 	context.drawImage(video, 0, 0, canvas.width, canvas.height)
-	const posterDataUrl = canvas.toDataURL('image/png')
+	const posterDataUrl = canvas.toDataURL('image/webp')
 
 	// save the poster as an attachment and return the url for the poster
 	return await savePoster.submit(posterDataUrl)

--- a/frontend/src/utils/mediaUploads.js
+++ b/frontend/src/utils/mediaUploads.js
@@ -1,4 +1,4 @@
-import { FileUploadHandler, toast } from 'frappe-ui'
+import { FileUploadHandler, toast, call } from 'frappe-ui'
 
 import { presentationId } from '../stores/presentation'
 import { currentSlide } from '../stores/slide'
@@ -6,7 +6,11 @@ import { addMediaElement, replaceMediaElement } from '../stores/element'
 
 const fileUploadHandler = new FileUploadHandler()
 
-const performPostUploadActions = (fileDoc, fileType, targetElement, resolve) => {
+const performPostUploadActions = async (fileDoc, fileType, targetElement, resolve) => {
+	if (fileType === 'image') {
+		fileDoc = await getWebPDoc(fileDoc.file_url)
+	}
+
 	if (targetElement) {
 		replaceMediaElement(targetElement, fileDoc, fileType)
 		resolve(fileDoc)
@@ -46,6 +50,13 @@ const getFileObject = (file) => {
 	} else if (isFile(file)) {
 		return file
 	}
+}
+
+const getWebPDoc = async (fileUrl) => {
+	return await call('slides.slides.doctype.presentation.presentation.get_webp_doc', {
+		presentation_name: presentationId.value,
+		file_url: fileUrl,
+	})
 }
 
 const handleFile = (file, isPrivate, toastProps, targetElement) => {

--- a/slides/slides/doctype/presentation/presentation.py
+++ b/slides/slides/doctype/presentation/presentation.py
@@ -429,6 +429,7 @@ def create_new_webp_file_doc(presentation_name, file_url, image, extn):
 		new_file.file_name = f"{_file.file_name.replace(extn, 'webp')}"
 		new_file.file_url = f"{_file.file_url.replace(extn, 'webp')}"
 		new_file.save()
+		_file.delete()
 		return new_file
 	return file_url
 

--- a/slides/slides/doctype/presentation/presentation.py
+++ b/slides/slides/doctype/presentation/presentation.py
@@ -411,11 +411,11 @@ def convert_and_save_image(image, path):
 	return path
 
 
-def create_new_webp_file_doc(presentation, file_url, image, extn):
+def create_new_webp_file_doc(presentation_name, file_url, image, extn):
 	files = frappe.get_all(
 		"File",
 		filters={
-			"attached_to_name": presentation,
+			"attached_to_name": presentation_name,
 			"file_url": file_url,
 		},
 		fields=["name"],
@@ -429,22 +429,30 @@ def create_new_webp_file_doc(presentation, file_url, image, extn):
 		new_file.file_name = f"{_file.file_name.replace(extn, 'webp')}"
 		new_file.file_url = f"{_file.file_url.replace(extn, 'webp')}"
 		new_file.save()
-		return new_file.file_url
+		return new_file
 	return file_url
+
+
+@frappe.whitelist()
+def get_webp_doc(presentation_name, file_url):
+	if file_url.endswith((".webp", ".svg")):
+		return
+
+	image, filename, extn = get_local_image(file_url)
+
+	if can_convert_image(extn):
+		return create_new_webp_file_doc(presentation_name, file_url, image, extn)
 
 
 def update_element_urls(is_public, presentation, element):
 	attribute = "poster" if element.get("type") == "video" else "src"
 	image_url = element.get(attribute, "") if is_public else f"/private{element.get(attribute, '')}"
 
-	if image_url.endswith((".webp", ".svg")):
-		return
+	webp_doc = get_webp_doc(presentation, image_url)
 
-	image, filename, extn = get_local_image(image_url)
-
-	if can_convert_image(extn):
-		new_url = create_new_webp_file_doc(presentation, image_url, image, extn)
-		element[attribute] = new_url.replace("/private", "")
+	if webp_doc.file_url:
+		element["attachmentName"] = webp_doc.name
+		element[attribute] = webp_doc.file_url
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Automatically convert uploaded images and video posters to webp before saving as png or jpeg.