### PR TITLE
feat: double click for text, enter for slide + misc fixes

### DIFF
--- a/frontend/src/components/ImageElement.vue
+++ b/frontend/src/components/ImageElement.vue
@@ -11,7 +11,7 @@
 				:uploadArgs="{
 					doctype: 'Presentation',
 					docname: presentationId,
-					private: !isPublicPresentation,
+					private: true,
 				}"
 				@success="replaceTemplateImage"
 			>

--- a/frontend/src/components/SharePopover.vue
+++ b/frontend/src/components/SharePopover.vue
@@ -40,12 +40,7 @@
 <script setup>
 import { ref, inject } from 'vue'
 import { Popover, Switch, call, toast } from 'frappe-ui'
-import {
-	presentationId,
-	isPublicPresentation,
-	ignoreUpdates,
-	parseElements,
-} from '@/stores/presentation'
+import { presentationId, isPublicPresentation } from '@/stores/presentation'
 import { resetFocus } from '@/stores/element'
 import { copyToClipboard } from '@/stores/copyPaste'
 

--- a/frontend/src/components/SharePopover.vue
+++ b/frontend/src/components/SharePopover.vue
@@ -47,7 +47,7 @@ import {
 	parseElements,
 } from '@/stores/presentation'
 import { resetFocus } from '@/stores/element'
-import { copyToClipboard } from '@/utils/helpers'
+import { copyToClipboard } from '@/stores/copyPaste'
 
 const savePresentation = inject('savePresentation', async () => {})
 

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -61,9 +61,9 @@ import {
 	selectionBounds,
 	updateSelectionBounds,
 	setSlideRef,
-	insertSlide,
 	slideIndex,
 } from '@/stores/slide'
+
 import {
 	activeElementIds,
 	activeElement,
@@ -82,8 +82,7 @@ import { useResizer } from '@/composables/useResizer'
 import { usePanAndZoom } from '@/composables/usePanAndZoom'
 import { useSnapping } from '@/composables/useSnapping'
 
-import { getDocFromHTML, isCmdOrCtrl } from '@/utils/helpers'
-import { handleUploadedMedia } from '../utils/mediaUploads'
+import { isCmdOrCtrl } from '@/utils/helpers'
 
 const props = defineProps({
 	highlight: Boolean,

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -497,8 +497,8 @@ watch(
 const handleSlideDoubleClick = (e) => {
 	if (props.readonlyMode || e.target !== e.currentTarget) return
 	addTextElement('', {
-		x: (e.clientX - slideBounds.left) / scale.value,
-		y: (e.clientY - slideBounds.top) / scale.value,
+		left: (e.clientX - slideBounds.left) / scale.value,
+		top: (e.clientY - slideBounds.top) / scale.value,
 	})
 }
 </script>

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -2,7 +2,13 @@
 	<div ref="slideContainer" class="flex size-full" @dragenter="showOverlay">
 		<!-- when mounting place slide directly in the center of the visible container -->
 		<!-- 1/2 width of viewport + 1/2 width of offset caused due to thinner navigation panel -->
-		<div ref="slideRef" :style="slideStyles" :class="slideClasses" @contextmenu.prevent>
+		<div
+			ref="slideRef"
+			:style="slideStyles"
+			:class="slideClasses"
+			@contextmenu.prevent
+			@dblclick="handleSlideDoubleClick"
+		>
 			<SelectionBox
 				ref="selectionBox"
 				v-if="!readonlyMode"
@@ -73,6 +79,7 @@ import {
 	setEditableState,
 	duplicateElements,
 	activeElements,
+	addTextElement,
 } from '@/stores/element'
 
 import { handleCopy, handlePaste } from '@/stores/copyPaste'
@@ -486,4 +493,12 @@ watch(
 		emit('update:hasOngoingInteraction', newVal)
 	},
 )
+
+const handleSlideDoubleClick = (e) => {
+	if (props.readonlyMode || e.target !== e.currentTarget) return
+	addTextElement('', {
+		x: (e.clientX - slideBounds.left) / scale.value,
+		y: (e.clientY - slideBounds.top) / scale.value,
+	})
+}
 </script>

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -67,10 +67,6 @@ import {
 import {
 	activeElementIds,
 	activeElement,
-	handleCopy,
-	handleSvgText,
-	handlePastedText,
-	handlePastedJSON,
 	focusElementId,
 	pairElementId,
 	addFixedWidthToElement,
@@ -78,6 +74,8 @@ import {
 	duplicateElements,
 	activeElements,
 } from '@/stores/element'
+
+import { handleCopy, handlePaste } from '@/stores/copyPaste'
 
 import { useDragAndDrop } from '@/composables/useDragAndDrop'
 import { useResizer } from '@/composables/useResizer'
@@ -427,90 +425,6 @@ watch(
 		handleDimensionChange(delta)
 	},
 )
-
-const handlePastedSlideJSON = async (json) => {
-	const index = slideIndex.value
-
-	insertSlide(JSON.parse(json), index)
-
-	emit('changeSlide', index + 1)
-}
-
-const isInputElement = (el) => {
-	const activeElement = document.activeElement
-	return (
-		activeElement?.tagName == 'INPUT' ||
-		activeElement?.tagName == 'TEXTAREA' ||
-		activeElement?.isContentEditable
-	)
-}
-
-const handleClipboardText = (clipboardText) => {
-	if (clipboardText?.trim().startsWith('<svg') && clipboardText?.trim().endsWith('</svg>')) {
-		handleSvgText(clipboardText)
-	} else if (clipboardText && !focusElementId.value) {
-		handlePastedText(clipboardText)
-	}
-}
-
-const handleClipboardJSON = (clipboardJSON) => {
-	const isSlideJSON = !Array.isArray(clipboardJSON) && clipboardJSON.includes('"elements"')
-	if (isSlideJSON) {
-		return handlePastedSlideJSON(clipboardJSON)
-	}
-	return handlePastedJSON(JSON.parse(clipboardJSON))
-}
-
-const dataURLToFile = (dataURL, filename) => {
-	const [meta, base64] = dataURL.split(',')
-	const mime = meta.match(/:(.*?);/)[1]
-	const binary = atob(base64)
-	const len = binary.length
-	const buffer = new Uint8Array(len)
-
-	for (let i = 0; i < len; i++) {
-		buffer[i] = binary.charCodeAt(i)
-	}
-
-	return new File([buffer], filename, {
-		type: mime,
-		lastModified: Date.now(),
-	})
-}
-
-const getImageSrcFromHTML = (clipboardTextHTML) => {
-	const doc = getDocFromHTML(clipboardTextHTML)
-	const img = doc.querySelector('img')
-
-	if (img) return img.src
-	return null
-}
-
-const handleClipboardTextHTML = (imgSrc) => {
-	const file = dataURLToFile(imgSrc, 'pasted-image.png')
-	handleUploadedMedia([{ kind: 'file', getAsFile: () => file }])
-}
-
-const handlePaste = (e) => {
-	// do not override paste event if current element is input or content editable
-	if (isInputElement()) return
-
-	e.preventDefault()
-
-	const clipboardTextHTML = e.clipboardData.getData('text/html')
-	const imgSrc = getImageSrcFromHTML(clipboardTextHTML)
-	if (clipboardTextHTML && imgSrc && imgSrc.startsWith('data:'))
-		return handleClipboardTextHTML(imgSrc)
-
-	const clipboardJSON = e.clipboardData.getData('application/json')
-	if (clipboardJSON) return handleClipboardJSON(clipboardJSON)
-
-	const clipboardText = e.clipboardData.getData('text/plain')
-	if (clipboardText) return handleClipboardText(clipboardText)
-
-	const clipboardItems = e.clipboardData.items
-	if (clipboardItems) return handleUploadedMedia(clipboardItems)
-}
 
 const initSlideAndListeners = () => {
 	if (!slideRef.value) return

--- a/frontend/src/components/SlideContainer.vue
+++ b/frontend/src/components/SlideContainer.vue
@@ -440,7 +440,7 @@ const initSlideAndListeners = () => {
 	updateSlideBounds()
 
 	document.addEventListener('copy', handleCopy)
-	document.addEventListener('paste', handlePaste)
+	document.addEventListener('paste', (e) => handlePaste(e, emit.bind(null, 'changeSlide')))
 	window.addEventListener('resize', updateSlideBounds)
 }
 

--- a/frontend/src/components/Toolbar.vue
+++ b/frontend/src/components/Toolbar.vue
@@ -15,7 +15,7 @@
 				:uploadArgs="{
 					doctype: 'Presentation',
 					docname: presentationId,
-					private: !isPublicPresentation,
+					private: true,
 				}"
 				@success="(file) => handleUploadSuccess(file)"
 			>

--- a/frontend/src/components/controls/ColorPicker.vue
+++ b/frontend/src/components/controls/ColorPicker.vue
@@ -97,12 +97,12 @@
 import { ref, unref, computed, useTemplateRef, watch } from 'vue'
 import { useElementBounding, useEyeDropper } from '@vueuse/core'
 
-import { Popover } from 'frappe-ui'
+import { Popover, Input } from 'frappe-ui'
+
+import { copyToClipboard } from '@/stores/copyPaste'
 import EyeDropper from '@/icons/EyeDropper.vue'
 
 import tinycolor from 'tinycolor2'
-import { Input } from 'frappe-ui'
-import { copyToClipboard } from '@/stores/copyPaste'
 
 const shadeSlider = useTemplateRef('shadeSlider')
 const colorSlider = useTemplateRef('colorSlider')

--- a/frontend/src/components/controls/ColorPicker.vue
+++ b/frontend/src/components/controls/ColorPicker.vue
@@ -102,7 +102,7 @@ import EyeDropper from '@/icons/EyeDropper.vue'
 
 import tinycolor from 'tinycolor2'
 import { Input } from 'frappe-ui'
-import { copyToClipboard } from '@/utils/helpers'
+import { copyToClipboard } from '@/stores/copyPaste'
 
 const shadeSlider = useTemplateRef('shadeSlider')
 const colorSlider = useTemplateRef('colorSlider')

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -172,6 +172,17 @@ const toggleSlideNavigator = () => {
 	}
 }
 
+const handleShowLayoutDialogShortcut = (e) => {
+	e.preventDefault()
+	openLayoutDialog('insert')
+}
+
+const addEmptySlide = (e) => {
+	e.preventDefault()
+	const layoutId = layoutResource.data?.slides[0]?.name
+	if (layoutId) handleInsertSlide(layoutId)
+}
+
 const handleElementShortcuts = (e) => {
 	switch (e.key) {
 		case 'ArrowLeft':
@@ -241,10 +252,10 @@ const handleGlobalShortcuts = (e) => {
 			if (isCmdOrCtrl(e)) saveSlide(e)
 			break
 		case 'n':
-			if (e.ctrlKey) {
-				e.preventDefault()
-				openLayoutDialog('insert')
-			}
+			if (e.ctrlKey) handleShowLayoutDialogShortcut(e)
+			break
+		case 'Enter':
+			addEmptySlide(e)
 			break
 		case 'F5':
 			e.preventDefault()

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -97,6 +97,7 @@ import {
 	lastThumbnailTime,
 	focusedSlide,
 	insertSlide,
+	getNewSlide,
 } from '@/stores/slide'
 import {
 	resetFocus,
@@ -213,9 +214,6 @@ const handleSlideShortcuts = (e) => {
 			break
 		case 'd':
 			if (isCmdOrCtrl(e)) duplicateSlide(e)
-			break
-		case 'c':
-			if (isCmdOrCtrl(e)) copySlide(e)
 			break
 	}
 }
@@ -458,35 +456,6 @@ const changeSlide = async (index, focus = true) => {
 	}
 }
 
-const getNewSlide = (toDuplicate = false, layoutId) => {
-	let layout = null
-
-	if (toDuplicate) {
-		layout = currentSlide.value
-		layout.elements = layout.elements.map((e) => ({
-			...e,
-			refId: e.refId || generateUniqueId(),
-		}))
-	} else {
-		layout = layoutResource.data?.slides?.find((l) => l.name == layoutId)
-	}
-
-	const slide = {}
-	if (layout) {
-		slide.background = layout.background
-		slide.transition = layout.transition
-		slide.transitionDuration = layout.transitionDuration
-		slide.fadeUnmatchedElements = layout.fadeUnmatchedElements
-		slide.elements = layout.elements.map((e) => ({ ...e }))
-	}
-
-	// override metadata and generate unique IDs for elements
-	slide.name = ''
-	slide.parent = presentationId.value
-
-	return slide
-}
-
 const insertDuplicateSlide = async (index, layoutId, toDuplicate) => {
 	if (toDuplicate || !index) index = slideIndex.value
 
@@ -543,18 +512,6 @@ const replaceSlide = (layoutId) => {
 	slides.value.forEach((slide, index) => {
 		slide.idx = index + 1
 	})
-}
-
-const getCopiedSlideJSON = () => {
-	const slide = getNewSlide(true)
-	return JSON.stringify(slide)
-}
-
-const copySlide = (e) => {
-	e.preventDefault()
-	const clipboardJSON = getCopiedSlideJSON()
-	e.clipboardData?.setData('application/json', clipboardJSON)
-	toast.success('Slide copied to clipboard')
 }
 
 const resetAndSave = async () => {

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -90,7 +90,6 @@ import {
 import {
 	slides,
 	slideIndex,
-	currentSlide,
 	selectionBounds,
 	updateSelectionBounds,
 	updateThumbnail,
@@ -113,7 +112,7 @@ import {
 
 import { useTextEditor } from '@/composables/useTextEditor'
 
-import { generateUniqueId, isCmdOrCtrl } from '@/utils/helpers'
+import { isCmdOrCtrl } from '@/utils/helpers'
 
 const { activeEditor, toggleMark } = useTextEditor()
 

--- a/frontend/src/stores/copyPaste.js
+++ b/frontend/src/stores/copyPaste.js
@@ -141,10 +141,14 @@ const handleClipboardText = (clipboardText) => {
 	}
 }
 
-const handleClipboardJSON = (clipboardJSON) => {
+const handleClipboardJSON = (clipboardJSON, changeSlide) => {
 	const isSlideJSON = !Array.isArray(clipboardJSON) && clipboardJSON.includes('"elements"')
 	if (isSlideJSON) {
-		return handlePastedSlideJSON(clipboardJSON)
+		handlePastedSlideJSON(clipboardJSON)
+		if (changeSlide) {
+			changeSlide(slideIndex.value + 1)
+		}
+		return
 	}
 	return handlePastedJSON(JSON.parse(clipboardJSON))
 }
@@ -179,7 +183,7 @@ const handleClipboardTextHTML = (imgSrc) => {
 	handleUploadedMedia([{ kind: 'file', getAsFile: () => file }])
 }
 
-const handlePaste = (e) => {
+const handlePaste = (e, changeSlide) => {
 	// do not override paste event if current element is input or content editable
 	if (isInputElement()) return
 
@@ -191,7 +195,7 @@ const handlePaste = (e) => {
 		return handleClipboardTextHTML(imgSrc)
 
 	const clipboardJSON = e.clipboardData.getData('application/json')
-	if (clipboardJSON) return handleClipboardJSON(clipboardJSON)
+	if (clipboardJSON) return handleClipboardJSON(clipboardJSON, changeSlide)
 
 	const clipboardText = e.clipboardData.getData('text/plain')
 	if (clipboardText) return handleClipboardText(clipboardText)

--- a/frontend/src/stores/copyPaste.js
+++ b/frontend/src/stores/copyPaste.js
@@ -1,0 +1,203 @@
+import { ref } from 'vue'
+import { toast, call } from 'frappe-ui'
+
+import { presentationId } from '@/stores/presentation'
+import { slideIndex, insertSlide, getNewSlide } from '@/stores/slide'
+import {
+	activeElements,
+	activeElementIds,
+	focusElementId,
+	addTextElement,
+	duplicateElements,
+	resetFocus,
+} from '@/stores/element'
+
+import { useTextEditor } from '@/composables/useTextEditor'
+
+import { getDocFromHTML } from '@/utils/helpers'
+import { handleUploadedMedia } from '@/utils/mediaUploads'
+
+const { activeEditor } = useTextEditor()
+
+// Copy Handlers
+
+const isCopyTriggeredByButton = ref(false)
+
+const getCopiedElementsJSON = () => JSON.stringify(activeElements.value)
+
+const getCopiedSlideJSON = () => {
+	const slide = getNewSlide(true)
+	return JSON.stringify(slide)
+}
+
+const copiedFrom = ref({})
+
+const copySlide = (e) => {
+	const clipboardJSON = getCopiedSlideJSON()
+	e.clipboardData.setData('application/json', clipboardJSON)
+	toast.success('Slide copied to clipboard')
+}
+
+const copyElements = (e) => {
+	const clipboardJSON = getCopiedElementsJSON()
+	e.clipboardData.setData('application/json', clipboardJSON)
+	copiedFrom.value = {
+		srcPresentation: presentationId.value,
+		srcSlide: slideIndex.value,
+	}
+}
+
+const handleCopy = (e) => {
+	if (isCopyTriggeredByButton.value) return
+
+	e.preventDefault()
+	const isCopyingElements = activeElementIds.value.length > 0
+	if (isCopyingElements) {
+		copyElements(e)
+	} else {
+		copySlide(e)
+	}
+}
+
+const copyToClipboard = async (text) => {
+	isCopyTriggeredByButton.value = true
+
+	if (navigator.clipboard && window.isSecureContext) {
+		await navigator.clipboard.writeText(text)
+	} else {
+		let input = document.createElement('textarea')
+		document.body.appendChild(input)
+		input.value = text
+		input.select()
+		document.execCommand('copy')
+		document.body.removeChild(input)
+	}
+
+	isCopyTriggeredByButton.value = false
+	toast.success('Copied to clipboard')
+}
+
+// Paste Handlers
+
+const handlePastedText = async (clipboardText) => {
+	await resetFocus()
+	addTextElement(clipboardText)
+}
+
+const handlePastedJSON = async (json) => {
+	const pastedArray = Array.isArray(json) ? json : []
+
+	if (
+		pastedArray[0]?.type == 'text' &&
+		focusElementId.value &&
+		focusElementId.value != pastedArray[0].id
+	) {
+		activeEditor.value.commands.insertContent(pastedArray[0].content)
+		return
+	}
+
+	const { srcPresentation, srcSlide } = copiedFrom.value
+
+	if (srcPresentation !== presentationId.value) {
+		// if pasted elements are from a different presentation
+		// add file attachments correctly to current presentation + update docnames in json
+		json = await call('slides.slides.doctype.presentation.presentation.get_updated_json', {
+			presentation: presentationId.value,
+			json: json,
+		})
+	}
+
+	duplicateElements(null, json, srcSlide)
+}
+
+const handleSvgText = (svgText) => {
+	const svgBlob = new Blob([svgText], { type: 'image/svg+xml' })
+	const svgFile = new File([svgBlob], 'pasted-image.svg', { type: 'image/svg+xml' })
+	handleUploadedMedia([{ kind: 'file', getAsFile: () => svgFile }])
+}
+
+const handlePastedSlideJSON = async (json) => {
+	const index = slideIndex.value
+
+	insertSlide(JSON.parse(json), index)
+
+	// emit('changeSlide', index + 1)
+}
+
+const isInputElement = (el) => {
+	const activeElement = document.activeElement
+	return (
+		activeElement?.tagName == 'INPUT' ||
+		activeElement?.tagName == 'TEXTAREA' ||
+		activeElement?.isContentEditable
+	)
+}
+
+const handleClipboardText = (clipboardText) => {
+	if (clipboardText?.trim().startsWith('<svg') && clipboardText?.trim().endsWith('</svg>')) {
+		handleSvgText(clipboardText)
+	} else if (clipboardText && !focusElementId.value) {
+		handlePastedText(clipboardText)
+	}
+}
+
+const handleClipboardJSON = (clipboardJSON) => {
+	const isSlideJSON = !Array.isArray(clipboardJSON) && clipboardJSON.includes('"elements"')
+	if (isSlideJSON) {
+		return handlePastedSlideJSON(clipboardJSON)
+	}
+	return handlePastedJSON(JSON.parse(clipboardJSON))
+}
+
+const dataURLToFile = (dataURL, filename) => {
+	const [meta, base64] = dataURL.split(',')
+	const mime = meta.match(/:(.*?);/)[1]
+	const binary = atob(base64)
+	const len = binary.length
+	const buffer = new Uint8Array(len)
+
+	for (let i = 0; i < len; i++) {
+		buffer[i] = binary.charCodeAt(i)
+	}
+
+	return new File([buffer], filename, {
+		type: mime,
+		lastModified: Date.now(),
+	})
+}
+
+const getImageSrcFromHTML = (clipboardTextHTML) => {
+	const doc = getDocFromHTML(clipboardTextHTML)
+	const img = doc.querySelector('img')
+
+	if (img) return img.src
+	return null
+}
+
+const handleClipboardTextHTML = (imgSrc) => {
+	const file = dataURLToFile(imgSrc, 'pasted-image.png')
+	handleUploadedMedia([{ kind: 'file', getAsFile: () => file }])
+}
+
+const handlePaste = (e) => {
+	// do not override paste event if current element is input or content editable
+	if (isInputElement()) return
+
+	e.preventDefault()
+
+	const clipboardTextHTML = e.clipboardData.getData('text/html')
+	const imgSrc = getImageSrcFromHTML(clipboardTextHTML)
+	if (clipboardTextHTML && imgSrc && imgSrc.startsWith('data:'))
+		return handleClipboardTextHTML(imgSrc)
+
+	const clipboardJSON = e.clipboardData.getData('application/json')
+	if (clipboardJSON) return handleClipboardJSON(clipboardJSON)
+
+	const clipboardText = e.clipboardData.getData('text/plain')
+	if (clipboardText) return handleClipboardText(clipboardText)
+
+	const clipboardItems = e.clipboardData.items
+	if (clipboardItems) return handleUploadedMedia(clipboardItems)
+}
+
+export { handleCopy, handlePaste, copyToClipboard }

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -112,7 +112,7 @@ const getElementContent = (element) => {
 	return generateHTML(contentJSON, extensions)
 }
 
-const addTextElement = async (text) => {
+const addTextElement = async (text, position) => {
 	const elementPresets = {
 		textAlign: 'left',
 		fontSize: 28,
@@ -127,8 +127,8 @@ const addTextElement = async (text) => {
 		zIndex: currentSlide.value.elements.length + 1,
 		transformOrigin: 'center center',
 		transform: 'translate(-50%, -50%)',
-		left: 0,
-		top: 0,
+		left: position ? position.x : 0,
+		top: position ? position.y : 0,
 		type: 'text',
 		content: getElementContent(elementPresets),
 		editorMetadata: {
@@ -140,7 +140,16 @@ const addTextElement = async (text) => {
 
 	updateElementRefId(element)
 
-	selectAndCenterElement(element.id)
+	if (!position) selectAndCenterElement(element.id)
+	else {
+		nextTick(() => {
+			setActiveElements([element.id])
+			nextTick(() => {
+				focusElementId.value = element.id
+				setEditableState()
+			})
+		})
+	}
 }
 
 const savePoster = createResource({

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -13,7 +13,7 @@ import {
 } from './slide'
 import { useTextEditor } from '@/composables/useTextEditor'
 
-import { generateUniqueId, cloneObj, isCopyTriggeredByButton } from '../utils/helpers'
+import { generateUniqueId, cloneObj } from '../utils/helpers'
 import { guessTextColorFromBackground } from '../utils/color'
 import { handleUploadedMedia } from '../utils/mediaUploads'
 import { presentationId } from './presentation'
@@ -387,59 +387,6 @@ const isWithinOverlappingBounds = (outer, inner) => {
 	return withinWidth && withinHeight
 }
 
-const getCopiedJSON = () => JSON.stringify(activeElements.value)
-
-const copiedFrom = ref({})
-
-const handleCopy = (e) => {
-	if (!activeElements.value.length || isCopyTriggeredByButton.value) return
-
-	e.preventDefault()
-	const clipboardJSON = getCopiedJSON()
-	e.clipboardData.setData('application/json', clipboardJSON)
-	copiedFrom.value = {
-		srcPresentation: presentationId.value,
-		srcSlide: slideIndex.value,
-	}
-}
-
-const handlePastedText = async (clipboardText) => {
-	await resetFocus()
-	addTextElement(clipboardText)
-}
-
-const handlePastedJSON = async (json) => {
-	const pastedArray = Array.isArray(json) ? json : []
-
-	if (
-		pastedArray[0]?.type == 'text' &&
-		focusElementId.value &&
-		focusElementId.value != pastedArray[0].id
-	) {
-		activeEditor.value.commands.insertContent(pastedArray[0].content)
-		return
-	}
-
-	const { srcPresentation, srcSlide } = copiedFrom.value
-
-	if (srcPresentation !== presentationId.value) {
-		// if pasted elements are from a different presentation
-		// add file attachments correctly to current presentation + update docnames in json
-		json = await call('slides.slides.doctype.presentation.presentation.get_updated_json', {
-			presentation: presentationId.value,
-			json: json,
-		})
-	}
-
-	duplicateElements(null, json, srcSlide)
-}
-
-const handleSvgText = (svgText) => {
-	const svgBlob = new Blob([svgText], { type: 'image/svg+xml' })
-	const svgFile = new File([svgBlob], 'pasted-image.svg', { type: 'image/svg+xml' })
-	handleUploadedMedia([{ kind: 'file', getAsFile: () => svgFile }])
-}
-
 const addFixedWidthToElement = (deltaWidth) => {
 	const elementDiv = document.querySelector(`[data-index="${activeElement.value.id}"]`)
 	if (elementDiv) {
@@ -558,10 +505,6 @@ export {
 	deleteElements,
 	selectAllElements,
 	getElementPosition,
-	handleCopy,
-	handleSvgText,
-	handlePastedText,
-	handlePastedJSON,
 	addFixedWidthToElement,
 	deleteAttachments,
 	setEditableState,

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -48,33 +48,12 @@ const setActiveElements = (ids, focus = false) => {
 	focusElementId.value = null
 }
 
-const selectAndCenterElement = (elementId) => {
-	const slideWidth = slideBounds.width / slideBounds.scale
-	const slideHeight = slideBounds.height / slideBounds.scale
-
+const selectAddedElement = (elementId, type) => {
 	nextTick(() => {
 		setActiveElements([elementId])
-		// to allow centering element only after it's rendered in order to correctly calculate its offset from center
-		requestAnimationFrame(async () => {
-			await nextTick()
-			const elementRect = document
-				.querySelector(`[data-index="${elementId}"]`)
-				.getBoundingClientRect()
+		if (type !== 'text') return
 
-			const elementWidth = elementRect.width / slideBounds.scale
-			const elementHeight = elementRect.height / slideBounds.scale
-
-			const elementLeft = (slideWidth - elementWidth) / 2
-			const elementTop = (slideHeight - elementHeight) / 2
-
-			updateSelectionBounds({
-				left: elementLeft,
-				top: elementTop,
-			})
-
-			activeElement.value.left = elementLeft + elementWidth / 2
-			activeElement.value.top = elementTop + elementHeight / 2
-		})
+		focusElementId.value = elementId
 	})
 }
 
@@ -112,6 +91,32 @@ const getElementContent = (element) => {
 	return generateHTML(contentJSON, extensions)
 }
 
+const getTextElementDimensions = (presets) => {
+	const tempTextElement = document.createElement('div')
+
+	Object.assign(tempTextElement.style, {
+		position: 'absolute',
+		visibility: 'hidden',
+		height: 'auto',
+		width: 'auto',
+		whiteSpace: 'pre',
+		fontSize: `${presets.fontSize}px`,
+		fontFamily: presets.fontFamily,
+		letterSpacing: `${presets.letterSpacing}px`,
+		color: presets.color || '#000000',
+	})
+	tempTextElement.innerHTML = presets.innerText || 'Text'
+
+	document.body.appendChild(tempTextElement)
+
+	const elementWidth = tempTextElement.offsetWidth
+	const elementHeight = tempTextElement.offsetHeight
+
+	document.body.removeChild(tempTextElement)
+
+	return { elementWidth, elementHeight }
+}
+
 const addTextElement = async (text, position) => {
 	const elementPresets = {
 		textAlign: 'left',
@@ -122,13 +127,20 @@ const addTextElement = async (text, position) => {
 		letterSpacing: 0,
 	}
 
+	if (!position) {
+		const { elementWidth, elementHeight } = getTextElementDimensions(elementPresets)
+		position = getLeftTopForCenteredElement(elementWidth, elementHeight)
+		position.left += elementWidth / 2
+		position.top += elementHeight / 2
+	}
+
 	const element = {
 		id: generateUniqueId(),
 		zIndex: currentSlide.value.elements.length + 1,
 		transformOrigin: 'center center',
 		transform: 'translate(-50%, -50%)',
-		left: position ? position.x : 0,
-		top: position ? position.y : 0,
+		left: position.left,
+		top: position.top,
 		type: 'text',
 		content: getElementContent(elementPresets),
 		editorMetadata: {
@@ -140,16 +152,7 @@ const addTextElement = async (text, position) => {
 
 	updateElementRefId(element)
 
-	if (!position) selectAndCenterElement(element.id)
-	else {
-		nextTick(() => {
-			setActiveElements([element.id])
-			nextTick(() => {
-				focusElementId.value = element.id
-				setEditableState()
-			})
-		})
-	}
+	selectAddedElement(element.id, 'text')
 }
 
 const savePoster = createResource({
@@ -185,7 +188,7 @@ const getVideoElementClone = (videoUrl) => {
 	videoElement.src = videoUrl
 	videoElement.style.position = 'absolute'
 	videoElement.style.left = '-9999px'
-	videoElement.style.width = '300px'
+	videoElement.style.width = '400px'
 	videoElement.style.height = 'auto'
 
 	return videoElement
@@ -194,7 +197,8 @@ const getVideoElementClone = (videoUrl) => {
 const handleVideoCloneDataLoad = async (videoClone, resolve, reject) => {
 	try {
 		const poster = await generatePoster(videoClone)
-		resolve(poster)
+		const aspectRatio = videoClone.videoWidth / videoClone.videoHeight
+		resolve({ posterURL: poster, aspectRatio: aspectRatio })
 	} catch (err) {
 		reject(err)
 	} finally {
@@ -235,21 +239,55 @@ const getNaturalSize = async (dataURL) => {
 		img.onload = () =>
 			resolve({
 				width: (img.naturalWidth / 2) * slideBounds.scale,
+				aspectRatio: img.naturalWidth / img.naturalHeight,
 			})
 		img.onerror = reject
 		img.src = dataURL
 	})
 }
 
+const getLeftTopForCenteredElement = (elementWidth, elementHeight) => {
+	const slideWidth = slideBounds.width / slideBounds.scale
+	const slideHeight = slideBounds.height / slideBounds.scale
+
+	const elementLeft = (slideWidth - elementWidth) / 2
+	const elementTop = (slideHeight - elementHeight) / 2
+
+	return { left: elementLeft, top: elementTop }
+}
+
 const addMediaElement = async (file, type) => {
 	const src = file.file_url
-	const { width } = type === 'image' ? await getNaturalSize(src) : { width: 400 }
+
+	let elementWidth = 0
+
+	let position = {
+		left: 0,
+		top: 0,
+	}
+
+	let videoPoster = null
+
+	if (type == 'image') {
+		const { width, aspectRatio } = await getNaturalSize(src)
+		elementWidth = Math.max(Math.min(width, 800), 30)
+		const elementHeight = elementWidth / aspectRatio
+		position = getLeftTopForCenteredElement(elementWidth, elementHeight)
+	} else {
+		elementWidth = 400
+		const { posterURL, aspectRatio } = await getVideoPoster(src)
+		const elementHeight = elementWidth / aspectRatio
+		position = getLeftTopForCenteredElement(elementWidth, elementHeight)
+		videoPoster = posterURL
+	}
+
+	const { width, height } = type === 'image' ? await getNaturalSize(src) : { width: 400 }
 	let element = {
 		id: generateUniqueId(),
 		zIndex: currentSlide.value.elements.length + 1,
-		width: Math.max(Math.min(width, 800), 30),
-		left: 0,
-		top: 0,
+		width: elementWidth,
+		left: position.left,
+		top: position.top,
 		opacity: 100,
 		type: type,
 		src: src,
@@ -264,8 +302,7 @@ const addMediaElement = async (file, type) => {
 		shadowColor: '#000000ff',
 	}
 	if (type == 'video') {
-		const posterURL = await getVideoPoster(file.file_url)
-		element.poster = posterURL
+		element.poster = videoPoster
 		element.autoplay = false
 		element.loop = false
 		element.playbackRate = 1
@@ -277,7 +314,7 @@ const addMediaElement = async (file, type) => {
 
 	updateElementRefId(element)
 
-	selectAndCenterElement(element.id)
+	selectAddedElement(element.id, type)
 }
 
 const replaceMediaElement = async (element, fileDoc) => {

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -9,13 +9,11 @@ import {
 	currentSlide,
 	slideIndex,
 	updateThumbnail,
-	insertSlide,
 } from './slide'
 import { useTextEditor } from '@/composables/useTextEditor'
 
 import { generateUniqueId, cloneObj } from '../utils/helpers'
 import { guessTextColorFromBackground } from '../utils/color'
-import { handleUploadedMedia } from '../utils/mediaUploads'
 import { presentationId } from './presentation'
 import { initElementRefId, updateElementRefId } from './transition'
 

--- a/frontend/src/stores/presentation.js
+++ b/frontend/src/stores/presentation.js
@@ -360,7 +360,6 @@ export {
 	applyReverseTransition,
 	createPresentationResource,
 	updatePresentationTitle,
-	getPresentationResource,
 	hasStateChanged,
 	savePresentationDoc,
 	initPresentationDoc,
@@ -374,6 +373,5 @@ export {
 	isPublicPresentation,
 	readonlyMode,
 	slidesLength,
-	parseElements,
 	historyMetadata,
 }

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -1,11 +1,5 @@
 import { ref, computed, reactive } from 'vue'
-import {
-	ignoreUpdates,
-	isPublicPresentation,
-	slidesLength,
-	presentationId,
-	layoutResource,
-} from '@/stores/presentation'
+import { ignoreUpdates, slidesLength, presentationId, layoutResource } from '@/stores/presentation'
 import { generateUniqueId } from '@/utils/helpers'
 
 import html2canvas from 'html2canvas'
@@ -221,11 +215,11 @@ export {
 	slideBounds,
 	selectionBounds,
 	guideVisibilityMap,
+	focusedSlide,
+	lastThumbnailTime,
 	updateSelectionBounds,
 	setSlideRef,
 	updateThumbnail,
-	focusedSlide,
-	lastThumbnailTime,
 	insertSlide,
 	getNewSlide,
 }

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -1,5 +1,12 @@
-import { ignoreUpdates, isPublicPresentation, slidesLength } from '@/stores/presentation'
 import { ref, computed, reactive } from 'vue'
+import {
+	ignoreUpdates,
+	isPublicPresentation,
+	slidesLength,
+	presentationId,
+	layoutResource,
+} from '@/stores/presentation'
+import { generateUniqueId } from '@/utils/helpers'
 
 import html2canvas from 'html2canvas'
 
@@ -178,6 +185,35 @@ const insertSlide = async (newSlide, index) => {
 	slidesLength.value = slides.value.length
 }
 
+const getNewSlide = (toDuplicate = false, layoutId) => {
+	let layout = null
+
+	if (toDuplicate) {
+		layout = currentSlide.value
+		layout.elements = layout.elements.map((e) => ({
+			...e,
+			refId: e.refId || generateUniqueId(),
+		}))
+	} else {
+		layout = layoutResource.data?.slides?.find((l) => l.name == layoutId)
+	}
+
+	const slide = {}
+	if (layout) {
+		slide.background = layout.background
+		slide.transition = layout.transition
+		slide.transitionDuration = layout.transitionDuration
+		slide.fadeUnmatchedElements = layout.fadeUnmatchedElements
+		slide.elements = layout.elements.map((e) => ({ ...e }))
+	}
+
+	// override metadata and generate unique IDs for elements
+	slide.name = ''
+	slide.parent = presentationId.value
+
+	return slide
+}
+
 export {
 	slideIndex,
 	slides,
@@ -191,4 +227,5 @@ export {
 	focusedSlide,
 	lastThumbnailTime,
 	insertSlide,
+	getNewSlide,
 }

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -1,5 +1,3 @@
-import { ref } from 'vue'
-import { toast } from 'frappe-ui'
 import { getAttachmentUrl } from './mediaUploads'
 
 let isClicked = false
@@ -66,26 +64,6 @@ const handleScrollBarWheelEvent = (e: WheelEvent) => {
 
 const cloneObj = (obj: any) => JSON.parse(JSON.stringify(obj))
 
-const isCopyTriggeredByButton = ref(false)
-
-const copyToClipboard = async (text: string) => {
-	isCopyTriggeredByButton.value = true
-
-	if (navigator.clipboard && window.isSecureContext) {
-		await navigator.clipboard.writeText(text)
-	} else {
-		let input = document.createElement('textarea')
-		document.body.appendChild(input)
-		input.value = text
-		input.select()
-		document.execCommand('copy')
-		document.body.removeChild(input)
-	}
-
-	isCopyTriggeredByButton.value = false
-	toast.success('Copied to clipboard')
-}
-
 const getThumbnailCardStyles = (thumbnail: string) => {
 	const thumbnailUrl = getAttachmentUrl(thumbnail)
 	return {
@@ -111,9 +89,7 @@ export {
 	setCursorPositionAtEnd,
 	handleScrollBarWheelEvent,
 	cloneObj,
-	copyToClipboard,
 	getThumbnailCardStyles,
 	getDocFromHTML,
 	isCmdOrCtrl,
-	isCopyTriggeredByButton
 }


### PR DESCRIPTION
### UX Enhancements

- Many people preferred the Enter shortcut for adding a new empty slide without any templates at the current index so added that. Now, CTRL + N shows the layout dialog to add a new slide with a layout but enter directly adds a new empty slide without any layout right below to the current one.
- Double clicking in the slide now adds a text element at the current mouse position. 

<br>

https://github.com/user-attachments/assets/a8209f69-b054-42b8-9d1a-b75136ffc611

<br>

### Fixes

- Pasting copied slide was breaking so fixed it's handler and cleaned up the copy paste logic into a new store.
- Replacing slide placeholder image from the layout led to it being uploaded to incorrect folder after the presentation was made public so fixed that.
- Newly added elements were first dropped onto the slide to get their width and height and then centered leading to there being two states for element addition. This meant doing undo after adding a new element moved it to the slide start position instead of completely removing it. So fixed that behaviour and elements are rendered directly in the center without an extra state in the middle.