### PR TITLE
fix: jumping to slide after history operation and other fixes

### DIFF
--- a/frontend/src/components/NavigationPanel.vue
+++ b/frontend/src/components/NavigationPanel.vue
@@ -29,7 +29,7 @@
 				<Draggable
 					v-model="slides"
 					item-key="name"
-					@start="resetFocus"
+					@start="handleSortStart"
 					@end="handleSortEnd"
 				>
 					<template #item="{ element: slide }">
@@ -82,7 +82,7 @@ import { slides, slideIndex, currentSlide, focusedSlide } from '@/stores/slide'
 import { handleScrollBarWheelEvent, getThumbnailCardStyles } from '@/utils/helpers'
 import { isBackgroundColorDark } from '@/utils/color'
 
-import { ignoreUpdates } from '@/stores/presentation'
+import { ignoreUpdates, historyMetadata } from '@/stores/presentation'
 import { resetFocus } from '@/stores/element'
 
 const attrs = useAttrs()
@@ -195,7 +195,13 @@ const toggleButtonClasses = computed(() => {
 	return `${baseClasses} absolute top-1/2 transform -transform-y-1/2 h-12 w-4 justify-center rounded-r-lg shadow-xl`
 })
 
+const handleSortStart = (event) => {
+	historyMetadata.focusIndexPostUndo = event.oldIndex
+	resetFocus()
+}
+
 const handleSortEnd = async (event) => {
+	historyMetadata.focusIndexPostRedo = event.newIndex
 	ignoreUpdates(() => {
 		slides.value.forEach((slide, index) => {
 			slide.idx = index + 1

--- a/frontend/src/components/NavigationPanel.vue
+++ b/frontend/src/components/NavigationPanel.vue
@@ -182,7 +182,7 @@ const getThumbnailStyles = (s) => {
 	let styles = getThumbnailCardStyles(s.thumbnail)
 
 	// intentional to reduce extreme color change while loading new thumbnail which might be visually distracting
-	styles.backgroundColor = currentSlide.value?.background || '#ffffff' //fallback color
+	styles.backgroundColor = s.background || '#ffffff' //fallback color
 
 	return styles
 }

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -306,9 +306,14 @@ const getJumpToSlideId = (operation, oldList, newList) => {
 	return slides.value.findIndex((slide) => slide.name === slideId)
 }
 
-const restoreState = (state) => {
+const restoreState = (state, jumpToSlideId) => {
 	ignoreUpdates(() => {
-		slides.value = JSON.parse(JSON.stringify(state))
+		slides.value = JSON.parse(JSON.stringify(state)).map((slide, idx) => {
+			if (idx === jumpToSlideId) {
+				slide.thumbnail = ''
+			}
+			return slide
+		})
 		slidesLength.value = slides.value.length
 	})
 }
@@ -346,11 +351,11 @@ const handleHistoryOperation = async (operation) => {
 	const oldList = JSON.parse(JSON.stringify(slides.value))
 	const newList = JSON.parse(JSON.stringify(historyState.value.slides))
 
-	restoreState(historyState.value.slides)
+	const jumpToSlideId = await jumpToSlide(operation, oldList, newList)
+
+	restoreState(historyState.value.slides, jumpToSlideId)
 
 	await nextTick()
-
-	const jumpToSlideId = await jumpToSlide(operation, oldList, newList)
 
 	updateThumbnail(jumpToSlideId)
 

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -265,6 +265,7 @@ const handleHistoryOperation = async (operation) => {
 
 	ignoreUpdates(() => {
 		slides.value = JSON.parse(JSON.stringify(historyState.value.slides))
+		slidesLength.value = slides.value.length
 	})
 
 	const onActiveSlide = slideToFocus == slideIndex.value
@@ -281,6 +282,7 @@ const handleHistoryOperation = async (operation) => {
 	if (activeElementIds.value != elementsToFocus) {
 		activeElementIds.value = elementsToFocus
 	}
+
 	nextTick(() => {
 		updateThumbnail(slideToFocus)
 	})
@@ -361,7 +363,7 @@ const handleThumbnailGeneration = async (index) => {
 }
 
 const changeSlide = async (index, focus = true) => {
-	index = Math.max(0, Math.min(index, slides.value.length - 1))
+	index = Math.max(0, Math.min(index, slidesLength.value - 1))
 
 	const oldIndex = slideIndex.value
 

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -292,16 +292,16 @@ const getJumpToSlideId = (operation, oldList, newList) => {
 	if (didReorder && operation == 'undo') return historyMetadata.focusIndexPostUndo
 	if (didReorder && operation == 'redo') return historyMetadata.focusIndexPostRedo
 
-	if (historyControl.undoStack.value.length == 1 && operation == 'undo') {
-		return Math.max(0, Math.min(slideIndex.value, slidesLength.value - 1))
-	}
-
 	if (oldList.length < newList.length) {
 		return getRestoredSlideId(oldList, newList)
 	}
 
 	if (oldList.length > newList.length) {
 		return getPrevToDeletedSlideId(oldList, newList)
+	}
+
+	if (historyControl.undoStack.value.length == 1 && operation == 'undo') {
+		return Math.max(0, Math.min(slideIndex.value, slidesLength.value - 1))
 	}
 
 	const slideId = historyState.value.activeSlide

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -254,19 +254,30 @@ const handleGlobalShortcuts = (e) => {
 
 const recentlyRestored = ref(false)
 
+const getJumpToSlideId = (operation) => {
+	if (historyControl.undoStack.value.length == 1 && operation == 'undo') {
+		return Math.max(0, Math.min(slideIndex.value, slidesLength.value - 1))
+	}
+
+	const slideId = historyState.value.activeSlide
+	return slides.value.findIndex((slide) => slide.name === slideId)
+}
+
 const handleHistoryOperation = async (operation) => {
 	activeElementIds.value = []
 
 	if (operation == 'undo') await historyControl.undo()
 	else if (operation == 'redo') await historyControl.redo()
 
-	const slideToFocus = historyState.value.activeSlide
-	const elementsToFocus = [...historyState.value.elementIds]
-
 	ignoreUpdates(() => {
 		slides.value = JSON.parse(JSON.stringify(historyState.value.slides))
 		slidesLength.value = slides.value.length
 	})
+
+	const jumpToSlideId = getJumpToSlideId(operation)
+	const elementsToFocus = [...historyState.value.elementIds]
+
+	await nextTick()
 
 	const onActiveSlide = slideToFocus == slideIndex.value
 

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -277,25 +277,15 @@ const getJumpToSlideId = (operation, oldList, newList) => {
 	return slides.value.findIndex((slide) => slide.name === slideId)
 }
 
-const handleHistoryOperation = async (operation) => {
-	activeElementIds.value = []
-
-	if (operation == 'undo') await historyControl.undo()
-	else if (operation == 'redo') await historyControl.redo()
-
-	const oldList = JSON.parse(JSON.stringify(slides.value))
-	const newList = JSON.parse(JSON.stringify(historyState.value.slides))
-
+const restoreState = (state) => {
 	ignoreUpdates(() => {
-		slides.value = JSON.parse(JSON.stringify(historyState.value.slides))
+		slides.value = JSON.parse(JSON.stringify(state))
 		slidesLength.value = slides.value.length
 	})
+}
 
-	await nextTick()
-
+const jumpToSlide = async (operation, oldList, newList) => {
 	const jumpToSlideId = getJumpToSlideId(operation, oldList, newList)
-	const elementsToFocus = [...historyState.value.elementIds]
-
 	const onActiveSlide = jumpToSlideId == slideIndex.value
 
 	if (!onActiveSlide && jumpToSlideId != null) {
@@ -307,9 +297,33 @@ const handleHistoryOperation = async (operation) => {
 		}, 1000)
 	}
 
+	return jumpToSlideId
+}
+
+const jumpToActiveElements = () => {
+	const elementsToFocus = [...historyState.value.elementIds]
+
 	if (activeElementIds.value != elementsToFocus) {
 		activeElementIds.value = elementsToFocus
 	}
+}
+
+const handleHistoryOperation = async (operation) => {
+	activeElementIds.value = []
+
+	if (operation == 'undo') await historyControl.undo()
+	else if (operation == 'redo') await historyControl.redo()
+
+	const oldList = JSON.parse(JSON.stringify(slides.value))
+	const newList = JSON.parse(JSON.stringify(historyState.value.slides))
+
+	restoreState(historyState.value.slides)
+
+	await nextTick()
+
+	const jumpToSlideId = await jumpToSlide(operation, oldList, newList)
+
+	jumpToActiveElements()
 
 	nextTick(() => {
 		updateThumbnail(jumpToSlideId)

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -256,12 +256,22 @@ const recentlyRestored = ref(false)
 
 const getRestoredSlideId = (oldList, newList) => {
 	let restoredId = ''
-	newList.forEach((slide) => {
+	newList.forEach((slide, index) => {
 		if (!oldList.find((s) => s.name === slide.name)) {
-			restoredId = slide.name
+			restoredId = index
 		}
 	})
-	return slides.value.findIndex((slide) => slide.name === restoredId)
+	return restoredId
+}
+
+const getPrevToDeletedSlideId = (oldList, newList) => {
+	let prevId = null
+	oldList.forEach((slide, index) => {
+		if (!newList.find((s) => s.name === slide.name)) {
+			prevId = index - 1
+		}
+	})
+	return prevId
 }
 
 const getJumpToSlideId = (operation, oldList, newList) => {
@@ -271,6 +281,10 @@ const getJumpToSlideId = (operation, oldList, newList) => {
 
 	if (oldList.length < newList.length) {
 		return getRestoredSlideId(oldList, newList)
+	}
+
+	if (oldList.length > newList.length) {
+		return getPrevToDeletedSlideId(oldList, newList)
 	}
 
 	const slideId = historyState.value.activeSlide

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -84,6 +84,7 @@ import {
 	unsyncedPresentationRecord,
 	readonlyMode,
 	slidesLength,
+	historyMetadata,
 } from '@/stores/presentation'
 import {
 	slides,
@@ -274,7 +275,21 @@ const getPrevToDeletedSlideId = (oldList, newList) => {
 	return prevId
 }
 
+const wereSlidesReordered = (oldList, newList) => {
+	for (let i = 0; i < newList.length; i++) {
+		if (oldList[i] && oldList[i].name !== newList[i].name) {
+			return true
+		}
+	}
+	return false
+}
+
 const getJumpToSlideId = (operation, oldList, newList) => {
+	// reordered slides -> the jump to index becomes the slide that was moved
+	const didReorder = wereSlidesReordered(oldList, newList)
+	if (didReorder && operation == 'undo') return historyMetadata.focusIndexPostUndo
+	if (didReorder && operation == 'redo') return historyMetadata.focusIndexPostRedo
+
 	if (historyControl.undoStack.value.length == 1 && operation == 'undo') {
 		return Math.max(0, Math.min(slideIndex.value, slidesLength.value - 1))
 	}
@@ -337,10 +352,10 @@ const handleHistoryOperation = async (operation) => {
 
 	const jumpToSlideId = await jumpToSlide(operation, oldList, newList)
 
-	jumpToActiveElements()
+	updateThumbnail(jumpToSlideId)
 
 	nextTick(() => {
-		updateThumbnail(jumpToSlideId)
+		jumpToActiveElements()
 	})
 }
 

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -279,10 +279,10 @@ const handleHistoryOperation = async (operation) => {
 
 	await nextTick()
 
-	const onActiveSlide = slideToFocus == slideIndex.value
+	const onActiveSlide = jumpToSlideId == slideIndex.value
 
-	if (!onActiveSlide && slideToFocus != null) {
-		await changeSlide(slideToFocus, false)
+	if (!onActiveSlide && jumpToSlideId != null) {
+		await changeSlide(jumpToSlideId, false)
 
 		recentlyRestored.value = true
 		setTimeout(() => {
@@ -295,21 +295,21 @@ const handleHistoryOperation = async (operation) => {
 	}
 
 	nextTick(() => {
-		updateThumbnail(slideToFocus)
+		updateThumbnail(jumpToSlideId)
 	})
 }
 
 const handleUndoRedo = (e) => {
+	e.preventDefault()
+
 	if (activeEditor.value?.isEditable) {
 		e.stopPropagation()
 		return
 	}
 
 	if (isCmdOrCtrl(e) && e.shiftKey && historyControl.canRedo.value) {
-		e.preventDefault()
 		handleHistoryOperation('redo')
 	} else if (isCmdOrCtrl(e) && historyControl.undoStack.value.length > 1) {
-		e.preventDefault()
 		handleHistoryOperation('undo')
 	}
 }

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -254,9 +254,20 @@ const handleGlobalShortcuts = (e) => {
 
 const recentlyRestored = ref(false)
 
-const getJumpToSlideId = (operation) => {
+const getJumpToSlideId = (operation, oldList, newList) => {
 	if (historyControl.undoStack.value.length == 1 && operation == 'undo') {
 		return Math.max(0, Math.min(slideIndex.value, slidesLength.value - 1))
+	}
+
+	if (oldList.length < newList.length) {
+		// slide was restored, jump to that slide
+		let restoredId = ''
+		newList.forEach((slide) => {
+			if (!oldList.find((s) => s.name === slide.name)) {
+				restoredId = slide.name
+			}
+		})
+		return slides.value.findIndex((slide) => slide.name === restoredId)
 	}
 
 	const slideId = historyState.value.activeSlide
@@ -269,15 +280,18 @@ const handleHistoryOperation = async (operation) => {
 	if (operation == 'undo') await historyControl.undo()
 	else if (operation == 'redo') await historyControl.redo()
 
+	const oldList = JSON.parse(JSON.stringify(slides.value))
+	const newList = JSON.parse(JSON.stringify(historyState.value.slides))
+
 	ignoreUpdates(() => {
 		slides.value = JSON.parse(JSON.stringify(historyState.value.slides))
 		slidesLength.value = slides.value.length
 	})
 
-	const jumpToSlideId = getJumpToSlideId(operation)
-	const elementsToFocus = [...historyState.value.elementIds]
-
 	await nextTick()
+
+	const jumpToSlideId = getJumpToSlideId(operation, oldList, newList)
+	const elementsToFocus = [...historyState.value.elementIds]
 
 	const onActiveSlide = jumpToSlideId == slideIndex.value
 

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -254,20 +254,23 @@ const handleGlobalShortcuts = (e) => {
 
 const recentlyRestored = ref(false)
 
+const getRestoredSlideId = (oldList, newList) => {
+	let restoredId = ''
+	newList.forEach((slide) => {
+		if (!oldList.find((s) => s.name === slide.name)) {
+			restoredId = slide.name
+		}
+	})
+	return slides.value.findIndex((slide) => slide.name === restoredId)
+}
+
 const getJumpToSlideId = (operation, oldList, newList) => {
 	if (historyControl.undoStack.value.length == 1 && operation == 'undo') {
 		return Math.max(0, Math.min(slideIndex.value, slidesLength.value - 1))
 	}
 
 	if (oldList.length < newList.length) {
-		// slide was restored, jump to that slide
-		let restoredId = ''
-		newList.forEach((slide) => {
-			if (!oldList.find((s) => s.name === slide.name)) {
-				restoredId = slide.name
-			}
-		})
-		return slides.value.findIndex((slide) => slide.name === restoredId)
+		return getRestoredSlideId(oldList, newList)
 	}
 
 	const slideId = historyState.value.activeSlide

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -276,6 +276,8 @@ const getPrevToDeletedSlideId = (oldList, newList) => {
 }
 
 const wereSlidesReordered = (oldList, newList) => {
+	if (oldList.length !== newList.length) return false
+
 	for (let i = 0; i < newList.length; i++) {
 		if (oldList[i] && oldList[i].name !== newList[i].name) {
 			return true

--- a/frontend/src/stores/presentation.js
+++ b/frontend/src/stores/presentation.js
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { ref, reactive } from 'vue'
 import { watchIgnorable, useManualRefHistory } from '@vueuse/core'
 import { createResource, call, createDocumentResource } from 'frappe-ui'
 import { isEqual } from 'lodash'
@@ -304,12 +304,13 @@ const historyState = ref({
 	slides: [],
 })
 
+const historyMetadata = reactive({})
+
 const updateHistoryState = (slides, activeSlide, elementIds) => {
 	const slidesClone = [...slides].map((slide, idx) => {
 		return {
 			...slide,
 			elements: slide.elements.map((el) => cloneObj(el)),
-			thumbnail: idx == activeSlide ? '' : slide.thumbnail,
 		}
 	})
 
@@ -374,4 +375,5 @@ export {
 	readonlyMode,
 	slidesLength,
 	parseElements,
+	historyMetadata,
 }

--- a/frontend/src/stores/presentation.js
+++ b/frontend/src/stores/presentation.js
@@ -228,6 +228,18 @@ const hasStateChanged = (original, current) => {
 	return hasChanged
 }
 
+const updateNewlyAddedSlideUUIDs = () => {
+	// for newly added slides, update their names from server response
+	// required for correct jumping to slide during undo / redo operations
+	ignoreUpdates(() => {
+		slides.value.forEach((slide, idx) => {
+			if (slide.name === '') {
+				slide.name = presentationResource.value.doc.slides[idx].name
+			}
+		})
+	})
+}
+
 const savePresentationDoc = async () => {
 	const newSlides = slides.value.map((slide) => ({
 		...slide,
@@ -241,6 +253,8 @@ const savePresentationDoc = async () => {
 	})
 
 	presentationDoc.value = presentationResource.value.doc
+
+	updateNewlyAddedSlideUUIDs()
 }
 
 const layoutResource = createResource({

--- a/frontend/src/stores/presentation.js
+++ b/frontend/src/stores/presentation.js
@@ -234,7 +234,7 @@ const updateNewlyAddedSlideUUIDs = () => {
 	ignoreUpdates(() => {
 		slides.value.forEach((slide, idx) => {
 			if (slide.name === '') {
-				slide.name = presentationResource.value.doc.slides[idx].name
+				slide.name = presentationResource.value.doc.slides[idx]?.name
 			}
 		})
 	})

--- a/frontend/src/stores/presentation.js
+++ b/frontend/src/stores/presentation.js
@@ -3,7 +3,7 @@ import { watchIgnorable, useManualRefHistory } from '@vueuse/core'
 import { createResource, call, createDocumentResource } from 'frappe-ui'
 import { isEqual } from 'lodash'
 
-import { slides, slideIndex } from './slide'
+import { slides, slideIndex, currentSlide } from './slide'
 import { activeElementIds, normalizeZIndices } from '@/stores/element'
 
 import { cloneObj } from '@/utils/helpers'
@@ -286,7 +286,7 @@ let historyControl = null
 
 const historyState = ref({
 	elementIds: '',
-	activeSlide: 0,
+	activeSlide: '',
 	slides: [],
 })
 
@@ -319,7 +319,7 @@ const { ignoreUpdates } = watchIgnorable(
 )
 
 const initHistory = () => {
-	historyState.value.activeSlide = slideIndex.value
+	historyState.value.activeSlide = currentSlide.value?.name
 	historyControl = useManualRefHistory(historyState, {
 		capacity: 25,
 		clone: true,

--- a/frontend/src/stores/presentation.js
+++ b/frontend/src/stores/presentation.js
@@ -310,13 +310,19 @@ const { ignoreUpdates } = watchIgnorable(
 	() => slides.value,
 	(newVal) => {
 		if (!newVal.length) return
-
-		updateHistoryState(newVal, slideIndex.value, activeElementIds.value)
-
-		historyControl?.commit()
+		commitToHistory(newVal)
 	},
 	{ deep: true },
 )
+
+const commitToHistory = (state) => {
+	const activeSlide = currentSlide.value?.name
+	const elementIds = activeElementIds.value
+
+	updateHistoryState(state, activeSlide, elementIds)
+
+	historyControl?.commit()
+}
 
 const initHistory = () => {
 	historyState.value.activeSlide = currentSlide.value?.name


### PR DESCRIPTION
## Incorrect Thumbnail & Focus After Undo and Redo

- Fixed incorrect behaviour where the thumbnail was updated for an incorrect slide after undo and redo operations and the user was jumped to incorrect index after the operation.
- In cases where the number of slides changes after undoing an added / deleted slide or redoing a previously added / deleted one, the focus and thumbnail is fixed now. Now the focus is always taken to the slide that is restored after the history operation or if the slide is removed after the history operation then to its previous slide.

### Before

https://github.com/user-attachments/assets/b0b78fb2-ccc1-45cc-8776-a2fe9093ae56

<br>

### After
https://github.com/user-attachments/assets/7de4221d-644f-4f38-a1ee-f84d93677e2f


<br>



## Reordering slides and performing undo / redo led to unexpected behaviour.

- Performing history operations after reordering slides led to changes to unrelated slides.
- The slide whose index was affected after undo / redo reordering was not focused correctly before.


### Before

https://github.com/user-attachments/assets/bb22eec5-c7fa-45d4-9c7e-4390c7cd24d9

<br>

### After

https://github.com/user-attachments/assets/d6f5c799-b367-435e-960f-a6c79e0ff503

<br>

Closes #122 

