### PR TITLE
fix: styles don't get re-computed correctly for slideshow text

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Find tests
         run: |
@@ -46,14 +46,14 @@ jobs:
           grep -rn "def test" > /dev/null
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.14'
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
           check-latest: true
 
       - name: Cache pip

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,11 +18,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
+      - name: Clone
+        uses: actions/checkout@v6
 
-      - uses: actions/checkout@v4
+      - name: Setup Python
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
 
       - name: Cache pip
         uses: actions/cache@v4

--- a/frontend/src/components/SlideshowText.vue
+++ b/frontend/src/components/SlideshowText.vue
@@ -64,7 +64,7 @@ const createSpansForTextNode = (blockNode, textNode) => {
 	let spansHTML = ''
 
 	const span = getClosestSpan(textNode, blockNode)
-	const style = span?.getAttribute('style') || ''
+	const style = span?.getAttribute('style')?.replace(/"/g, "'") || ''
 
 	const { openWrap, closeWrap } = getWrappingTags(textNode, span)
 

--- a/frontend/src/composables/useSnapping.js
+++ b/frontend/src/composables/useSnapping.js
@@ -344,6 +344,8 @@ export const useSnapping = (target, parent, currentResizer, hasOngoingInteractio
 			Object.entries(oppositeGuides).forEach(([side, opposite]) => {
 				if (resizer.includes(side)) {
 					resistanceMap[opposite] = false
+					resistanceMap['centerX'] = false
+					resistanceMap['centerY'] = false
 				}
 			})
 		}


### PR DESCRIPTION
Double quotes were not getting escaped correctly while computing the styles for text in slideshow leading to breaking fonts which have spaces in their names. 

Bump up to python 3.14 and node24 for CI.