### PR TITLE
feat: custom plugin for styled empty line within text

### DIFF
--- a/frontend/src/components/SlideshowText.vue
+++ b/frontend/src/components/SlideshowText.vue
@@ -4,6 +4,8 @@
 <script setup>
 import { ref, watch } from 'vue'
 
+import { getDocFromHTML } from '@/utils/helpers'
+
 const props = defineProps({
 	content: {
 		type: String,
@@ -12,11 +14,6 @@ const props = defineProps({
 })
 
 const textRef = ref(null)
-
-const getDocFromHTML = (html) => {
-	const parser = new DOMParser()
-	return parser.parseFromString(html, 'text/html')
-}
 
 const encodeCharForHtml = (c) => {
 	switch (c) {

--- a/frontend/src/components/TextElement.vue
+++ b/frontend/src/components/TextElement.vue
@@ -165,9 +165,4 @@ onBeforeMount(() => normalizeContent())
 	overflow-wrap: break-word;
 	hyphens: auto;
 }
-
-.textElement p:empty::before {
-	content: '\00a0';
-	font-size: calc(v-bind(baseFontSize, 28) * 1px);
-}
 </style>

--- a/frontend/src/composables/useTextEditor.js
+++ b/frontend/src/composables/useTextEditor.js
@@ -23,10 +23,6 @@ const editorStyles = reactive({
 	orderedList: false,
 })
 
-export const lastUsedStyles = reactive({ ...editorStyles })
-
-const baseFontSize = ref()
-
 export const useTextEditor = () => {
 	const setEditorStyles = (editor) => {
 		if (!editor) return
@@ -51,77 +47,19 @@ export const useTextEditor = () => {
 		})
 	}
 
-	const applyLastUsedStyles = (editor) => {
-		const oldStyles = JSON.parse(JSON.stringify(lastUsedStyles))
-
-		let chain = editor.chain().focus()
-
-		if (oldStyles.textAlign) chain = chain.setTextAlign(oldStyles.textAlign)
-		if (oldStyles.color) chain = chain.setColor(oldStyles.color)
-
-		chain = chain.setMark('textStyle', {
-			fontSize: oldStyles.fontSize,
-			fontFamily: oldStyles.fontFamily,
-			letterSpacing: oldStyles.letterSpacing,
-			opacity: oldStyles.opacity,
-			textTransform: oldStyles.uppercase ? 'uppercase' : null,
-		})
-
-		if (oldStyles.bold) chain = chain.setBold()
-		if (oldStyles.italic) chain = chain.setItalic()
-		if (oldStyles.underline) chain = chain.setUnderline()
-		if (oldStyles.strike) chain = chain.setStrike()
-
-		chain.run()
-	}
-
-	const applyWhenPlainSelection = (editor) => {
-		const { state } = editor
-		const { $from } = state.selection
-
-		const hasStoredMarks = (state.storedMarks || []).length > 0
-
-		const style = editor.getAttributes('textStyle')
-		const hasTextStyle = !!(
-			style.color ||
-			style.fontSize ||
-			style.fontFamily ||
-			style.letterSpacing ||
-			style.opacity ||
-			style.textTransform
-		)
-
-		const inParagraph = $from.parent.type.name === 'paragraph'
-
-		const isCursor = state.selection.empty
-
-		if (!hasStoredMarks && !hasTextStyle && inParagraph && isCursor) {
-			applyLastUsedStyles(editor)
-		}
-
-		if (!baseFontSize.value) {
-			baseFontSize.value = lastUsedStyles.fontSize || 28
-		}
-		editor.view.dom.style.fontSize = `${baseFontSize.value}px`
-	}
-
-	let isRestoringStyles = false
-
 	const updateElementContent = (editor) => {
 		activeElement.value.content = editor.getHTML()
 	}
 
-	const updateLastUsedStyles = (editor) => {
-		setEditorStyles(editor)
-		for (const key in editorStyles) {
-			lastUsedStyles[key] = editorStyles[key]
-		}
-	}
+	const handleOnTransaction = (editor, transaction) => {
+		if (!transaction.docChanged) return
 
-	const updateEditor = ({ transaction, editor }) => {
-		if (transaction.docChanged) {
-			updateElementContent(editor)
-		}
+		// purposefully using onTransaction + docChanged instead of onUpdate
+		// since onUpdate also triggers when activeEditor changes from one text box to another
+		// leading to overwriting content for second one with first one's content
+
+		updateElementContent(editor)
+		setEditorStyles(editor)
 	}
 
 	const markCommands = {
@@ -257,24 +195,18 @@ export const useTextEditor = () => {
 			editable: isEditable,
 			content: content,
 			editorProps: getEditorProps(editorMetadata),
-			onTransaction: ({ transaction, editor }) => updateEditor({ transaction, editor }),
-			onUpdate: ({ editor }) => updateLastUsedStyles(editor),
-			onSelectionUpdate: ({ editor }) => applyWhenPlainSelection(editor),
+			// to update styles in sidebar based on cursor position
+			onSelectionUpdate: ({ editor }) => setEditorStyles(editor),
+			// to update element content on every change
+			onTransaction: ({ editor, transaction }) => handleOnTransaction(editor, transaction),
 		})
-	}
 
-	watch(
-		() => activeEditor.value,
-		(newEditor) => {
-			updateLastUsedStyles(newEditor)
-			applyWhenPlainSelection(newEditor)
-		},
-	)
+		setEditorStyles(activeEditor.value)
+	}
 
 	return {
 		activeEditor,
 		editorStyles,
-		baseFontSize,
 		toggleMark,
 		updateProperty,
 		initTextEditor,

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -269,7 +269,7 @@ const handleHistoryOperation = async (operation) => {
 
 	const onActiveSlide = slideToFocus == slideIndex.value
 
-	if (!onActiveSlide && slideToFocus) {
+	if (!onActiveSlide && slideToFocus != null) {
 		await changeSlide(slideToFocus, false)
 
 		recentlyRestored.value = true

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -361,7 +361,7 @@ const handleThumbnailGeneration = async (index) => {
 }
 
 const changeSlide = async (index, focus = true) => {
-	if (index < 0 || index >= slides.value.length) return
+	index = Math.max(0, Math.min(index, slides.value.length - 1))
 
 	const oldIndex = slideIndex.value
 
@@ -415,6 +415,8 @@ const insertSlide = async (index, layoutId, toDuplicate) => {
 		slide.idx = index + 1
 	})
 
+	slidesLength.value = slides.value.length
+
 	await changeSlide(index + 1)
 
 	updateThumbnail(index + 1)
@@ -441,6 +443,8 @@ const deleteSlide = (deleteActive) => {
 	slides.value.forEach((slide, index) => {
 		slide.idx = index + 1
 	})
+
+	slidesLength.value = slides.value.length
 
 	if (deleteIndex == totalLength - 1) {
 		// if last slide is deleted, switch to previous slide since no slide at current index

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -470,12 +470,56 @@ const addFixedWidthToElement = (deltaWidth) => {
 const { initTextEditor, activeEditor } = useTextEditor()
 let editorOldText = ''
 
+const patchEmptyParagraphs = (htmlString) => {
+	let didUpdate = false
+
+	const parser = new DOMParser()
+	const doc = parser.parseFromString(htmlString, 'text/html')
+
+	const allParagraphs = Array.from(doc.body.querySelectorAll('p'))
+	let prevSpanStyles = null
+
+	allParagraphs.forEach((p, index) => {
+		const isEmpty = p.textContent.trim() === ''
+		const firstSpan = p.querySelector('span')
+
+		if (!isEmpty && firstSpan) {
+			prevSpanStyles = firstSpan.getAttribute('style') || ''
+			return
+		}
+
+		if (isEmpty && prevSpanStyles) {
+			p.innerHTML = ''
+
+			if (!didUpdate) didUpdate = true
+
+			const span = doc.createElement('span')
+			span.setAttribute('style', prevSpanStyles)
+			span.innerHTML = '\u200B'
+
+			p.appendChild(span)
+		}
+	})
+
+	return {
+		wasUpdated: didUpdate,
+		updatedHTML: didUpdate ? doc.body.innerHTML : htmlString,
+	}
+}
+
+const getEditorHTML = () => {
+	const html = activeEditor.value.getHTML()
+	return patchEmptyParagraphs(html)
+}
+
 const updateElementContent = (element) => {
+	const { wasUpdated, updatedHTML } = getEditorHTML()
 	const currentText = activeEditor.value.getText()
-	if (editorOldText == currentText) return
+
+	if (editorOldText == currentText && !wasUpdated) return
 
 	element.id = getUpdatedIdAfterConnections(element)
-	element.content = activeEditor.value.getHTML()
+	element.content = updatedHTML
 	editorOldText = currentText
 }
 

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -19,7 +19,7 @@ import { presentationId } from './presentation'
 import { getUpdatedIdAfterConnections } from './transition'
 
 import { generateHTML } from '@tiptap/core'
-import { extensions } from '@/stores/tiptapSetup'
+import { extensions, patchEmptyParagraphs } from '@/stores/tiptapSetup'
 
 const activeElementIds = ref([])
 const focusElementId = ref(null)
@@ -469,43 +469,6 @@ const addFixedWidthToElement = (deltaWidth) => {
 
 const { initTextEditor, activeEditor } = useTextEditor()
 let editorOldText = ''
-
-const patchEmptyParagraphs = (htmlString) => {
-	let didUpdate = false
-
-	const parser = new DOMParser()
-	const doc = parser.parseFromString(htmlString, 'text/html')
-
-	const allParagraphs = Array.from(doc.body.querySelectorAll('p'))
-	let prevSpanStyles = null
-
-	allParagraphs.forEach((p, index) => {
-		const isEmpty = p.textContent.trim() === ''
-		const firstSpan = p.querySelector('span')
-
-		if (!isEmpty && firstSpan) {
-			prevSpanStyles = firstSpan.getAttribute('style') || ''
-			return
-		}
-
-		if (isEmpty && prevSpanStyles) {
-			p.innerHTML = ''
-
-			if (!didUpdate) didUpdate = true
-
-			const span = doc.createElement('span')
-			span.setAttribute('style', prevSpanStyles)
-			span.innerHTML = '\u200B'
-
-			p.appendChild(span)
-		}
-	})
-
-	return {
-		wasUpdated: didUpdate,
-		updatedHTML: didUpdate ? doc.body.innerHTML : htmlString,
-	}
-}
 
 const getEditorHTML = () => {
 	const html = activeEditor.value.getHTML()

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -89,12 +89,68 @@ const PastePlainText = Extension.create({
 	},
 })
 
+const getItemAttributes = (node) => {
+	const paragraphNode = node.content?.firstChild
+	const textNode = paragraphNode?.firstChild
+
+	const attrs = {
+		color: null,
+		fontSize: null,
+		fontFamily: null,
+		letterSpacing: null,
+		opacity: null,
+	}
+
+	if (textNode?.marks) {
+		for (const mark of textNode.marks) {
+			if (mark.type.name == 'textStyle') {
+				const styleAttrs = mark.attrs
+				styleAttrs.fontSize = parseInt(styleAttrs.fontSize)
+				Object.assign(attrs, styleAttrs)
+				return attrs
+			}
+		}
+	}
+
+	return attrs
+}
+
+const CustomListItem = ListItem.extend({
+	renderHTML({ node, HTMLAttributes, ...rest }) {
+		const liAttrs = { ...HTMLAttributes }
+
+		const { color, fontSize, fontFamily, letterSpacing, opacity } = getItemAttributes(node)
+
+		liAttrs.style = [
+			liAttrs.style || '',
+			`color: ${color};`,
+			`font-size: ${fontSize}px;`,
+			`font-family: ${fontFamily};`,
+			`letter-spacing: ${letterSpacing};`,
+			`opacity: ${opacity};`,
+		].join(' ')
+
+		return ['li', liAttrs, 0]
+	},
+})
+
 const ZWSP = '\u200B'
+
+const isInList = ($pos) => {
+	// intentional since <li> is not direct parent of text node
+	for (let d = $pos.depth; d > 0; d--) {
+		const node = $pos.node(d)
+		if (node.type.name === 'listItem') return true
+	}
+	return false
+}
 
 const handleEnterKey = (editor) => {
 	const { state, view } = editor
 	const { selection, storedMarks } = state
 	const $pos = selection.$from
+
+	if (isInList($pos)) return false
 
 	// fetch current marks before splitting to next line
 	const marks = storedMarks || $pos.marks()
@@ -135,6 +191,7 @@ export const extensions = [
 	StarterKit.configure({
 		bulletList: false,
 		orderedList: false,
+		listItem: false,
 	}),
 	CustomTextStyle,
 	Underline,
@@ -151,5 +208,6 @@ export const extensions = [
 		keepAttributes: true,
 		keepMarks: true,
 	}),
+	CustomListItem,
 	StyledEmptyLine,
 ]

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -277,6 +277,16 @@ const getTextForSelection = (from) => {
 	return firstChild.text
 }
 
+const getPrevNode = ($from, view) => {
+	const blockDepth = $from.depth
+
+	// Position before the current block
+	const posBeforeBlock = $from.before(blockDepth)
+
+	const resolved = view.state.doc.resolve(posBeforeBlock)
+	return resolved.nodeBefore
+}
+
 const handleKeyDown = (view, event) => {
 	if (event.key !== 'Backspace') return false
 
@@ -297,12 +307,19 @@ const handleKeyDown = (view, event) => {
 		return addPlaceholderAndRetainMarks(event, view, start, end)
 	}
 
-	if (text === ZWSP) {
+	const prevNode = getPrevNode($from, view)
+
+	if (text === ZWSP && prevNode && prevNode.isTextblock) {
 		// if only ZWSP is present, default behavior will lead to
 		// deleting it and adding <br class="ProseMirror-trailingBreak">
 		// so manually delete ZWSP and join with previous line which is expected behavior without the placeholder
-
 		return removePlaceholderAndJoinBackward(event, view, start, end)
+	}
+
+	if (text === ZWSP) {
+		// if only ZWSP is present but no previous textblock, do nothing
+		event.preventDefault()
+		return true
 	}
 
 	return false

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -170,12 +170,37 @@ const handleListItemEnterKey = (editor, pos, marks) => {
 	return true
 }
 
+const addEmptyLineBefore = (state, view, pos, marks) => {
+	const startOfCurrentPos = pos.start()
+	const $before = state.doc.resolve(startOfCurrentPos - 1)
+	const prevNode = $before.nodeBefore
+
+	if (prevNode && !prevNode.isTextblock) return false
+
+	let tr = view.state.tr
+	const prevEnd = startOfCurrentPos - 1
+	// insert ZWSP inside previous node as placeholder so
+	// <br class="ProseMirror-trailingBreak"> is not added
+	tr.insert(prevEnd + 1, state.schema.text(ZWSP, marks))
+	tr = tr.setStoredMarks(marks)
+	view.dispatch(tr)
+	return true
+}
+
+const getCursorPositionFlags = (pos) => {
+	const parent = pos.parent
+
+	return {
+		isCursorAtStart: pos.parentOffset === 0,
+		isCursorAtEnd: pos.parentOffset === parent.content.size,
+	}
+}
+
 const handleEnterKey = (editor) => {
 	const { state, view } = editor
 	const { selection, storedMarks } = state
 	const $pos = selection.$from
 
-	// fetch current marks before splitting to next line
 	const marks = storedMarks || $pos.marks()
 
 	if (isInList($pos)) {
@@ -187,29 +212,13 @@ const handleEnterKey = (editor) => {
 	// splitting to new line failed so don't change anything
 	if (!didSplit) return false
 
-	const parent = $pos.parent
-	const cursorAtStart = $pos.parentOffset === 0
-	const cursorAtEnd = $pos.parentOffset === parent.content.size
+	const { isCursorAtStart, isCursorAtEnd } = getCursorPositionFlags($pos)
 
-	// insert ZWSP char so ProseMirror does not add <br class="ProseMirror-trailingBreak">
-	// instead adds an empty styled span - so line height, font size etc. are consistent
 	let tr = view.state.tr
 
-	if (cursorAtStart) {
-		const startOfCurrentPos = $pos.start()
-		const $before = state.doc.resolve(startOfCurrentPos - 1)
-		const prevNode = $before.nodeBefore
-
-		if (!prevNode || prevNode.isTextblock) {
-			const prevEnd = startOfCurrentPos - 1
-			// insert ZWSP inside previous node as placeholder so
-			// <br class="ProseMirror-trailingBreak"> is not added
-			tr.insert(prevEnd + 1, state.schema.text(ZWSP, marks))
-			tr = tr.setStoredMarks(marks)
-			view.dispatch(tr)
-			return true
-		}
-	} else if (cursorAtEnd) {
+	if (isCursorAtStart) {
+		return addEmptyLineBefore(state, view, $pos, marks)
+	} else if (isCursorAtEnd) {
 		tr.insertText(ZWSP)
 	}
 
@@ -344,6 +353,8 @@ export const StyledEmptyLine = Extension.create({
 
 	addKeyboardShortcuts() {
 		return {
+			// insert ZWSP char so ProseMirror does not add <br class="ProseMirror-trailingBreak">
+			// instead adds an empty styled span - so line height, font size etc. are consistent
 			Enter: ({ editor }) => handleEnterKey(editor),
 		}
 	},

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -184,6 +184,7 @@ const handleKeyDown = (view, event) => {
 	const { selection, storedMarks } = state
 
 	const $from = selection.$from
+	const $to = selection.$to
 
 	if (isInList($from)) return false
 
@@ -196,9 +197,12 @@ const handleKeyDown = (view, event) => {
 	const start = $from.start()
 	const end = $from.end()
 
+	const from = $from.pos
+	const to = $to.pos
+
 	// if the last non-ZWSP character is being deleted, replace with ZWSP + re-apply marks
 	// so <br class="ProseMirror-trailingBreak"> is not added
-	if (text.length === 1 && text !== ZWSP) {
+	if ((text.length === 1 && text !== ZWSP) || (from === start && to === end)) {
 		event.preventDefault()
 
 		let tr = state.tr

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -195,6 +195,17 @@ const handleEnterKey = (editor) => {
 	return true
 }
 
+const removePlaceholderAndJoinBackward = (event, view, start, end) => {
+	event.preventDefault()
+
+	let tr = view.state.tr.delete(start, end)
+	view.dispatch(tr)
+
+	joinBackward(view.state, view.dispatch)
+
+	return true
+}
+
 const handleKeyDown = (view, event) => {
 	if (event.key !== 'Backspace') return false
 
@@ -236,15 +247,7 @@ const handleKeyDown = (view, event) => {
 		// if only ZWSP is present, default behavior will lead to
 		// deleting it and adding <br class="ProseMirror-trailingBreak">
 		// so manually delete ZWSP and join with previous line which is expected behavior without the placeholder
-
-		event.preventDefault()
-
-		let tr = state.tr.delete(start, end)
-		dispatch(tr)
-
-		joinBackward(view.state, view.dispatch)
-
-		return true
+		return removePlaceholderAndJoinBackward(event, view, start, end)
 	}
 
 	return false

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -89,6 +89,39 @@ const PastePlainText = Extension.create({
 	},
 })
 
+const ZWSP = '\u200B'
+
+export const StyledEmptyLine = Extension.create({
+	name: 'StyledEmptyLine',
+
+	addKeyboardShortcuts() {
+		return {
+			Enter: ({ editor }) => {
+				const { state, view } = editor
+				const { selection, storedMarks } = state
+				const $pos = selection.$from
+
+				// fetch current marks before splitting to next line
+				const marks = storedMarks || $pos.marks()
+
+				const didSplit = editor.commands.splitBlock()
+				// splitting to new line failed so don't change anything
+				if (!didSplit) return false
+
+				// insert ZWSP char so ProseMirror does not add <br class="ProseMirror-trailingBreak">
+				// instead adds an empty styled span - so line height, font size etc are consistent
+				let tr = view.state.tr
+				tr.insertText(ZWSP)
+				tr = tr.setStoredMarks(marks)
+
+				view.dispatch(tr)
+
+				return true
+			},
+		}
+	},
+})
+
 export const extensions = [
 	StarterKit.configure({
 		bulletList: false,
@@ -109,4 +142,5 @@ export const extensions = [
 		keepAttributes: true,
 		keepMarks: true,
 	}),
+	StyledEmptyLine,
 ]

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -195,6 +195,21 @@ const handleEnterKey = (editor) => {
 	return true
 }
 
+const addPlaceholderAndRetainMarks = (event, view, start, end) => {
+	event.preventDefault()
+
+	const state = view.state
+
+	const marks = state.storedMarks || state.selection.$from.marks()
+
+	let tr = state.tr
+	tr = tr.replaceWith(start, end, state.schema.text(ZWSP, marks))
+	tr = tr.setStoredMarks(marks)
+	view.dispatch(tr)
+
+	return true
+}
+
 const removePlaceholderAndJoinBackward = (event, view, start, end) => {
 	event.preventDefault()
 
@@ -206,47 +221,51 @@ const removePlaceholderAndJoinBackward = (event, view, start, end) => {
 	return true
 }
 
-const handleKeyDown = (view, event) => {
-	if (event.key !== 'Backspace') return false
-
-	const { state, dispatch } = view
-	const { selection, storedMarks } = state
-
+const getSelectionRange = (selection) => {
 	const $from = selection.$from
 	const $to = selection.$to
 
+	return {
+		from: $from.pos,
+		to: $to.pos,
+		start: $from.start(),
+		end: $from.end(),
+	}
+}
+
+const getTextForSelection = (from) => {
+	const firstChild = from.parent.content.firstChild
+
+	if (!firstChild || !firstChild.isText) return undefined
+
+	return firstChild.text
+}
+
+const handleKeyDown = (view, event) => {
+	if (event.key !== 'Backspace') return false
+
+	const { selection } = view.state
+	const $from = selection.$from
+
 	if (isInList($from)) return false
 
-	const firstChild = $from.parent.content.firstChild
-	if (!firstChild || !firstChild.isText) return false
+	const text = getTextForSelection($from)
+	if (text === undefined) return false
 
-	const text = firstChild.text
-	const marks = storedMarks || $from.marks()
+	const { from, to, start, end } = getSelectionRange(selection)
 
-	const start = $from.start()
-	const end = $from.end()
-
-	const from = $from.pos
-	const to = $to.pos
-
-	// if the last non-ZWSP character is being deleted, replace with ZWSP + re-apply marks
-	// so <br class="ProseMirror-trailingBreak"> is not added
 	if ((text.length === 1 && text !== ZWSP) || (from === start && to === end)) {
-		event.preventDefault()
+		// if the last non-ZWSP character is being deleted, replace with ZWSP + re-apply marks
+		// so <br class="ProseMirror-trailingBreak"> is not added
 
-		let tr = state.tr
-		tr = tr.replaceWith(start, end, state.schema.text(ZWSP, marks))
-		tr = tr.setStoredMarks(marks)
-
-		dispatch(tr)
-
-		return true
+		return addPlaceholderAndRetainMarks(event, view, start, end)
 	}
 
 	if (text === ZWSP) {
 		// if only ZWSP is present, default behavior will lead to
 		// deleting it and adding <br class="ProseMirror-trailingBreak">
 		// so manually delete ZWSP and join with previous line which is expected behavior without the placeholder
+
 		return removePlaceholderAndJoinBackward(event, view, start, end)
 	}
 
@@ -281,8 +300,8 @@ const handleTextInput = (view, from, to, text) => {
 	return removePlaceholderAndInsertText(view, $pos, text)
 }
 
-const styledSpanPlugin = new Plugin({
-	key: new PluginKey('styledSpanPlugin'),
+const styledEmptyLinePlugin = new Plugin({
+	key: new PluginKey('styledEmptyLinePlugin'),
 	props: {
 		// before adding an unstyled empty line on clearing content
 		// add a ZWSP with stored marks to retain styles
@@ -303,7 +322,7 @@ export const StyledEmptyLine = Extension.create({
 	},
 
 	addProseMirrorPlugins() {
-		return [styledSpanPlugin]
+		return [styledEmptyLinePlugin]
 	},
 })
 

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -231,6 +231,7 @@ const addPlaceholderAndRetainMarks = (event, view, start, end) => {
 	let tr = state.tr
 	tr = tr.replaceWith(start, end, state.schema.text(ZWSP, marks))
 	tr = tr.setStoredMarks(marks)
+	tr = tr.setSelection(TextSelection.create(tr.doc, start + 1))
 	view.dispatch(tr)
 
 	return true

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -10,6 +10,7 @@ import OrderedList from '@tiptap/extension-ordered-list'
 import ListItem from '@tiptap/extension-list-item'
 import Color from '@tiptap/extension-color'
 import { Plugin, PluginKey } from 'prosemirror-state'
+import { joinBackward } from 'prosemirror-commands'
 
 const parseElementStyle = (attribute, value) => {
 	if (!value) return null
@@ -210,6 +211,21 @@ const handleKeyDown = (view, event) => {
 		tr = tr.setStoredMarks(marks)
 
 		dispatch(tr)
+
+		return true
+	}
+
+	if (text === ZWSP) {
+		// if only ZWSP is present, default behavior will lead to
+		// deleting it and adding <br class="ProseMirror-trailingBreak">
+		// so manually delete ZWSP and join with previous line which is expected behavior without the placeholder
+
+		event.preventDefault()
+
+		let tr = state.tr.delete(start, end)
+		dispatch(tr)
+
+		joinBackward(view.state, view.dispatch)
 
 		return true
 	}

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -91,33 +91,42 @@ const PastePlainText = Extension.create({
 
 const ZWSP = '\u200B'
 
+const handleEnterKey = (editor) => {
+	const { state, view } = editor
+	const { selection, storedMarks } = state
+	const $pos = selection.$from
+
+	// fetch current marks before splitting to next line
+	const marks = storedMarks || $pos.marks()
+
+	const didSplit = editor.commands.splitBlock()
+
+	// splitting to new line failed so don't change anything
+	if (!didSplit) return false
+
+	const parent = $pos.parent
+	const cursorAtEnd = $pos.parentOffset === parent.content.size
+
+	// insert ZWSP char so ProseMirror does not add <br class="ProseMirror-trailingBreak">
+	// instead adds an empty styled span - so line height, font size etc are consistent
+	let tr = view.state.tr
+	if (cursorAtEnd) {
+		tr.insertText(ZWSP)
+	}
+	// re-apply marks to new span (created after split)
+	tr = tr.setStoredMarks(marks)
+
+	view.dispatch(tr)
+
+	return true
+}
+
 export const StyledEmptyLine = Extension.create({
 	name: 'StyledEmptyLine',
 
 	addKeyboardShortcuts() {
 		return {
-			Enter: ({ editor }) => {
-				const { state, view } = editor
-				const { selection, storedMarks } = state
-				const $pos = selection.$from
-
-				// fetch current marks before splitting to next line
-				const marks = storedMarks || $pos.marks()
-
-				const didSplit = editor.commands.splitBlock()
-				// splitting to new line failed so don't change anything
-				if (!didSplit) return false
-
-				// insert ZWSP char so ProseMirror does not add <br class="ProseMirror-trailingBreak">
-				// instead adds an empty styled span - so line height, font size etc are consistent
-				let tr = view.state.tr
-				tr.insertText(ZWSP)
-				tr = tr.setStoredMarks(marks)
-
-				view.dispatch(tr)
-
-				return true
-			},
+			Enter: ({ editor }) => handleEnterKey(editor),
 		}
 	},
 })

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -250,27 +250,32 @@ const handleKeyDown = (view, event) => {
 	return false
 }
 
-const handleTextInput = (view, from, to, text) => {
+const removePlaceholderAndInsertText = (view, pos, text) => {
 	const { state, dispatch } = view
 	const { selection, storedMarks } = state
+
 	const marks = storedMarks || selection.$from.marks()
-
-	const $pos = selection.$from
-	const nodeBefore = $pos.nodeBefore
-
-	// if the prev char is not ZWSP, use default behavior
-	if (!nodeBefore || nodeBefore.text !== ZWSP) return false
 
 	// remove ZWSP when user enters actual text
 	let tr = state.tr
 
-	tr = tr.delete($pos.pos - 1, $pos.pos)
+	tr = tr.delete(pos.pos - 1, pos.pos)
 	tr = tr.setStoredMarks(marks)
 	tr = tr.insertText(text)
 
 	dispatch(tr)
 
 	return true
+}
+
+const handleTextInput = (view, from, to, text) => {
+	const $pos = view.state.selection.$from
+	const nodeBefore = $pos.nodeBefore
+
+	// if the prev char is not ZWSP, use default behavior
+	if (!nodeBefore || nodeBefore.text !== ZWSP) return false
+
+	return removePlaceholderAndInsertText(view, $pos, text)
 }
 
 export const StyledEmptyLine = Extension.create({

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -200,7 +200,7 @@ const handleEnterKey = (editor) => {
 		const $before = state.doc.resolve(startOfCurrentPos - 1)
 		const prevNode = $before.nodeBefore
 
-		if (prevNode && prevNode.isTextblock) {
+		if (!prevNode || prevNode.isTextblock) {
 			const prevEnd = startOfCurrentPos - 1
 			// insert ZWSP inside previous node as placeholder so
 			// <br class="ProseMirror-trailingBreak"> is not added

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -230,12 +230,30 @@ const handleEnterKey = (editor) => {
 	return true
 }
 
+function getFirstTextNodeInsideSelection(state) {
+	const { from, to } = state.selection
+	let foundText = null
+
+	state.doc.nodesBetween(from, to, (node) => {
+		if (node.isText) {
+			foundText = node
+			return false
+		}
+	})
+
+	return foundText
+}
+
 const addPlaceholderAndRetainMarks = (event, view, start, end) => {
 	event.preventDefault()
 
 	const state = view.state
 
-	const marks = state.storedMarks || state.selection.$from.marks()
+	let marks = state.storedMarks || state.selection.$from.marks()
+	if (!marks || marks.length === 0) {
+		const firstText = getFirstTextNodeInsideSelection(view.state)
+		marks = firstText ? firstText.marks : []
+	}
 
 	let tr = state.tr
 	tr = tr.replaceWith(start, end, state.schema.text(ZWSP, marks))
@@ -269,12 +287,8 @@ const getSelectionRange = (selection) => {
 	}
 }
 
-const getTextForSelection = (from) => {
-	const firstChild = from.parent.content.firstChild
-
-	if (!firstChild || !firstChild.isText) return undefined
-
-	return firstChild.text
+const getTextForSelection = ($from) => {
+	return $from.parent.textContent || ''
 }
 
 const getPrevNode = ($from, view) => {
@@ -309,10 +323,13 @@ const handleKeyDown = (view, event) => {
 
 	const { from, to, start, end } = getSelectionRange(selection)
 
-	if ((text.length === 1 && text !== ZWSP) || (from === start && to === end)) {
+	const lastCharOnLine = text.length === 1 && text !== ZWSP
+	const isEntireParagraphSelected = from === start && to === end
+	const isFullDocSelected = from === 0 && to === view.state.doc.content.size
+
+	if (lastCharOnLine || isEntireParagraphSelected || isFullDocSelected) {
 		// if the last non-ZWSP character is being deleted, replace with ZWSP + re-apply marks
 		// so <br class="ProseMirror-trailingBreak"> is not added
-
 		return addPlaceholderAndRetainMarks(event, view, start, end)
 	}
 

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -244,16 +244,22 @@ function getFirstTextNodeInsideSelection(state) {
 	return foundText
 }
 
+const getMarksForPlaceholder = (state) => {
+	let marks = state.storedMarks || state.selection.$from.marks()
+
+	if (!marks || marks.length === 0) {
+		const firstText = getFirstTextNodeInsideSelection(state)
+		marks = firstText ? firstText.marks : []
+	}
+
+	return marks
+}
+
 const addPlaceholderAndRetainMarks = (event, view, start, end) => {
 	event.preventDefault()
 
 	const state = view.state
-
-	let marks = state.storedMarks || state.selection.$from.marks()
-	if (!marks || marks.length === 0) {
-		const firstText = getFirstTextNodeInsideSelection(view.state)
-		marks = firstText ? firstText.marks : []
-	}
+	const marks = getMarksForPlaceholder(state)
 
 	let tr = state.tr
 	tr = tr.replaceWith(start, end, state.schema.text(ZWSP, marks))
@@ -293,8 +299,6 @@ const getTextForSelection = ($from) => {
 
 const getPrevNode = ($from, view) => {
 	const blockDepth = $from.depth
-
-	// Position before the current block
 	const posBeforeBlock = $from.before(blockDepth)
 
 	const resolved = view.state.doc.resolve(posBeforeBlock)
@@ -303,10 +307,12 @@ const getPrevNode = ($from, view) => {
 
 const joinBackwardAfterPlaceholder = (view) => {
 	joinBackward(view.state, view.dispatch)
+
 	let tr = view.state.tr
 	const newPos = view.state.selection.$from.pos
 	tr = tr.delete(newPos - 1, newPos)
 	view.dispatch(tr)
+
 	return true
 }
 

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -9,8 +9,10 @@ import BulletList from '@tiptap/extension-bullet-list'
 import OrderedList from '@tiptap/extension-ordered-list'
 import ListItem from '@tiptap/extension-list-item'
 import Color from '@tiptap/extension-color'
+
 import { Plugin, PluginKey } from 'prosemirror-state'
 import { joinBackward } from 'prosemirror-commands'
+import { TextSelection } from 'prosemirror-state'
 
 const parseElementStyle = (attribute, value) => {
 	if (!value) return null
@@ -117,6 +119,8 @@ const getItemAttributes = (node) => {
 }
 
 const CustomListItem = ListItem.extend({
+	// needed to ensure that <li> tag renders the span styles (e.g. font size, color etc.)
+	// they need to be present at <li> level so that CSS ::before element can work for bullet styling
 	renderHTML({ node, HTMLAttributes, ...rest }) {
 		const liAttrs = { ...HTMLAttributes }
 
@@ -146,15 +150,37 @@ const isInList = ($pos) => {
 	return false
 }
 
+const handleListItemEnterKey = (editor, pos, marks) => {
+	const { state, view } = editor
+
+	const endPos = pos.end()
+
+	// before splitting to next list item, insert ZWSP at end of current item
+	// move cursor to end of current item and then split
+	// so new list already has placeholder
+
+	let tr = state.tr.insertText(ZWSP, endPos, endPos, marks)
+	tr = tr.setSelection(TextSelection.create(tr.doc, endPos))
+	view.dispatch(tr)
+
+	// intentional since if we split and then add placeholder
+	// ProseMirror will not automatically re-trigger renderHTML for CustomListItem - line 122
+	editor.commands.splitListItem('listItem')
+
+	return true
+}
+
 const handleEnterKey = (editor) => {
 	const { state, view } = editor
 	const { selection, storedMarks } = state
 	const $pos = selection.$from
 
-	if (isInList($pos)) return false
-
 	// fetch current marks before splitting to next line
 	const marks = storedMarks || $pos.marks()
+
+	if (isInList($pos)) {
+		return handleListItemEnterKey(editor, $pos, marks)
+	}
 
 	const didSplit = editor.commands.splitBlock()
 

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -401,7 +401,7 @@ const styledEmptyLinePlugin = new Plugin({
 	},
 })
 
-export const StyledEmptyLine = Extension.create({
+const StyledEmptyLine = Extension.create({
 	name: 'StyledEmptyLine',
 
 	addKeyboardShortcuts() {
@@ -416,6 +416,43 @@ export const StyledEmptyLine = Extension.create({
 		return [styledEmptyLinePlugin]
 	},
 })
+
+export const patchEmptyParagraphs = (htmlString) => {
+	let didUpdate = false
+
+	const parser = new DOMParser()
+	const doc = parser.parseFromString(htmlString, 'text/html')
+
+	const allParagraphs = Array.from(doc.body.querySelectorAll('p'))
+	let prevSpanStyles = null
+
+	allParagraphs.forEach((p, index) => {
+		const isEmpty = p.textContent.trim() === ''
+		const firstSpan = p.querySelector('span')
+
+		if (!isEmpty && firstSpan) {
+			prevSpanStyles = firstSpan.getAttribute('style') || ''
+			return
+		}
+
+		if (isEmpty && prevSpanStyles) {
+			p.innerHTML = ''
+
+			if (!didUpdate) didUpdate = true
+
+			const span = doc.createElement('span')
+			span.setAttribute('style', prevSpanStyles)
+			span.innerHTML = '\u200B'
+
+			p.appendChild(span)
+		}
+	})
+
+	return {
+		wasUpdated: didUpdate,
+		updatedHTML: didUpdate ? doc.body.innerHTML : htmlString,
+	}
+}
 
 export const extensions = [
 	StarterKit.configure({

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -11,8 +11,6 @@ import ListItem from '@tiptap/extension-list-item'
 import Color from '@tiptap/extension-color'
 import { Plugin } from 'prosemirror-state'
 
-import { lastUsedStyles } from '@/composables/useTextEditor'
-
 const parseElementStyle = (attribute, value) => {
 	if (!value) return null
 
@@ -91,57 +89,10 @@ const PastePlainText = Extension.create({
 	},
 })
 
-const getItemAttributes = (node) => {
-	const paragraphNode = node.content?.firstChild
-	const textNode = paragraphNode?.firstChild
-
-	const attrs = {
-		color: null,
-		fontSize: null,
-		fontFamily: null,
-		letterSpacing: null,
-		opacity: null,
-	}
-
-	if (textNode?.marks) {
-		for (const mark of textNode.marks) {
-			if (mark.type.name == 'textStyle') {
-				const styleAttrs = mark.attrs
-				styleAttrs.fontSize = parseInt(styleAttrs.fontSize)
-				Object.assign(attrs, styleAttrs)
-				return attrs
-			}
-		}
-	}
-
-	Object.assign(attrs, lastUsedStyles)
-	return attrs
-}
-
-const CustomListItem = ListItem.extend({
-	renderHTML({ node, HTMLAttributes, ...rest }) {
-		const liAttrs = { ...HTMLAttributes }
-
-		const { color, fontSize, fontFamily, letterSpacing, opacity } = getItemAttributes(node)
-
-		liAttrs.style = [
-			liAttrs.style || '',
-			`color: ${color};`,
-			`font-size: ${fontSize}px;`,
-			`font-family: ${fontFamily};`,
-			`letter-spacing: ${letterSpacing};`,
-			`opacity: ${opacity};`,
-		].join(' ')
-
-		return ['li', liAttrs, 0]
-	},
-})
-
 export const extensions = [
 	StarterKit.configure({
 		bulletList: false,
 		orderedList: false,
-		listItem: false,
 	}),
 	CustomTextStyle,
 	Underline,
@@ -158,5 +109,4 @@ export const extensions = [
 		keepAttributes: true,
 		keepMarks: true,
 	}),
-	CustomListItem,
 ]

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -14,6 +14,8 @@ import { Plugin, PluginKey } from 'prosemirror-state'
 import { joinBackward } from 'prosemirror-commands'
 import { TextSelection } from 'prosemirror-state'
 
+import { getDocFromHTML } from '@/utils/helpers'
+
 const parseElementStyle = (attribute, value) => {
 	if (!value) return null
 
@@ -417,16 +419,27 @@ const StyledEmptyLine = Extension.create({
 	},
 })
 
+const updateParagraphHTML = (doc, p, prevSpanStyles) => {
+	p.innerHTML = ''
+
+	const span = doc.createElement('span')
+	span.setAttribute('style', prevSpanStyles)
+	span.innerHTML = ZWSP
+
+	p.appendChild(span)
+}
+
 export const patchEmptyParagraphs = (htmlString) => {
+	// to patch <br class="ProseMirror-trailingBreak"> -> ZWSP
+	// before StyledEmptyLine plugin was added
 	let didUpdate = false
 
-	const parser = new DOMParser()
-	const doc = parser.parseFromString(htmlString, 'text/html')
+	const doc = getDocFromHTML(htmlString)
 
 	const allParagraphs = Array.from(doc.body.querySelectorAll('p'))
 	let prevSpanStyles = null
 
-	allParagraphs.forEach((p, index) => {
+	allParagraphs.forEach((p) => {
 		const isEmpty = p.textContent.trim() === ''
 		const firstSpan = p.querySelector('span')
 
@@ -436,15 +449,9 @@ export const patchEmptyParagraphs = (htmlString) => {
 		}
 
 		if (isEmpty && prevSpanStyles) {
-			p.innerHTML = ''
-
 			if (!didUpdate) didUpdate = true
 
-			const span = doc.createElement('span')
-			span.setAttribute('style', prevSpanStyles)
-			span.innerHTML = '\u200B'
-
-			p.appendChild(span)
+			updateParagraphHTML(doc, p, prevSpanStyles)
 		}
 	})
 

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -180,7 +180,6 @@ const handleEnterKey = (editor) => {
 const handleKeyDown = (view, event) => {
 	if (event.key !== 'Backspace') return false
 
-	// before adding an unstyled empty line, check for last styles
 	const { state, dispatch } = view
 	const { selection, storedMarks } = state
 
@@ -214,6 +213,29 @@ const handleKeyDown = (view, event) => {
 	return false
 }
 
+const handleTextInput = (view, from, to, text) => {
+	const { state, dispatch } = view
+	const { selection, storedMarks } = state
+	const marks = storedMarks || selection.$from.marks()
+
+	const $pos = selection.$from
+	const nodeBefore = $pos.nodeBefore
+
+	// if the prev char is not ZWSP, use default behavior
+	if (!nodeBefore || nodeBefore.text !== ZWSP) return false
+
+	// remove ZWSP when user enters actual text
+	let tr = state.tr
+
+	tr = tr.delete($pos.pos - 1, $pos.pos)
+	tr = tr.setStoredMarks(marks)
+	tr = tr.insertText(text)
+
+	dispatch(tr)
+
+	return true
+}
+
 export const StyledEmptyLine = Extension.create({
 	name: 'StyledEmptyLine',
 
@@ -228,7 +250,12 @@ export const StyledEmptyLine = Extension.create({
 			new Plugin({
 				key: new PluginKey('styledSpanPlugin'),
 				props: {
+					// before adding an unstyled empty line on clearing content
+					// add a ZWSP with stored marks to retain styles
 					handleKeyDown,
+					// before typing new text to styled empty line
+					// remove the placeholder ZWSP
+					handleTextInput,
 				},
 			}),
 		]

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -287,6 +287,15 @@ const getPrevNode = ($from, view) => {
 	return resolved.nodeBefore
 }
 
+const joinBackwardAfterPlaceholder = (view) => {
+	joinBackward(view.state, view.dispatch)
+	let tr = view.state.tr
+	const newPos = view.state.selection.$from.pos
+	tr = tr.delete(newPos - 1, newPos)
+	view.dispatch(tr)
+	return true
+}
+
 const handleKeyDown = (view, event) => {
 	if (event.key !== 'Backspace') return false
 
@@ -320,6 +329,10 @@ const handleKeyDown = (view, event) => {
 		// if only ZWSP is present but no previous textblock, do nothing
 		event.preventDefault()
 		return true
+	}
+
+	if (prevNode && prevNode.isTextblock && prevNode.textContent === ZWSP) {
+		return joinBackwardAfterPlaceholder(event, view, $from)
 	}
 
 	return false

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -162,14 +162,31 @@ const handleEnterKey = (editor) => {
 	if (!didSplit) return false
 
 	const parent = $pos.parent
+	const cursorAtStart = $pos.parentOffset === 0
 	const cursorAtEnd = $pos.parentOffset === parent.content.size
 
 	// insert ZWSP char so ProseMirror does not add <br class="ProseMirror-trailingBreak">
 	// instead adds an empty styled span - so line height, font size etc. are consistent
 	let tr = view.state.tr
-	if (cursorAtEnd) {
+
+	if (cursorAtStart) {
+		const startOfCurrentPos = $pos.start()
+		const $before = state.doc.resolve(startOfCurrentPos - 1)
+		const prevNode = $before.nodeBefore
+
+		if (prevNode && prevNode.isTextblock) {
+			const prevEnd = startOfCurrentPos - 1
+			// insert ZWSP inside previous node as placeholder so
+			// <br class="ProseMirror-trailingBreak"> is not added
+			tr.insert(prevEnd + 1, state.schema.text(ZWSP, marks))
+			tr = tr.setStoredMarks(marks)
+			view.dispatch(tr)
+			return true
+		}
+	} else if (cursorAtEnd) {
 		tr.insertText(ZWSP)
 	}
+
 	// re-apply marks to new span (created after split)
 	tr = tr.setStoredMarks(marks)
 

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -177,6 +177,43 @@ const handleEnterKey = (editor) => {
 	return true
 }
 
+const handleKeyDown = (view, event) => {
+	if (event.key !== 'Backspace') return false
+
+	// before adding an unstyled empty line, check for last styles
+	const { state, dispatch } = view
+	const { selection, storedMarks } = state
+
+	const $from = selection.$from
+
+	if (isInList($from)) return false
+
+	const firstChild = $from.parent.content.firstChild
+	if (!firstChild || !firstChild.isText) return false
+
+	const text = firstChild.text
+	const marks = storedMarks || $from.marks()
+
+	const start = $from.start()
+	const end = $from.end()
+
+	// if the last non-ZWSP character is being deleted, replace with ZWSP + re-apply marks
+	// so <br class="ProseMirror-trailingBreak"> is not added
+	if (text.length === 1 && text !== ZWSP) {
+		event.preventDefault()
+
+		let tr = state.tr
+		tr = tr.replaceWith(start, end, state.schema.text(ZWSP, marks))
+		tr = tr.setStoredMarks(marks)
+
+		dispatch(tr)
+
+		return true
+	}
+
+	return false
+}
+
 export const StyledEmptyLine = Extension.create({
 	name: 'StyledEmptyLine',
 
@@ -191,39 +228,7 @@ export const StyledEmptyLine = Extension.create({
 			new Plugin({
 				key: new PluginKey('styledSpanPlugin'),
 				props: {
-					handleKeyDown(view, event) {
-						if (event.key !== 'Backspace') return false
-
-						const { state, dispatch } = view
-						const { selection, storedMarks } = state
-
-						const $from = selection.$from
-
-						if (isInList($from)) return false
-
-						const firstChild = $from.parent.content.firstChild
-						if (!firstChild || !firstChild.isText) return false
-
-						const text = firstChild.text
-						const marks = storedMarks || $from.marks()
-
-						const start = $from.start()
-						const end = $from.end()
-
-						if (text.length === 1 && text !== ZWSP) {
-							event.preventDefault()
-
-							let tr = state.tr
-							tr = tr.replaceWith(start, end, state.schema.text(ZWSP, marks))
-							tr = tr.setStoredMarks(marks)
-
-							dispatch(tr)
-
-							return true
-						}
-
-						return false
-					},
+					handleKeyDown,
 				},
 			}),
 		]

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -281,6 +281,18 @@ const handleTextInput = (view, from, to, text) => {
 	return removePlaceholderAndInsertText(view, $pos, text)
 }
 
+const styledSpanPlugin = new Plugin({
+	key: new PluginKey('styledSpanPlugin'),
+	props: {
+		// before adding an unstyled empty line on clearing content
+		// add a ZWSP with stored marks to retain styles
+		handleKeyDown,
+		// before typing new text to styled empty line
+		// remove the placeholder ZWSP
+		handleTextInput,
+	},
+})
+
 export const StyledEmptyLine = Extension.create({
 	name: 'StyledEmptyLine',
 
@@ -291,19 +303,7 @@ export const StyledEmptyLine = Extension.create({
 	},
 
 	addProseMirrorPlugins() {
-		return [
-			new Plugin({
-				key: new PluginKey('styledSpanPlugin'),
-				props: {
-					// before adding an unstyled empty line on clearing content
-					// add a ZWSP with stored marks to retain styles
-					handleKeyDown,
-					// before typing new text to styled empty line
-					// remove the placeholder ZWSP
-					handleTextInput,
-				},
-			}),
-		]
+		return [styledSpanPlugin]
 	},
 })
 

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -9,7 +9,7 @@ import BulletList from '@tiptap/extension-bullet-list'
 import OrderedList from '@tiptap/extension-ordered-list'
 import ListItem from '@tiptap/extension-list-item'
 import Color from '@tiptap/extension-color'
-import { Plugin } from 'prosemirror-state'
+import { Plugin, PluginKey } from 'prosemirror-state'
 
 const parseElementStyle = (attribute, value) => {
 	if (!value) return null
@@ -164,7 +164,7 @@ const handleEnterKey = (editor) => {
 	const cursorAtEnd = $pos.parentOffset === parent.content.size
 
 	// insert ZWSP char so ProseMirror does not add <br class="ProseMirror-trailingBreak">
-	// instead adds an empty styled span - so line height, font size etc are consistent
+	// instead adds an empty styled span - so line height, font size etc. are consistent
 	let tr = view.state.tr
 	if (cursorAtEnd) {
 		tr.insertText(ZWSP)
@@ -184,6 +184,49 @@ export const StyledEmptyLine = Extension.create({
 		return {
 			Enter: ({ editor }) => handleEnterKey(editor),
 		}
+	},
+
+	addProseMirrorPlugins() {
+		return [
+			new Plugin({
+				key: new PluginKey('styledSpanPlugin'),
+				props: {
+					handleKeyDown(view, event) {
+						if (event.key !== 'Backspace') return false
+
+						const { state, dispatch } = view
+						const { selection, storedMarks } = state
+
+						const $from = selection.$from
+
+						if (isInList($from)) return false
+
+						const firstChild = $from.parent.content.firstChild
+						if (!firstChild || !firstChild.isText) return false
+
+						const text = firstChild.text
+						const marks = storedMarks || $from.marks()
+
+						const start = $from.start()
+						const end = $from.end()
+
+						if (text.length === 1 && text !== ZWSP) {
+							event.preventDefault()
+
+							let tr = state.tr
+							tr = tr.replaceWith(start, end, state.schema.text(ZWSP, marks))
+							tr = tr.setStoredMarks(marks)
+
+							dispatch(tr)
+
+							return true
+						}
+
+						return false
+					},
+				},
+			}),
+		]
 	},
 })
 

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -89,4 +89,19 @@ const getThumbnailCardStyles = (thumbnail: string) => {
 	}
 }
 
-export { handleSingleAndDoubleClick, debounce, generateUniqueId, setCursorPositionAtEnd, handleScrollBarWheelEvent, cloneObj, copyToClipboard, getThumbnailCardStyles }
+const getDocFromHTML = (html: string) => {
+	const parser = new DOMParser()
+	return parser.parseFromString(html, 'text/html')
+}
+
+export {
+	handleSingleAndDoubleClick,
+	debounce,
+	generateUniqueId,
+	setCursorPositionAtEnd,
+	handleScrollBarWheelEvent,
+	cloneObj,
+	copyToClipboard,
+	getThumbnailCardStyles,
+	getDocFromHTML
+}


### PR DESCRIPTION
## Problem
For Text Elements, styles for every paragraph were maintained through the default behaviour of Tiptap. The only difference being that when the user clears all the text from a paragraph or goes from one paragraph to the other, if no styles are applied on the text, then the previously used styles would be carried forward. If the user typed in text, it would appear with the preserved set of styles. However, this meant that if the paragraph was left empty it would not have any span within it with those styles applied because of no text content within that paragraph. ProseMirror adds a `<br class="ProseMirror-trailingBreak">` element within such empty paragraphs to ensure that it is still visible and editable. However, for each of these empty paragraphs, the font size defaults to the browsers default `16px` with the selected line height. This leads to unwanted behaviour both in editable and non-editable state for the text -

1. The line height becomes inconsistent since text paragraphs have the visual height calculated using the applied font size and line height. On the other hand, height for the empty paragraphs is calculated without the font size.
    

    https://github.com/user-attachments/assets/b990dc8a-ad0a-4290-9df6-15ed74149a26

    <br>

2. When the tiptap editor is in editable state, the cursor remains unstyled for such empty lines in the middle because of missing styles on the current node.


     https://github.com/user-attachments/assets/e4380f9e-6f35-41e7-8553-17f4c55f1bea
    
      <br>

4. When the HTML for the text is rendered normally without tiptap, the empty paragraphs collapse because of missing "ProseMirror-trailingBreak" class without the tiptap instance. This was kind of handled till now using CSS workaround -
https://github.com/frappe/slides/blob/bb298a124e1911b2ad7d2f11ee18342961ef8b0f/frontend/src/components/TextElement.vue#L168-L172  but without additional CSS it would be like this -


      https://github.com/user-attachments/assets/66fee2ad-73cf-4fae-9ecb-12d205cf2c7a


<br>

## Styled Empty Line Extension
Added a custom extension that adds a placeholder span with a zero width space ('\u200B') so ProseMirror doesn't fallback to <br class="ProseMirror-trailingBreak"> and always has the default styles within the paragraph itself including the font size and font color - to solve for all the 3 issues.


### Enter:

- When the user clicks the enter key and a new paragraph is created after the current one, add the placeholder zwsp span with stored marks after splitting the block.
- Similarly when new paragraph is created from beginning of a line, add the placeholder span to the previous line.
- When text is split from the middle, both the lines already have text content within them so don't change the normal behaviour here.
- In case of `<li>` blocks, when user clicks enter to create new `<li>`, add the ZWSP character at the end of the current block before splitting. If we add it after splitting, `renderHTML` function does not rerun from the CustomListItem extension.


### Backspace:

- If backspace is pressed to clear the last character, entire line selection or entire doc selection, insert placeholder zwsp span instead of emptying everything.
- If only zwsp exists on the current line and its the first line, don't do anything since we need the zwsp always.
- If only zwsp exists and we have a line before it, backspacing on it removes the zwsp and merges the line with the previous.
- If user clicks backspace from the start of a line to merge it previous line, check if it has zwsp if yes remove it.


### handleTextInput:

On text input, check if the line consists of the zwsp character. If not, use default behaviour. Otherwise remove it since we don't need a placeholder anymore after actual text being typed.
