### PR TITLE
fix: missing file_url for SVG image type

### DIFF
--- a/frontend/src/utils/mediaUploads.js
+++ b/frontend/src/utils/mediaUploads.js
@@ -8,7 +8,7 @@ const fileUploadHandler = new FileUploadHandler()
 
 const performPostUploadActions = async (fileDoc, fileType, targetElement, resolve) => {
 	if (fileType === 'image') {
-		fileDoc = await getWebPDoc(fileDoc.file_url)
+		fileDoc = await getWebPDoc(fileDoc)
 	}
 
 	if (targetElement) {
@@ -52,10 +52,10 @@ const getFileObject = (file) => {
 	}
 }
 
-const getWebPDoc = async (fileUrl) => {
+const getWebPDoc = async (fileDoc) => {
 	return await call('slides.slides.doctype.presentation.presentation.get_webp_doc', {
 		presentation_name: presentationId.value,
-		file_url: fileUrl,
+		file_doc: fileDoc,
 	})
 }
 

--- a/slides/slides/doctype/presentation/presentation.py
+++ b/slides/slides/doctype/presentation/presentation.py
@@ -364,9 +364,10 @@ def create_new_webp_file_doc(presentation_name, file_url, image, extn):
 
 
 @frappe.whitelist()
-def get_webp_doc(presentation_name, file_url):
+def get_webp_doc(presentation_name, file_doc):
+	file_url = file_doc.get("file_url", "")
 	if file_url.endswith((".webp", ".svg")):
-		return
+		return file_doc
 
 	image, filename, extn = get_local_image(file_url)
 


### PR DESCRIPTION
For File documents that are not converted to WebP, use the correct return type so the url can be read correctly while adding or replacing SVG images.

Closes https://github.com/frappe/slides/issues/113
