### PR TITLE
feat: initial changes needed for drive integration 

### DIFF
--- a/frontend/src/components/PresentationActionDialog.vue
+++ b/frontend/src/components/PresentationActionDialog.vue
@@ -6,7 +6,7 @@
 		<template #body-content>
 			<FormControl
 				ref="inputRef"
-				v-if="['Duplicate', 'Rename'].includes(dialogAction)"
+				v-if="dialogAction == 'Rename'"
 				:type="'text'"
 				size="md"
 				variant="subtle"
@@ -42,7 +42,7 @@ import { Dialog, FormControl, call } from 'frappe-ui'
 
 import { createPresentationResource, updatePresentationTitle } from '@/stores/presentation'
 
-import { Copy, Trash, PenLine } from 'lucide-vue-next'
+import { Trash, PenLine } from 'lucide-vue-next'
 
 const props = defineProps({
 	presentation: Object,
@@ -56,10 +56,6 @@ const inputRef = useTemplateRef('inputRef')
 const newPresentationTitle = ref('')
 
 const actions = {
-	Duplicate: {
-		label: 'Create Copy',
-		icon: Copy,
-	},
 	Rename: {
 		label: 'Update Title',
 		icon: PenLine,
@@ -85,9 +81,6 @@ const performAction = async () => {
 		case 'Delete':
 			await deletePresentation()
 			break
-		default:
-			newPresentationId = await duplicatePresentation()
-			break
 	}
 
 	if (newPresentationId) {
@@ -95,13 +88,6 @@ const performAction = async () => {
 	} else {
 		emit('reloadList')
 	}
-}
-
-const duplicatePresentation = async () => {
-	return await createPresentationResource.submit({
-		title: newPresentationTitle.value,
-		duplicateFrom: props.presentation.name,
-	})
 }
 
 const deletePresentation = async () => {
@@ -118,17 +104,10 @@ watch(
 	() => [props.dialogAction, props.presentation],
 	(val) => {
 		if (!val) return
-		let newTitle
-		switch (props.dialogAction) {
-			case 'Duplicate':
-				newTitle = `Copy of ${props.presentation.title}`
-				break
-			case 'Rename':
-				newTitle = props.presentation.title
-				break
-			default:
-				newTitle = ''
-				break
+
+		let newTitle = ''
+		if (props.dialogAction == 'Rename') {
+			newTitle = props.presentation.title
 		}
 
 		newPresentationTitle.value = newTitle

--- a/frontend/src/components/PresentationList.vue
+++ b/frontend/src/components/PresentationList.vue
@@ -64,7 +64,7 @@ const props = defineProps({
 	presentations: Object,
 })
 
-const emit = defineEmits(['navigate', 'setPreview', 'openDialog'])
+const emit = defineEmits(['navigate', 'setPreview', 'openDialog', 'duplicatePresentation'])
 
 const backgroundClasses = 'size-full bg-gray-100 flex flex-col pt-8 overflow-y-auto'
 const contextMenuIconClasses = 'stroke-[1.5] !size-3.5'
@@ -82,7 +82,7 @@ const getContextMenuOptions = (presentation) => {
 				{
 					label: 'Duplicate',
 					icon: h(Copy, { class: contextMenuIconClasses }),
-					onClick: () => emit('openDialog', 'Duplicate', presentation),
+					onClick: () => emit('duplicatePresentation', presentation.name),
 				},
 				{
 					label: 'Delete',

--- a/frontend/src/components/PresentationPreview.vue
+++ b/frontend/src/components/PresentationPreview.vue
@@ -70,7 +70,7 @@ const props = defineProps({
 	required: true,
 })
 
-const emit = defineEmits(['setPreview', 'openDialog', 'navigate'])
+const emit = defineEmits(['setPreview', 'openDialog', 'navigate', 'duplicatePresentation'])
 
 let interval = null
 
@@ -147,7 +147,7 @@ const presentationActions = [
 	{
 		icon: Copy,
 		label: 'Duplicate',
-		onClick: (e) => emit('openDialog', 'Duplicate'),
+		onClick: (e) => emit('duplicatePresentation', props.presentation.name),
 	},
 	{
 		icon: Trash,

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -13,6 +13,7 @@
 			@setPreview="setPreview"
 			@navigate="(name, present) => navigateToPresentation(name, present)"
 			@openDialog="openDialog"
+			@duplicatePresentation="(name) => duplicatePresentation(name)"
 		/>
 
 		<PresentationPreview
@@ -21,6 +22,7 @@
 			@setPreview="setPreview"
 			@openDialog="openDialog"
 			@navigate="navigateToPresentation"
+			@duplicatePresentation="(name) => duplicatePresentation(name)"
 		/>
 	</div>
 
@@ -114,8 +116,18 @@ const setPreview = (presentation) => {
 const createPresentation = async (theme) => {
 	showThemeDialog.value = false
 	const newPresentation = await createPresentationResource.submit({
-		title: 'Untitled',
 		theme: theme,
+	})
+	if (newPresentation) {
+		navigateToPresentation(newPresentation)
+	} else {
+		console.error('Failed to create new presentation')
+	}
+}
+
+const duplicatePresentation = async (presentation) => {
+	const newPresentation = await createPresentationResource.submit({
+		duplicateFrom: presentation,
 	})
 	if (newPresentation) {
 		navigateToPresentation(newPresentation)

--- a/frontend/src/stores/presentation.js
+++ b/frontend/src/stores/presentation.js
@@ -21,7 +21,6 @@ const createPresentationResource = createResource({
 	method: 'POST',
 	makeParams: (args) => {
 		return {
-			title: args.title,
 			duplicate_from: args.duplicateFrom,
 			theme: args.theme,
 		}

--- a/slides/slides/doctype/presentation/presentation.py
+++ b/slides/slides/doctype/presentation/presentation.py
@@ -188,9 +188,12 @@ def get_slides_from_ref(parent, theme, duplicate_from):
 
 
 @frappe.whitelist()
-def create_presentation(title, theme=None, duplicate_from=None):
+def create_presentation(theme=None, duplicate_from=None):
 	presentation = frappe.new_doc("Presentation")
-	presentation.title = title
+	if duplicate_from:
+		presentation.title = f"Copy of {frappe.get_value('Presentation', duplicate_from, 'title')}"
+	else:
+		presentation.title = "Untitled"
 	presentation.theme = theme
 	presentation.insert()
 

--- a/slides/slides/doctype/presentation/presentation.py
+++ b/slides/slides/doctype/presentation/presentation.py
@@ -90,6 +90,8 @@ def slug(text: str) -> str:
 	return text.lower().replace(" ", "-")
 
 
+# whitelist needed for drive integration
+@frappe.whitelist()
 def get_presentation_thumbnail(presentation_name: str, index: int | None = 1) -> str:
 	"""Returns the thumbnail of the first slide in a presentation"""
 	return (


### PR DESCRIPTION
Don't show a dialog for renaming duplicated presentation while creation. Directly navigate to the newly created presentation with the default title "Copy of ..." so the user can rename post-creation.

Whitelisted the `get_presentation_thumbnail` method so that drive can directly access the presentation's first thumbnail for the list.
