### PR TITLE
fix: magic move fixes + copy paste improvements

### DIFF
--- a/frontend/src/components/FadeElementTransition.vue
+++ b/frontend/src/components/FadeElementTransition.vue
@@ -33,7 +33,10 @@ const enter = (el, done) => {
 
 	el.offsetWidth
 
-	el.style.transition = `opacity ${props.duration}s ease-in-out`
+	el.style.transitionProperty = 'all'
+	el.style.transitionTimingFunction = 'ease-in-out'
+	el.style.transitionDuration = `${1}s`
+	el.style.transitionDelay = `${props.duration}s`
 	el.style.opacity = 1
 
 	el.addEventListener('transitionend', done, { once: true })

--- a/frontend/src/components/FadeElementTransition.vue
+++ b/frontend/src/components/FadeElementTransition.vue
@@ -4,6 +4,7 @@
 		@before-enter="beforeEnter"
 		@enter="enter"
 		@after-enter="afterEnter"
+		@before-leave="beforeLeave"
 	>
 		<slot></slot>
 	</transition-group>
@@ -46,5 +47,10 @@ const afterEnter = (el) => {
 	if (props.skip) return
 
 	el.style.transition = ''
+}
+
+const beforeLeave = (el) => {
+	el.style.transition = 'none'
+	el.style.opacity = 0
 }
 </script>

--- a/frontend/src/components/LayoutDialog.vue
+++ b/frontend/src/components/LayoutDialog.vue
@@ -4,7 +4,7 @@
 			<div class="font-semibold">Select a Template Layout</div>
 		</template>
 		<template #body-content>
-			<div class="grid max-h-[32rem] grid-cols-3 gap-6 overflow-y-auto p-2">
+			<div class="grid max-h-[32rem] grid-cols-3 gap-6 overflow-y-auto">
 				<div
 					v-for="layout in layouts.slides"
 					:key="layout.idx"

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -82,7 +82,7 @@ import { useResizer } from '@/composables/useResizer'
 import { usePanAndZoom } from '@/composables/usePanAndZoom'
 import { useSnapping } from '@/composables/useSnapping'
 
-import { isCmdOrCtrl } from '@/utils/helpers'
+import { getDocFromHTML, isCmdOrCtrl } from '@/utils/helpers'
 import { handleUploadedMedia } from '../utils/mediaUploads'
 
 const props = defineProps({
@@ -451,20 +451,54 @@ const handleClipboardJSON = (clipboardJSON) => {
 	return handlePastedJSON(clipboardJSON)
 }
 
+const dataURLToFile = (dataURL, filename) => {
+	const [meta, base64] = dataURL.split(',')
+	const mime = meta.match(/:(.*?);/)[1]
+	const binary = atob(base64)
+	const len = binary.length
+	const buffer = new Uint8Array(len)
+
+	for (let i = 0; i < len; i++) {
+		buffer[i] = binary.charCodeAt(i)
+	}
+
+	return new File([buffer], filename, {
+		type: mime,
+		lastModified: Date.now(),
+	})
+}
+
+const getImageSrcFromHTML = (clipboardTextHTML) => {
+	const doc = getDocFromHTML(clipboardTextHTML)
+	const img = doc.querySelector('img')
+
+	if (img) return img.src
+	return null
+}
+
+const handleClipboardTextHTML = (imgSrc) => {
+	const file = dataURLToFile(imgSrc, 'pasted-image.png')
+	handleUploadedMedia([{ kind: 'file', getAsFile: () => file }])
+}
+
 const handlePaste = (e) => {
 	// do not override paste event if current element is input or content editable
 	if (isInputElement()) return
 
 	e.preventDefault()
 
+	const clipboardTextHTML = e.clipboardData.getData('text/html')
+	const imgSrc = getImageSrcFromHTML(clipboardTextHTML)
+	if (clipboardTextHTML && imgSrc) return handleClipboardTextHTML(clipboardTextHTML)
+
 	const clipboardJSON = e.clipboardData.getData('application/json')
 	if (clipboardJSON) return handleClipboardJSON(clipboardJSON)
 
-	const clipboardItems = e.clipboardData.items
-	if (clipboardItems) return handleUploadedMedia(clipboardItems)
-
 	const clipboardText = e.clipboardData.getData('text/plain')
 	if (clipboardText) return handleClipboardText(clipboardText)
+
+	const clipboardItems = e.clipboardData.items
+	if (clipboardItems) return handleUploadedMedia(clipboardItems)
 }
 
 const initSlideAndListeners = () => {

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -61,12 +61,16 @@ import {
 	selectionBounds,
 	updateSelectionBounds,
 	setSlideRef,
+	insertSlide,
+	slideIndex,
 } from '@/stores/slide'
 import {
 	activeElementIds,
 	activeElement,
 	handleCopy,
-	handlePaste,
+	handleSvgText,
+	handlePastedText,
+	handlePastedJSON,
 	focusElementId,
 	pairElementId,
 	addFixedWidthToElement,
@@ -79,6 +83,7 @@ import { usePanAndZoom } from '@/composables/usePanAndZoom'
 import { useSnapping } from '@/composables/useSnapping'
 
 import { isCmdOrCtrl } from '@/utils/helpers'
+import { handleUploadedMedia } from '../utils/mediaUploads'
 
 const props = defineProps({
 	highlight: Boolean,
@@ -88,7 +93,7 @@ const props = defineProps({
 	},
 })
 
-const emit = defineEmits(['update:hasOngoingInteraction'])
+const emit = defineEmits(['update:hasOngoingInteraction', 'changeSlide'])
 
 const slideContainerRef = useTemplateRef('slideContainer')
 const slideRef = useTemplateRef('slideRef')
@@ -412,6 +417,42 @@ watch(
 		handleDimensionChange(delta)
 	},
 )
+
+const handlePastedSlideJSON = async (json) => {
+	const index = slideIndex.value
+
+	insertSlide(JSON.parse(json), index)
+
+	emit('changeSlide', index + 1)
+}
+
+const handlePaste = (e) => {
+	// do not override paste event if current element is input or content editable
+	const activeElement = document.activeElement
+	if (
+		activeElement?.tagName == 'INPUT' ||
+		activeElement?.tagName == 'TEXTAREA' ||
+		activeElement?.isContentEditable
+	) {
+		return
+	}
+
+	e.preventDefault()
+	const clipboardItems = e.clipboardData.items
+	if (clipboardItems) handleUploadedMedia(clipboardItems)
+
+	const clipboardText = e.clipboardData.getData('text/plain')
+	if (clipboardText?.trim().startsWith('<svg') && clipboardText?.trim().endsWith('</svg>')) {
+		handleSvgText(clipboardText)
+	} else if (clipboardText && !focusElementId.value) {
+		handlePastedText(clipboardText)
+	}
+
+	const clipboardJSON = e.clipboardData.getData('application/json')
+	if (!Array.isArray(clipboardJSON) && clipboardJSON.includes('"elements"'))
+		return handlePastedSlideJSON(clipboardJSON)
+	return handlePastedJSON(clipboardJSON)
+}
 
 const initSlideAndListeners = () => {
 	if (!slideRef.value) return

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -448,7 +448,7 @@ const handleClipboardJSON = (clipboardJSON) => {
 	if (isSlideJSON) {
 		return handlePastedSlideJSON(clipboardJSON)
 	}
-	return handlePastedJSON(clipboardJSON)
+	return handlePastedJSON(JSON.parse(clipboardJSON))
 }
 
 const dataURLToFile = (dataURL, filename) => {

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -426,32 +426,45 @@ const handlePastedSlideJSON = async (json) => {
 	emit('changeSlide', index + 1)
 }
 
-const handlePaste = (e) => {
-	// do not override paste event if current element is input or content editable
+const isInputElement = (el) => {
 	const activeElement = document.activeElement
-	if (
+	return (
 		activeElement?.tagName == 'INPUT' ||
 		activeElement?.tagName == 'TEXTAREA' ||
 		activeElement?.isContentEditable
-	) {
-		return
-	}
+	)
+}
 
-	e.preventDefault()
-	const clipboardItems = e.clipboardData.items
-	if (clipboardItems) handleUploadedMedia(clipboardItems)
-
-	const clipboardText = e.clipboardData.getData('text/plain')
+const handleClipboardText = (clipboardText) => {
 	if (clipboardText?.trim().startsWith('<svg') && clipboardText?.trim().endsWith('</svg>')) {
 		handleSvgText(clipboardText)
 	} else if (clipboardText && !focusElementId.value) {
 		handlePastedText(clipboardText)
 	}
+}
+
+const handleClipboardJSON = (clipboardJSON) => {
+	const isSlideJSON = !Array.isArray(clipboardJSON) && clipboardJSON.includes('"elements"')
+	if (isSlideJSON) {
+		return handlePastedSlideJSON(clipboardJSON)
+	}
+	return handlePastedJSON(clipboardJSON)
+}
+
+const handlePaste = (e) => {
+	// do not override paste event if current element is input or content editable
+	if (isInputElement()) return
+
+	e.preventDefault()
 
 	const clipboardJSON = e.clipboardData.getData('application/json')
-	if (!Array.isArray(clipboardJSON) && clipboardJSON.includes('"elements"'))
-		return handlePastedSlideJSON(clipboardJSON)
-	return handlePastedJSON(clipboardJSON)
+	if (clipboardJSON) return handleClipboardJSON(clipboardJSON)
+
+	const clipboardItems = e.clipboardData.items
+	if (clipboardItems) return handleUploadedMedia(clipboardItems)
+
+	const clipboardText = e.clipboardData.getData('text/plain')
+	if (clipboardText) return handleClipboardText(clipboardText)
 }
 
 const initSlideAndListeners = () => {

--- a/frontend/src/components/SlideProperties.vue
+++ b/frontend/src/components/SlideProperties.vue
@@ -96,6 +96,8 @@ const setSlideTransition = (option) => {
 	}
 
 	if (option == 'Magic Move') createConnectionsForMagicMove(slideIndex.value)
+
+	slide.fadeUnmatchedElements = option == 'Magic Move'
 }
 
 const setTransitionAttribute = (property, value) => {

--- a/frontend/src/components/ThemeDialog.vue
+++ b/frontend/src/components/ThemeDialog.vue
@@ -4,14 +4,14 @@
 			<div class="font-semibold">Select a Theme</div>
 		</template>
 		<template #body-content>
-			<div class="grid max-h-[32rem] grid-cols-2 gap-6 overflow-y-auto p-2">
+			<div class="grid max-h-[32rem] grid-cols-2 gap-6 overflow-y-auto">
 				<div
 					v-for="(theme, idx) in themeResource.data"
 					:key="theme.idx"
 					class="flex flex-col gap-3"
 				>
 					<div
-						class="aspect-video cursor-pointer rounded-lg px-2 outline outline-1 outline-offset-2 outline-gray-200 hover:outline-gray-400"
+						class="aspect-video cursor-pointer rounded-lg border border-gray-200 hover:border-gray-300"
 						:style="getThumbnailCardStyles(theme.thumbnail)"
 						@click="$emit('create', theme.name)"
 					></div>

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -12,6 +12,7 @@
 				:readonlyMode="readonlyMode"
 				:highlight="slideHighlight"
 				v-model:hasOngoingInteraction="hasOngoingInteraction"
+				@changeSlide="changeSlide"
 			/>
 
 			<NavigationPanel
@@ -95,6 +96,7 @@ import {
 	updateThumbnail,
 	lastThumbnailTime,
 	focusedSlide,
+	insertSlide,
 } from '@/stores/slide'
 import {
 	resetFocus,
@@ -211,6 +213,9 @@ const handleSlideShortcuts = (e) => {
 			break
 		case 'd':
 			if (isCmdOrCtrl(e)) duplicateSlide(e)
+			break
+		case 'c':
+			if (isCmdOrCtrl(e)) copySlide(e)
 			break
 	}
 }
@@ -441,8 +446,6 @@ const handleThumbnailGeneration = async (index) => {
 const changeSlide = async (index, focus = true) => {
 	index = Math.max(0, Math.min(index, slidesLength.value - 1))
 
-	const oldIndex = slideIndex.value
-
 	if (!readonlyMode.value) {
 		await resetFocus()
 	}
@@ -483,17 +486,12 @@ const getNewSlide = (toDuplicate = false, layoutId) => {
 	return slide
 }
 
-const insertSlide = async (index, layoutId, toDuplicate) => {
+const insertDuplicateSlide = async (index, layoutId, toDuplicate) => {
 	if (toDuplicate || !index) index = slideIndex.value
 
 	const newSlide = getNewSlide(toDuplicate, layoutId)
 
-	slides.value.splice(index + 1, 0, newSlide)
-	slides.value.forEach((slide, index) => {
-		slide.idx = index + 1
-	})
-
-	slidesLength.value = slides.value.length
+	insertSlide(newSlide, index)
 
 	await changeSlide(index + 1)
 
@@ -533,7 +531,7 @@ const deleteSlide = (deleteActive) => {
 const duplicateSlide = (e) => {
 	e.preventDefault()
 
-	insertSlide(slideIndex.value, null, true)
+	insertDuplicateSlide(slideIndex.value, null, true)
 }
 
 const replaceSlide = (layoutId) => {
@@ -544,6 +542,18 @@ const replaceSlide = (layoutId) => {
 	slides.value.forEach((slide, index) => {
 		slide.idx = index + 1
 	})
+}
+
+const getCopiedSlideJSON = () => {
+	const slide = getNewSlide(true)
+	return JSON.stringify(slide)
+}
+
+const copySlide = (e) => {
+	e.preventDefault()
+	const clipboardJSON = getCopiedSlideJSON()
+	e.clipboardData?.setData('application/json', clipboardJSON)
+	toast.success('Slide copied to clipboard')
 }
 
 const resetAndSave = async () => {
@@ -652,7 +662,7 @@ const handleInsertSlide = (layoutId) => {
 	if (layoutAction.value == 'replace') {
 		replaceSlide(layoutId)
 	} else {
-		insertSlide(insertIndex.value, layoutId)
+		insertDuplicateSlide(insertIndex.value, layoutId)
 	}
 	insertIndex.value = null
 }

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -9,6 +9,7 @@ import {
 	currentSlide,
 	slideIndex,
 	updateThumbnail,
+	insertSlide,
 } from './slide'
 import { useTextEditor } from '@/composables/useTextEditor'
 
@@ -449,32 +450,6 @@ const handleSvgText = (svgText) => {
 	handleUploadedMedia([{ kind: 'file', getAsFile: () => svgFile }])
 }
 
-const handlePaste = (e) => {
-	// do not override paste event if current element is input or content editable
-	const activeElement = document.activeElement
-	if (
-		activeElement?.tagName == 'INPUT' ||
-		activeElement?.tagName == 'TEXTAREA' ||
-		activeElement?.isContentEditable
-	) {
-		return
-	}
-
-	e.preventDefault()
-	const clipboardItems = e.clipboardData.items
-	if (clipboardItems) handleUploadedMedia(clipboardItems)
-
-	const clipboardText = e.clipboardData.getData('text/plain')
-	if (clipboardText?.trim().startsWith('<svg') && clipboardText?.trim().endsWith('</svg>')) {
-		handleSvgText(clipboardText)
-	} else if (clipboardText && !focusElementId.value) {
-		handlePastedText(clipboardText)
-	}
-
-	const clipboardJSON = e.clipboardData.getData('application/json')
-	if (clipboardJSON) handlePastedJSON(JSON.parse(clipboardJSON))
-}
-
 const addFixedWidthToElement = (deltaWidth) => {
 	const elementDiv = document.querySelector(`[data-index="${activeElement.value.id}"]`)
 	if (elementDiv) {
@@ -593,7 +568,9 @@ export {
 	selectAllElements,
 	getElementPosition,
 	handleCopy,
-	handlePaste,
+	handleSvgText,
+	handlePastedText,
+	handlePastedJSON,
 	addFixedWidthToElement,
 	deleteAttachments,
 	setEditableState,

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -139,6 +139,8 @@ const addTextElement = async (text) => {
 
 	currentSlide.value.elements.push(element)
 
+	element.id = getUpdatedIdAfterConnections(element)
+
 	selectAndCenterElement(element.id)
 }
 
@@ -251,6 +253,9 @@ const addMediaElement = async (file, type) => {
 		element.invertY = 1
 	}
 	currentSlide.value.elements.push(element)
+
+	element.id = getUpdatedIdAfterConnections(element)
+
 	selectAndCenterElement(element.id)
 }
 

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -17,7 +17,7 @@ import { generateUniqueId, cloneObj } from '../utils/helpers'
 import { guessTextColorFromBackground } from '../utils/color'
 import { handleUploadedMedia } from '../utils/mediaUploads'
 import { presentationId } from './presentation'
-import { getUpdatedIdAfterConnections } from './transition'
+import { updateElementId } from './transition'
 
 import { generateHTML } from '@tiptap/core'
 import { extensions, patchEmptyParagraphs } from '@/stores/tiptapSetup'
@@ -140,7 +140,7 @@ const addTextElement = async (text) => {
 
 	currentSlide.value.elements.push(element)
 
-	element.id = getUpdatedIdAfterConnections(element)
+	updateElementId(element)
 
 	selectAndCenterElement(element.id)
 }
@@ -268,7 +268,7 @@ const addMediaElement = async (file, type) => {
 	}
 	currentSlide.value.elements.push(element)
 
-	element.id = getUpdatedIdAfterConnections(element)
+	updateElementId(element)
 
 	selectAndCenterElement(element.id)
 }
@@ -279,7 +279,7 @@ const replaceMediaElement = async (element, fileDoc) => {
 	if (element.type == 'video') {
 		element.poster = await getVideoPoster(fileDoc.file_url)
 	}
-	element.id = getUpdatedIdAfterConnections(element)
+	updateElementId(element)
 }
 
 const isElementInSlide = (slideIndex, elementId) => {
@@ -485,7 +485,8 @@ const updateElementContent = (element) => {
 
 	if (editorOldText == currentText && !wasUpdated) return
 
-	element.id = getUpdatedIdAfterConnections(element)
+	updateElementId(element)
+
 	element.content = updatedHTML
 	editorOldText = currentText
 }

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -264,8 +264,6 @@ const replaceMediaElement = async (element, fileDoc) => {
 }
 
 const getDuplicateElementId = (element, srcSlide) => {
-	let refId = null
-
 	if (srcSlide == slideIndex.value - 1) {
 		const prevSlide = slides.value[slideIndex.value - 1]
 		if (prevSlide?.transition == 'Magic Move') return element.id
@@ -279,7 +277,7 @@ const getDuplicateElementId = (element, srcSlide) => {
 const duplicateElements = async (e, elements, srcSlide) => {
 	e?.preventDefault()
 
-	if (!srcSlide) srcSlide = slideIndex.value
+	if (srcSlide == null) srcSlide = slideIndex.value
 
 	const displaceByPx = srcSlide == slideIndex.value ? 40 : 0
 

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -263,12 +263,25 @@ const replaceMediaElement = async (element, fileDoc) => {
 	element.id = getUpdatedIdAfterConnections(element)
 }
 
+const isElementInSlide = (slideIndex, elementId) => {
+	const slide = slides.value[slideIndex]
+	return slide.elements?.some((element) => element.id == elementId)
+}
+
 const getDuplicateElementId = (element, srcSlide) => {
 	if (srcSlide == slideIndex.value - 1) {
 		const prevSlide = slides.value[slideIndex.value - 1]
-		if (prevSlide?.transition == 'Magic Move') return element.id
+		if (
+			prevSlide?.transition == 'Magic Move' &&
+			!isElementInSlide(slideIndex.value, element.id)
+		)
+			return element.id
 	} else if (srcSlide == slideIndex.value + 1) {
-		if (currentSlide.value?.transition == 'Magic Move') return element.id
+		if (
+			currentSlide.value?.transition == 'Magic Move' &&
+			!isElementInSlide(slideIndex.value, element.id)
+		)
+			return element.id
 	}
 
 	return generateUniqueId()
@@ -583,4 +596,5 @@ export {
 	normalizeZIndices,
 	isWithinOverlappingBounds,
 	updatePosition,
+	isElementInSlide,
 }

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -222,12 +222,25 @@ const getVideoPoster = async (videoUrl) => {
 	})
 }
 
+const getNaturalSize = async (dataURL) => {
+	return new Promise((resolve, reject) => {
+		const img = new Image()
+		img.onload = () =>
+			resolve({
+				width: (img.naturalWidth / 2) * slideBounds.scale,
+			})
+		img.onerror = reject
+		img.src = dataURL
+	})
+}
+
 const addMediaElement = async (file, type) => {
 	const src = file.file_url
+	const { width } = await getNaturalSize(src)
 	let element = {
 		id: generateUniqueId(),
 		zIndex: currentSlide.value.elements.length + 1,
-		width: 300,
+		width: Math.max(Math.min(width, 800), 30),
 		left: 0,
 		top: 0,
 		opacity: 100,

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -1,4 +1,4 @@
-import { ignoreUpdates, isPublicPresentation } from '@/stores/presentation'
+import { ignoreUpdates, isPublicPresentation, slidesLength } from '@/stores/presentation'
 import { ref, computed, reactive } from 'vue'
 
 import html2canvas from 'html2canvas'
@@ -169,6 +169,15 @@ const guideVisibilityMap = reactive({
 	bottomEdge: false,
 })
 
+const insertSlide = async (newSlide, index) => {
+	slides.value.splice(index + 1, 0, newSlide)
+	slides.value.forEach((slide, index) => {
+		slide.idx = index + 1
+	})
+
+	slidesLength.value = slides.value.length
+}
+
 export {
 	slideIndex,
 	slides,
@@ -181,4 +190,5 @@ export {
 	updateThumbnail,
 	focusedSlide,
 	lastThumbnailTime,
+	insertSlide,
 }

--- a/frontend/src/stores/transition.js
+++ b/frontend/src/stores/transition.js
@@ -97,7 +97,17 @@ const updateIdsForNextSlides = (fromSlideIndex, element, newId) => {
 	}
 }
 
+const isAffectedByMagicMove = (slideIndex) => {
+	const prevSlide = slides.value[slideIndex - 1]
+	const currentSlide = slides.value[slideIndex]
+
+	return prevSlide?.transition === 'Magic Move' || currentSlide?.transition === 'Magic Move'
+}
+
 const updateElementId = (element) => {
+	const needsUpdate = isAffectedByMagicMove(slideIndex.value)
+	if (!needsUpdate) return
+
 	const id = getUpdatedIdAfterConnections(element)
 	element.id = id
 	updateIdsForNextSlides(slideIndex.value, element, id)

--- a/frontend/src/stores/transition.js
+++ b/frontend/src/stores/transition.js
@@ -65,11 +65,7 @@ const getUpdatedIdAfterConnections = (element) => {
 		id = getElementId(nextSlide, element)
 	}
 
-	if (!id) {
-		id = generateUniqueId()
-	}
-
-	return id
+	return id || element.id || generateUniqueId()
 }
 
 const createConnectionsForMagicMove = (index) => {

--- a/frontend/src/stores/transition.js
+++ b/frontend/src/stores/transition.js
@@ -78,13 +78,9 @@ const createConnectionsForMagicMove = (index) => {
 	const current = slides.value[index]
 	const next = slides.value[index + 1]
 
-	next.elements.forEach((nextElement) => {
-		const refElement = getReferenceElement(nextElement, current)
-
-		if (refElement) {
-			// update current element id to match reference from previous slide
-			nextElement.id = refElement.id
-		}
+	current.elements.forEach((currElement) => {
+		const refElement = getReferenceElement(currElement, next)
+		if (refElement) currElement.id = refElement.id
 	})
 }
 

--- a/frontend/src/stores/transition.js
+++ b/frontend/src/stores/transition.js
@@ -80,32 +80,27 @@ const createConnectionsForMagicMove = (index) => {
 		if (refElement) {
 			const id = refElement.id
 			currElement.id = id
-			updateIdsForPrevSlides(slideIndex.value, currElement, id)
+			updateIdsAcrossSlides(slideIndex.value, currElement, id, false)
 		}
 	})
 }
 
-const updateIdsForPrevSlides = (fromSlideIndex, element, newId) => {
-	while (slides.value[fromSlideIndex - 1]?.transition === 'Magic Move') {
-		const prevSlide = slides.value[fromSlideIndex - 1]
-		if (!prevSlide) break
+const updateIdsAcrossSlides = (fromSlideIndex, element, newId, isForward) => {
+	let i = isForward ? fromSlideIndex + 1 : fromSlideIndex - 1
 
-		const refElement = getReferenceElement(element, prevSlide)
-		if (refElement) refElement.id = newId
+	while (i >= 0 && i < slides.value.length) {
+		const slide = slides.value[i]
+		const transition = isForward ? slides.value[i - 1]?.transition : slide.transition
+		const hasTransition = transition === 'Magic Move'
 
-		fromSlideIndex--
-	}
-}
+		if (!hasTransition) break
 
-const updateIdsForNextSlides = (fromSlideIndex, element, newId) => {
-	while (slides.value[fromSlideIndex]?.transition === 'Magic Move') {
-		const nextSlide = slides.value[fromSlideIndex + 1]
-		if (!nextSlide) break
+		const refElement = getReferenceElement(element, slide)
+		if (refElement) {
+			refElement.id = newId
+		}
 
-		const refElement = getReferenceElement(element, nextSlide)
-		if (refElement) refElement.id = newId
-
-		fromSlideIndex++
+		i += isForward ? 1 : -1
 	}
 }
 
@@ -122,7 +117,7 @@ const updateElementId = (element) => {
 
 	const id = getUpdatedIdAfterConnections(element)
 	element.id = id
-	updateIdsForNextSlides(slideIndex.value, element, id)
+	updateIdsAcrossSlides(slideIndex.value, element, id, true)
 }
 
 export { createConnectionsForMagicMove, updateElementId }

--- a/frontend/src/stores/transition.js
+++ b/frontend/src/stores/transition.js
@@ -72,13 +72,29 @@ const createConnectionsForMagicMove = (index) => {
 	// adding magic move to last slide changes nothing
 	if (index == slides.value.length - 1) return
 
-	const current = slides.value[index]
-	const next = slides.value[index + 1]
+	const currentSlide = slides.value[index]
+	const nextSlide = slides.value[index + 1]
 
-	current.elements.forEach((currElement) => {
-		const refElement = getReferenceElement(currElement, next)
-		if (refElement) currElement.id = refElement.id
+	currentSlide.elements.forEach((currElement) => {
+		const refElement = getReferenceElement(currElement, nextSlide)
+		if (refElement) {
+			const id = refElement.id
+			currElement.id = id
+			updateIdsForPrevSlides(slideIndex.value, currElement, id)
+		}
 	})
+}
+
+const updateIdsForPrevSlides = (fromSlideIndex, element, newId) => {
+	while (slides.value[fromSlideIndex - 1]?.transition === 'Magic Move') {
+		const prevSlide = slides.value[fromSlideIndex - 1]
+		if (!prevSlide) break
+
+		const refElement = getReferenceElement(element, prevSlide)
+		if (refElement) refElement.id = newId
+
+		fromSlideIndex--
+	}
 }
 
 const updateIdsForNextSlides = (fromSlideIndex, element, newId) => {

--- a/frontend/src/stores/transition.js
+++ b/frontend/src/stores/transition.js
@@ -46,29 +46,30 @@ const getReferenceElement = (currElement, slide) => {
 	}
 }
 
+const getElementId = (candidateSlide, element) => {
+	if (!candidateSlide) return null
+
+	// find reference element in candidate slide
+	const refElement = getReferenceElement(element, candidateSlide)
+	// if found copy its id so that it does not re-render during transition
+	return refElement?.id
+}
+
 const getUpdatedIdAfterConnections = (element) => {
 	const prevSlide = slides.value[slideIndex.value - 1]
 	const nextSlide = slides.value[slideIndex.value + 1]
 
-	let candidateSlide = null
-	if (prevSlide?.transition === 'Magic Move') {
-		// if transition begins on previous slide -
-		// check if any element in current slide refers to element from previous slide
-		candidateSlide = prevSlide
-	} else if (currentSlide.value?.transition === 'Magic Move' && nextSlide) {
-		// if transition begins on current slide -
-		// check if any element in next slide refers to this element
-		candidateSlide = nextSlide
+	let id = getElementId(prevSlide, element)
+
+	if (!id && currentSlide.value?.transition === 'Magic Move') {
+		id = getElementId(nextSlide, element)
 	}
 
-	if (candidateSlide) {
-		// find reference element in candidate slide
-		const refElement = getReferenceElement(element, candidateSlide)
-		// if found copy its id so that it does not re-render during transition
-		if (refElement) return refElement.id
+	if (!id) {
+		id = generateUniqueId()
 	}
 
-	return generateUniqueId()
+	return id
 }
 
 const createConnectionsForMagicMove = (index) => {
@@ -84,4 +85,22 @@ const createConnectionsForMagicMove = (index) => {
 	})
 }
 
-export { createConnectionsForMagicMove, getUpdatedIdAfterConnections }
+const updateIdsForNextSlides = (fromSlideIndex, element, newId) => {
+	while (slides.value[fromSlideIndex]?.transition === 'Magic Move') {
+		const nextSlide = slides.value[fromSlideIndex + 1]
+		if (!nextSlide) break
+
+		const refElement = getReferenceElement(element, nextSlide)
+		if (refElement) refElement.id = newId
+
+		fromSlideIndex++
+	}
+}
+
+const updateElementId = (element) => {
+	const id = getUpdatedIdAfterConnections(element)
+	element.id = id
+	updateIdsForNextSlides(slideIndex.value, element, id)
+}
+
+export { createConnectionsForMagicMove, updateElementId }

--- a/frontend/src/stores/transition.js
+++ b/frontend/src/stores/transition.js
@@ -46,7 +46,7 @@ const getReferenceElement = (currElement, slide) => {
 	}
 }
 
-const getElementId = (candidateSlide, element) => {
+const getReferenceIdFromSlide = (candidateSlide, element) => {
 	if (!candidateSlide) return null
 
 	// find reference element in candidate slide
@@ -59,10 +59,10 @@ const getUpdatedIdAfterConnections = (element) => {
 	const prevSlide = slides.value[slideIndex.value - 1]
 	const nextSlide = slides.value[slideIndex.value + 1]
 
-	let id = getElementId(prevSlide, element)
+	let id = getReferenceIdFromSlide(prevSlide, element)
 
 	if (!id && currentSlide.value?.transition === 'Magic Move') {
-		id = getElementId(nextSlide, element)
+		id = getReferenceIdFromSlide(nextSlide, element)
 	}
 
 	return id || element.id || generateUniqueId()

--- a/frontend/src/stores/transition.js
+++ b/frontend/src/stores/transition.js
@@ -1,4 +1,5 @@
 import { slides, slideIndex, currentSlide } from '@/stores/slide'
+import { isElementInSlide } from '@/stores/element'
 import { generateUniqueId } from '@/utils/helpers'
 
 const canCreateTextConnection = (currentContent, nextContent) => {
@@ -26,24 +27,26 @@ const canCreateMediaConnection = (currentSrc, nextSrc) => {
 	return currentSrc == nextSrc
 }
 
-const canCreateConnection = (element, nextElement) => {
-	if (element.type == 'text') {
-		return canCreateTextConnection(element.content, nextElement.content)
+const canCreateConnection = (currElement, potentialConnectionElement) => {
+	if (currElement.type == 'text') {
+		return canCreateTextConnection(currElement.content, potentialConnectionElement.content)
 	}
-	return canCreateMediaConnection(element.src, nextElement.src)
+	return canCreateMediaConnection(currElement.src, potentialConnectionElement.src)
 }
 
-const getReferenceElement = (nextElement, slide) => {
+const getReferenceElement = (currElement, slide) => {
 	for (const element of slide.elements) {
-		if (element.type != nextElement.type) continue
+		if (element.type != currElement.type) continue
 
-		if (canCreateConnection(element, nextElement)) {
+		if (isElementInSlide(slideIndex.value, element.id)) continue
+
+		if (canCreateConnection(currElement, element)) {
 			return element
 		}
 	}
 }
 
-const getUpdatedIdAfterConnections = (element, currentText) => {
+const getUpdatedIdAfterConnections = (element) => {
 	const prevSlide = slides.value[slideIndex.value - 1]
 	const nextSlide = slides.value[slideIndex.value + 1]
 


### PR DESCRIPTION
### Fixes
- When applying magic move don't allow multiple elements on same slide to be connected. Only one connection should be made and the other should have a unique id.
- When an element is connected to previous element, check for all following slide elements for continued connections.
- Fade in non-connected elements after the magic move transition is complete.
- Avoid unnecessarily updating ids for slides not affected by magic move and elements not affected by it even if the slide has magic move.

### Misc
- Ctrl C + Ctrl V for copying and pasting slides in the same or a different presentation.
- Pasting images from google slides was not possible earlier because it used google clipboard formats, now the image is extracted and uploaded correctly.


Closes #118 