### PR TITLE
fix: temporarily limit overflow issue to magic move text elements

### DIFF
--- a/frontend/src/components/TextElement.vue
+++ b/frontend/src/components/TextElement.vue
@@ -9,7 +9,7 @@
 		@dblclick="handleDoubleClick"
 	/>
 	<div
-		v-else-if="!inSlideShow"
+		v-else-if="!inSlideShow || [null, undefined, ''].includes(element.refId)"
 		v-html="element.content"
 		class="textElement select-none"
 		:class="isAutoWidth ? 'text-auto-width' : 'text-fixed-width'"


### PR DESCRIPTION
Check if the ref id of text is set to render the text as character separated spans until overflow issue is fixed for spans splitting to next line without the native browser word split checks.