### PR TITLE
fix: separate ref id and id for magic move elements

### DIFF
--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -112,7 +112,7 @@ import {
 
 import { useTextEditor } from '@/composables/useTextEditor'
 
-import { isCmdOrCtrl } from '@/utils/helpers'
+import { generateUniqueId, isCmdOrCtrl } from '@/utils/helpers'
 
 const { activeEditor, toggleMark } = useTextEditor()
 
@@ -466,6 +466,10 @@ const getNewSlide = (toDuplicate = false, layoutId) => {
 
 	if (toDuplicate) {
 		layout = currentSlide.value
+		layout.elements = layout.elements.map((e) => ({
+			...e,
+			refId: e.refId || generateUniqueId(),
+		}))
 	} else {
 		layout = layoutResource.data?.slides?.find((l) => l.name == layoutId)
 	}

--- a/frontend/src/pages/Slideshow.vue
+++ b/frontend/src/pages/Slideshow.vue
@@ -26,7 +26,7 @@
 				>
 					<SlideElement
 						v-for="element in currentSlide?.elements"
-						:key="`slideshow-${element.id}`"
+						:key="`slideshow-${getElementKey(element)}`"
 						mode="slideshow"
 						:element="element"
 						:data-index="element.id"
@@ -52,7 +52,7 @@
 					>
 						<SlideElement
 							v-for="element in currentSlide?.elements"
-							:key="`slideshow-${element.id}`"
+							:key="`slideshow-${getElementKey(element)}`"
 							mode="slideshow"
 							:element="element"
 							:data-index="element.id"
@@ -100,6 +100,10 @@ const transition = ref('none')
 const transform = ref('')
 const opacity = ref(1)
 const clipPath = ref('')
+
+const getElementKey = (element) => {
+	return element.refId || element.id
+}
 
 const slideCursor = ref('none')
 

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -17,7 +17,7 @@ import { generateUniqueId, cloneObj } from '../utils/helpers'
 import { guessTextColorFromBackground } from '../utils/color'
 import { handleUploadedMedia } from '../utils/mediaUploads'
 import { presentationId } from './presentation'
-import { updateElementId, updateRefId } from './transition'
+import { initRefId, updateElementRefId } from './transition'
 
 import { generateHTML } from '@tiptap/core'
 import { extensions, patchEmptyParagraphs } from '@/stores/tiptapSetup'
@@ -140,7 +140,7 @@ const addTextElement = async (text) => {
 
 	currentSlide.value.elements.push(element)
 
-	updateElementId(element)
+	updateElementRefId(element)
 
 	selectAndCenterElement(element.id)
 }
@@ -268,7 +268,7 @@ const addMediaElement = async (file, type) => {
 	}
 	currentSlide.value.elements.push(element)
 
-	updateElementId(element)
+	updateElementRefId(element)
 
 	selectAndCenterElement(element.id)
 }
@@ -279,7 +279,7 @@ const replaceMediaElement = async (element, fileDoc) => {
 	if (element.type == 'video') {
 		element.poster = await getVideoPoster(fileDoc.file_url)
 	}
-	updateElementId(element)
+	updateElementRefId(element)
 }
 
 const isElementInSlide = (slideIndex, elementId) => {
@@ -299,7 +299,7 @@ const duplicateElements = async (e, elements, srcSlide) => {
 	elements.forEach((element) => {
 		let newElement = JSON.parse(JSON.stringify(element))
 		newElement.id = generateUniqueId()
-		updateRefId(newElement, element, srcSlide)
+		initRefId(newElement, element, srcSlide)
 		newElement.zIndex = currentSlide.value.elements.length + 1
 		newElement.top += displaceByPx
 		newElement.left += displaceByPx
@@ -467,7 +467,7 @@ const updateElementContent = (element) => {
 
 	if (editorOldText == currentText && !wasUpdated) return
 
-	updateElementId(element)
+	updateElementRefId(element)
 
 	element.content = updatedHTML
 	editorOldText = currentText

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -282,11 +282,6 @@ const replaceMediaElement = async (element, fileDoc) => {
 	updateElementRefId(element)
 }
 
-const isElementInSlide = (slideIndex, elementId) => {
-	const slide = slides.value[slideIndex]
-	return slide.elements?.some((element) => element.id == elementId)
-}
-
 const duplicateElements = async (e, elements, srcSlide) => {
 	e?.preventDefault()
 
@@ -574,5 +569,4 @@ export {
 	normalizeZIndices,
 	isWithinOverlappingBounds,
 	updatePosition,
-	isElementInSlide,
 }

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -17,7 +17,7 @@ import { generateUniqueId, cloneObj } from '../utils/helpers'
 import { guessTextColorFromBackground } from '../utils/color'
 import { handleUploadedMedia } from '../utils/mediaUploads'
 import { presentationId } from './presentation'
-import { updateElementId } from './transition'
+import { updateElementId, updateRefId } from './transition'
 
 import { generateHTML } from '@tiptap/core'
 import { extensions, patchEmptyParagraphs } from '@/stores/tiptapSetup'
@@ -287,25 +287,6 @@ const isElementInSlide = (slideIndex, elementId) => {
 	return slide.elements?.some((element) => element.id == elementId)
 }
 
-const getDuplicateElementId = (element, srcSlide) => {
-	if (srcSlide == slideIndex.value - 1) {
-		const prevSlide = slides.value[slideIndex.value - 1]
-		if (
-			prevSlide?.transition == 'Magic Move' &&
-			!isElementInSlide(slideIndex.value, element.id)
-		)
-			return element.id
-	} else if (srcSlide == slideIndex.value + 1) {
-		if (
-			currentSlide.value?.transition == 'Magic Move' &&
-			!isElementInSlide(slideIndex.value, element.id)
-		)
-			return element.id
-	}
-
-	return generateUniqueId()
-}
-
 const duplicateElements = async (e, elements, srcSlide) => {
 	e?.preventDefault()
 
@@ -317,7 +298,8 @@ const duplicateElements = async (e, elements, srcSlide) => {
 
 	elements.forEach((element) => {
 		let newElement = JSON.parse(JSON.stringify(element))
-		newElement.id = getDuplicateElementId(element, srcSlide)
+		newElement.id = generateUniqueId()
+		updateRefId(newElement, element, srcSlide)
 		newElement.zIndex = currentSlide.value.elements.length + 1
 		newElement.top += displaceByPx
 		newElement.left += displaceByPx

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -17,7 +17,7 @@ import { generateUniqueId, cloneObj } from '../utils/helpers'
 import { guessTextColorFromBackground } from '../utils/color'
 import { handleUploadedMedia } from '../utils/mediaUploads'
 import { presentationId } from './presentation'
-import { initRefId, updateElementRefId } from './transition'
+import { initElementRefId, updateElementRefId } from './transition'
 
 import { generateHTML } from '@tiptap/core'
 import { extensions, patchEmptyParagraphs } from '@/stores/tiptapSetup'
@@ -299,7 +299,7 @@ const duplicateElements = async (e, elements, srcSlide) => {
 	elements.forEach((element) => {
 		let newElement = JSON.parse(JSON.stringify(element))
 		newElement.id = generateUniqueId()
-		initRefId(newElement, element, srcSlide)
+		initElementRefId(newElement, element, srcSlide)
 		newElement.zIndex = currentSlide.value.elements.length + 1
 		newElement.top += displaceByPx
 		newElement.left += displaceByPx

--- a/frontend/src/stores/transition.js
+++ b/frontend/src/stores/transition.js
@@ -1,5 +1,4 @@
 import { slides, slideIndex, currentSlide } from '@/stores/slide'
-import { isElementInSlide } from '@/stores/element'
 import { generateUniqueId } from '@/utils/helpers'
 
 const canCreateTextConnection = (currentContent, nextContent) => {
@@ -40,8 +39,6 @@ const getReferenceElementOnSlide = (slide, currElement) => {
 	for (const element of slide.elements) {
 		if (element.type != currElement.type) continue
 
-		if (isElementInSlide(slideIndex.value, element.id)) continue
-
 		if (canCreateConnection(currElement, element)) {
 			return element
 		}
@@ -76,8 +73,9 @@ const createConnectionsForMagicMove = (index) => {
 			const refId = generateUniqueId()
 			currElement.refId = refId
 			refElement.refId = refId
-			updateRefIdsAcrossSlides(slideIndex.value, currElement, refId, false)
-			updateRefIdsAcrossSlides(slideIndex.value, currElement, refId, true)
+			// update refs till magic move series ends on both sides
+			updateRefIdsAcrossSlides(index, currElement, refId, false)
+			updateRefIdsAcrossSlides(index, currElement, refId, true)
 		}
 	})
 }
@@ -97,6 +95,8 @@ const updateElementRefId = (element) => {
 	if (el) {
 		const refId = generateUniqueId()
 		element.refId = refId
+		el.refId = refId
+		// update refs till magic move series ends on both sides
 		updateRefIdsAcrossSlides(slideIndex.value, element, refId, onPrev)
 		updateRefIdsAcrossSlides(slideIndex.value, element, refId, !onPrev)
 	} else {
@@ -111,6 +111,14 @@ const isSrcElementConnected = (srcElement) => {
 	return currentSlide.value.elements.some((el) => el.refId == refIdToCheck)
 }
 
+const isSrcSlideInMagicMove = (srcSlide) => {
+	const prevSlideIndex = slideIndex.value - 1
+
+	return srcSlide === prevSlideIndex
+		? slides.value[prevSlideIndex]?.transition === 'Magic Move'
+		: currentSlide.value?.transition === 'Magic Move'
+}
+
 const initElementRefId = (newElement, src, srcSlide) => {
 	newElement.refId = null
 
@@ -118,14 +126,7 @@ const initElementRefId = (newElement, src, srcSlide) => {
 
 	const srcElement = slides.value[srcSlide].elements.find((el) => el.id == src.id)
 
-	if (isSrcElementConnected(srcElement)) return
-
-	if (srcSlide == slideIndex.value - 1) {
-		const prevSlide = slides.value[slideIndex.value - 1]
-		if (prevSlide?.transition != 'Magic Move') return
-	} else if (srcSlide == slideIndex.value + 1) {
-		if (currentSlide.value?.transition != 'Magic Move') return
-	}
+	if (isSrcElementConnected(srcElement) || !isSrcSlideInMagicMove(srcSlide)) return
 
 	const refId = generateUniqueId()
 	newElement.refId = refId

--- a/frontend/src/stores/transition.js
+++ b/frontend/src/stores/transition.js
@@ -76,6 +76,7 @@ const createConnectionsForMagicMove = (index) => {
 			const refId = generateUniqueId()
 			currElement.refId = refId
 			refElement.refId = refId
+			updateRefIdsAcrossSlides(slideIndex.value, currElement, refId, false)
 			updateRefIdsAcrossSlides(slideIndex.value, currElement, refId, true)
 		}
 	})
@@ -96,8 +97,8 @@ const updateElementRefId = (element) => {
 	if (el) {
 		const refId = generateUniqueId()
 		element.refId = refId
-		el.refId = refId
 		updateRefIdsAcrossSlides(slideIndex.value, element, refId, onPrev)
+		updateRefIdsAcrossSlides(slideIndex.value, element, refId, !onPrev)
 	} else {
 		element.refId = null
 	}
@@ -110,7 +111,7 @@ const isSrcElementConnected = (srcElement) => {
 	return currentSlide.value.elements.some((el) => el.refId == refIdToCheck)
 }
 
-const initRefId = (newElement, src, srcSlide) => {
+const initElementRefId = (newElement, src, srcSlide) => {
 	newElement.refId = null
 
 	if (srcSlide !== slideIndex.value - 1 && srcSlide !== slideIndex.value + 1) return
@@ -153,4 +154,4 @@ const updateRefIdsAcrossSlides = (fromSlideIndex, element, refId, isForward) => 
 	}
 }
 
-export { createConnectionsForMagicMove, initRefId, updateElementRefId }
+export { createConnectionsForMagicMove, initElementRefId, updateElementRefId }

--- a/frontend/src/stores/transition.js
+++ b/frontend/src/stores/transition.js
@@ -71,32 +71,14 @@ const createConnectionsForMagicMove = (index) => {
 	const nextSlide = slides.value[index + 1]
 
 	currentSlide.elements.forEach((currElement) => {
-		const refElement = getReferenceElement(currElement, nextSlide)
+		const refElement = getReferenceElementOnSlide(nextSlide, currElement)
 		if (refElement) {
-			const id = refElement.id
-			currElement.id = id
-			updateIdsAcrossSlides(slideIndex.value, currElement, id, false)
+			const refId = generateUniqueId()
+			currElement.refId = refId
+			refElement.refId = refId
+			updateRefIdsAcrossSlides(slideIndex.value, currElement, refId, true)
 		}
 	})
-}
-
-const updateIdsAcrossSlides = (fromSlideIndex, element, newId, isForward) => {
-	let i = isForward ? fromSlideIndex + 1 : fromSlideIndex - 1
-
-	while (i >= 0 && i < slides.value.length) {
-		const slide = slides.value[i]
-		const transition = isForward ? slides.value[i - 1]?.transition : slide.transition
-		const hasTransition = transition === 'Magic Move'
-
-		if (!hasTransition) break
-
-		const refElement = getReferenceElement(element, slide)
-		if (refElement) {
-			refElement.id = newId
-		}
-
-		i += isForward ? 1 : -1
-	}
 }
 
 const isAffectedByMagicMove = (slideIndex) => {

--- a/frontend/src/stores/transition.js
+++ b/frontend/src/stores/transition.js
@@ -34,7 +34,9 @@ const canCreateConnection = (currElement, potentialConnectionElement) => {
 	return canCreateMediaConnection(currElement.src, potentialConnectionElement.src)
 }
 
-const getReferenceElement = (currElement, slide) => {
+const getReferenceElementOnSlide = (slide, currElement) => {
+	if (!slide) return null
+
 	for (const element of slide.elements) {
 		if (element.type != currElement.type) continue
 
@@ -46,26 +48,19 @@ const getReferenceElement = (currElement, slide) => {
 	}
 }
 
-const getReferenceIdFromSlide = (candidateSlide, element) => {
-	if (!candidateSlide) return null
-
-	// find reference element in candidate slide
-	const refElement = getReferenceElement(element, candidateSlide)
-	// if found copy its id so that it does not re-render during transition
-	return refElement?.id
-}
-
-const getUpdatedIdAfterConnections = (element) => {
+const getReferenceElement = (element) => {
 	const prevSlide = slides.value[slideIndex.value - 1]
 	const nextSlide = slides.value[slideIndex.value + 1]
 
-	let id = getReferenceIdFromSlide(prevSlide, element)
+	let el = getReferenceElementOnSlide(prevSlide, element)
+	let onPrev = true
 
-	if (!id && currentSlide.value?.transition === 'Magic Move') {
-		id = getReferenceIdFromSlide(nextSlide, element)
+	if (!el && currentSlide.value?.transition === 'Magic Move') {
+		el = getReferenceElementOnSlide(nextSlide, element)
+		onPrev = false
 	}
 
-	return id || element.id || generateUniqueId()
+	return { el, onPrev }
 }
 
 const createConnectionsForMagicMove = (index) => {
@@ -111,13 +106,19 @@ const isAffectedByMagicMove = (slideIndex) => {
 	return prevSlide?.transition === 'Magic Move' || currentSlide?.transition === 'Magic Move'
 }
 
-const updateElementId = (element) => {
+const updateElementRefId = (element) => {
 	const needsUpdate = isAffectedByMagicMove(slideIndex.value)
 	if (!needsUpdate) return
 
-	const id = getUpdatedIdAfterConnections(element)
-	element.id = id
-	updateIdsAcrossSlides(slideIndex.value, element, id, true)
+	const { el, onPrev } = getReferenceElement(element)
+	if (el) {
+		const refId = generateUniqueId()
+		element.refId = refId
+		el.refId = refId
+		updateRefIdsAcrossSlides(slideIndex.value, element, refId, onPrev)
+	} else {
+		element.refId = null
+	}
 }
 
 const isSrcElementConnected = (srcElement) => {
@@ -127,7 +128,7 @@ const isSrcElementConnected = (srcElement) => {
 	return currentSlide.value.elements.some((el) => el.refId == refIdToCheck)
 }
 
-const updateRefId = (newElement, src, srcSlide) => {
+const initRefId = (newElement, src, srcSlide) => {
 	newElement.refId = null
 
 	if (srcSlide !== slideIndex.value - 1 && srcSlide !== slideIndex.value + 1) return
@@ -161,7 +162,7 @@ const updateRefIdsAcrossSlides = (fromSlideIndex, element, refId, isForward) => 
 
 		if (!hasTransition) break
 
-		const refElement = getReferenceElement(element, slide)
+		const refElement = getReferenceElementOnSlide(slide, element)
 		if (refElement) {
 			refElement.refId = refId
 		}
@@ -170,4 +171,4 @@ const updateRefIdsAcrossSlides = (fromSlideIndex, element, refId, isForward) => 
 	}
 }
 
-export { createConnectionsForMagicMove, updateElementId, updateRefId }
+export { createConnectionsForMagicMove, initRefId, updateElementRefId }

--- a/frontend/src/stores/transition.js
+++ b/frontend/src/stores/transition.js
@@ -120,4 +120,54 @@ const updateElementId = (element) => {
 	updateIdsAcrossSlides(slideIndex.value, element, id, true)
 }
 
-export { createConnectionsForMagicMove, updateElementId }
+const isSrcElementConnected = (srcElement) => {
+	const refIdToCheck = srcElement?.refId
+	if (!refIdToCheck) return false
+
+	return currentSlide.value.elements.some((el) => el.refId == refIdToCheck)
+}
+
+const updateRefId = (newElement, src, srcSlide) => {
+	newElement.refId = null
+
+	if (srcSlide !== slideIndex.value - 1 && srcSlide !== slideIndex.value + 1) return
+
+	const srcElement = slides.value[srcSlide].elements.find((el) => el.id == src.id)
+
+	if (isSrcElementConnected(srcElement)) return
+
+	if (srcSlide == slideIndex.value - 1) {
+		const prevSlide = slides.value[slideIndex.value - 1]
+		if (prevSlide?.transition != 'Magic Move') return
+	} else if (srcSlide == slideIndex.value + 1) {
+		if (currentSlide.value?.transition != 'Magic Move') return
+	}
+
+	const refId = generateUniqueId()
+	newElement.refId = refId
+	srcElement.refId = refId
+
+	const isForward = srcSlide < slideIndex.value
+	updateRefIdsAcrossSlides(slideIndex.value, newElement, refId, isForward)
+}
+
+const updateRefIdsAcrossSlides = (fromSlideIndex, element, refId, isForward) => {
+	let i = isForward ? fromSlideIndex + 1 : fromSlideIndex - 1
+
+	while (i >= 0 && i < slides.value.length) {
+		const slide = slides.value[i]
+		const transition = isForward ? slides.value[i - 1]?.transition : slide.transition
+		const hasTransition = transition === 'Magic Move'
+
+		if (!hasTransition) break
+
+		const refElement = getReferenceElement(element, slide)
+		if (refElement) {
+			refElement.refId = refId
+		}
+
+		i += isForward ? 1 : -1
+	}
+}
+
+export { createConnectionsForMagicMove, updateElementId, updateRefId }


### PR DESCRIPTION
Use computed value and ref id for storing magic move connected elements instead of relying on element ids.

