### PR TITLE
fix: fallback format when google clipboard headers are missing

### DIFF
--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -489,7 +489,8 @@ const handlePaste = (e) => {
 
 	const clipboardTextHTML = e.clipboardData.getData('text/html')
 	const imgSrc = getImageSrcFromHTML(clipboardTextHTML)
-	if (clipboardTextHTML && imgSrc) return handleClipboardTextHTML(clipboardTextHTML)
+	if (clipboardTextHTML && imgSrc && imgSrc.startsWith('data:'))
+		return handleClipboardTextHTML(imgSrc)
 
 	const clipboardJSON = e.clipboardData.getData('application/json')
 	if (clipboardJSON) return handleClipboardJSON(clipboardJSON)


### PR DESCRIPTION
Copying images from external sources sometimes add them to both clipboard data items as well as as html so fallback to the correct source while parsing the copied image data.