### PR TITLE
fix: incorrect dirty value and shortcut fix

### DIFF
--- a/frontend/src/components/PresentationHeader.vue
+++ b/frontend/src/components/PresentationHeader.vue
@@ -6,7 +6,7 @@
 		@click="makeTitleEditable"
 		@focus="setCursorPositionAtEnd"
 		@blur="saveTitle"
-		@keydown.enter.prevent="(e) => e.target.blur()"
+		@keydown.enter.prevent.stop="(e) => e.target.blur()"
 	>
 		{{ title }}
 	</div>

--- a/frontend/src/stores/presentation.js
+++ b/frontend/src/stores/presentation.js
@@ -268,6 +268,7 @@ const layoutResource = createResource({
 			slide.transitionDuration = slide.transition_duration
 			// remove the transition_duration field to avoid confusion
 			delete slide.transition_duration
+			delete slide.fade_unmatched_elements
 		}
 	},
 	makeParams: ({ theme }) => {

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -201,6 +201,9 @@ const getNewSlide = (toDuplicate = false, layoutId) => {
 	// override metadata and generate unique IDs for elements
 	slide.name = ''
 	slide.parent = presentationId.value
+	slide.fadeUnmatchedElements = 1
+	slide.transitionDuration = 0
+	slide.transition = 'None'
 
 	return slide
 }

--- a/slides/slides/doctype/slide/slide.json
+++ b/slides/slides/doctype/slide/slide.json
@@ -38,19 +38,16 @@
    "label": "Thumbnail"
   },
   {
-   "default": "None",
    "fieldname": "transition",
    "fieldtype": "Data",
    "label": "Transition"
   },
   {
-   "default": "0",
    "fieldname": "transition_duration",
    "fieldtype": "Data",
    "label": "Transition Duration"
   },
   {
-   "default": "1",
    "fieldname": "fade_unmatched_elements",
    "fieldtype": "Check",
    "label": "Fade Unmatched Elements"
@@ -60,7 +57,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-12-05 01:20:50.333224",
+ "modified": "2026-01-18 00:24:21.114521",
  "modified_by": "Administrator",
  "module": "Slides",
  "name": "Slide",


### PR DESCRIPTION
### Fixes

1. Even though enter key was prevented for title editing, the event still propagated to the top which didn't cause issues until the enter key was actually assigned as a shortcut for adding a new empty slide recently. Fixed the behaviour so it doesn't trigger any slide actions.

2. `fade_unmatched_elements` value was defaulted to 1 by the server so adding a new slide with no value set made the client side value inconsistent with the saved value from that save onwards leading to incorrect dirty value after that so fixed that behaviour.