### PR TITLE
fix: prevent slide loss from overlapping auto-save network calls

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -13,7 +13,7 @@ import { onMounted, h, ref, provide } from 'vue'
 import { FrappeUIProvider, toast } from 'frappe-ui'
 
 import { Wifi, WifiOff } from 'lucide-vue-next'
-import { saveCurrentState, isSaving } from '@/stores/saving'
+import { saveCurrentState } from '@/stores/saving'
 
 const isOnline = ref(false)
 
@@ -27,7 +27,7 @@ const handleLostConnection = () => {
 
 const handleConnectionRestored = () => {
 	isOnline.value = true
-	if (!isSaving.value) saveCurrentState()
+	saveCurrentState()
 	toast.create({
 		message: 'You are back online.',
 		icon: h(Wifi, { color: 'white' }),

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -13,7 +13,7 @@ import { onMounted, h, ref, provide } from 'vue'
 import { FrappeUIProvider, toast } from 'frappe-ui'
 
 import { Wifi, WifiOff } from 'lucide-vue-next'
-import { syncPresentationToServer } from '@/stores/saving'
+import { saveCurrentState, isSaving } from '@/stores/saving'
 
 const isOnline = ref(false)
 
@@ -27,7 +27,7 @@ const handleLostConnection = () => {
 
 const handleConnectionRestored = () => {
 	isOnline.value = true
-	syncPresentationToServer()
+	if (!isSaving.value) saveCurrentState()
 	toast.create({
 		message: 'You are back online.',
 		icon: h(Wifi, { color: 'white' }),

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -99,14 +99,7 @@ import {
 import { resetFocus, focusElementId } from '@/stores/element'
 
 import { useShortcuts } from '@/composables/useShortcuts'
-import {
-	saveChanges,
-	saveCurrentState,
-	dirtySince,
-	isDirty,
-	isSaving,
-	syncThumbnail,
-} from '@/stores/saving'
+import { saveChanges, saveCurrentState, dirtySince, isDirty, syncThumbnail } from '@/stores/saving'
 import { inSlideShowMode, startSlideShow } from '@/stores/slideshow'
 import { Layout } from 'lucide-vue-next'
 import LayoutDialog from '@/components/LayoutDialog.vue'
@@ -244,7 +237,7 @@ const handleBeforeUnmount = () => {
 
 	if (router.currentRoute.value.name !== 'Slideshow') {
 		resetFocus()
-		if (!isSaving.value) saveCurrentState()
+		saveCurrentState()
 	}
 	window.removeEventListener('beforeunload', handleBeforeUnload)
 	window.removeEventListener('popstate', hideOpenDialogs)

--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -101,9 +101,10 @@ import { resetFocus, focusElementId } from '@/stores/element'
 import { useShortcuts } from '@/composables/useShortcuts'
 import {
 	saveChanges,
+	saveCurrentState,
 	dirtySince,
 	isDirty,
-	syncPresentationToServer,
+	isSaving,
 	syncThumbnail,
 } from '@/stores/saving'
 import { inSlideShowMode, startSlideShow } from '@/stores/slideshow'
@@ -243,7 +244,7 @@ const handleBeforeUnmount = () => {
 
 	if (router.currentRoute.value.name !== 'Slideshow') {
 		resetFocus()
-		syncPresentationToServer()
+		if (!isSaving.value) saveCurrentState()
 	}
 	window.removeEventListener('beforeunload', handleBeforeUnload)
 	window.removeEventListener('popstate', hideOpenDialogs)

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -281,7 +281,6 @@ const addMediaElement = async (file, type) => {
 		videoPoster = posterURL
 	}
 
-	const { width, height } = type === 'image' ? await getNaturalSize(src) : { width: 400 }
 	let element = {
 		id: generateUniqueId(),
 		zIndex: currentSlide.value.elements.length + 1,

--- a/frontend/src/stores/presentation.js
+++ b/frontend/src/stores/presentation.js
@@ -340,6 +340,7 @@ export {
 	applyReverseTransition,
 	createPresentationResource,
 	presentationDoc,
+	presentationResource,
 	unsyncedPresentationRecord,
 	isPublicPresentation,
 	slidesLength,

--- a/frontend/src/stores/presentation.js
+++ b/frontend/src/stores/presentation.js
@@ -340,7 +340,6 @@ export {
 	applyReverseTransition,
 	createPresentationResource,
 	presentationDoc,
-	presentationResource,
 	unsyncedPresentationRecord,
 	isPublicPresentation,
 	slidesLength,

--- a/frontend/src/stores/saving.js
+++ b/frontend/src/stores/saving.js
@@ -2,7 +2,6 @@ import { ref, computed } from 'vue'
 import {
 	presentationDoc,
 	presentationId,
-	presentationResource,
 	hasStateChanged,
 	savePresentationDoc,
 } from '@/stores/presentation'

--- a/frontend/src/stores/saving.js
+++ b/frontend/src/stores/saving.js
@@ -2,6 +2,7 @@ import { ref, computed } from 'vue'
 import {
 	presentationDoc,
 	presentationId,
+	presentationResource,
 	hasStateChanged,
 	savePresentationDoc,
 } from '@/stores/presentation'
@@ -113,8 +114,6 @@ const syncSnapshotToServer = async (snapshot) => {
 }
 
 const syncPresentationToServer = async () => {
-	isSaving.value = true
-
 	try {
 		const snapshot = await getPresentationFromLocalDB(presentationId.value)
 		if (!snapshot || !snapshot.dirty) return
@@ -123,8 +122,11 @@ const syncPresentationToServer = async () => {
 		await syncSnapshotToServer(snapshot)
 	} catch (err) {
 		console.error('Sync to server failed: ', err)
-	} finally {
-		isSaving.value = false
+		// Reset presentationDoc to the reverted server state so isDirty detects
+		// the unsaved changes and retries on the next autosave cycle
+		if (presentationResource.value?.doc) {
+			presentationDoc.value = presentationResource.value.doc
+		}
 	}
 }
 
@@ -134,21 +136,27 @@ const getLatestSlideContent = () => {
 }
 
 const saveCurrentState = async () => {
-	const content = getLatestSlideContent()
+	isSaving.value = true
 
-	// save latest content to indexedDB with dirty flag since it's not yet synced to server
-	await savePresentationToLocalDB({
-		id: presentationId.value,
-		content: content,
-		updatedAt: Date.now(),
-		dirty: true,
-	})
+	try {
+		const content = getLatestSlideContent()
 
-	// if offline, do not attempt to sync to server
-	if (!navigator.onLine) return
+		// save latest content to indexedDB with dirty flag since it's not yet synced to server
+		await savePresentationToLocalDB({
+			id: presentationId.value,
+			content: content,
+			updatedAt: Date.now(),
+			dirty: true,
+		})
 
-	// if online, sync to server
-	await syncPresentationToServer()
+		// if offline, do not attempt to sync to server
+		if (!navigator.onLine) return
+
+		// if online, sync to server
+		await syncPresentationToServer()
+	} finally {
+		isSaving.value = false
+	}
 }
 
 const saveChanges = () => {
@@ -162,4 +170,12 @@ const saveChanges = () => {
 	saveCurrentState()
 }
 
-export { syncPresentationToServer, saveChanges, dirtySince, isDirty, syncThumbnail }
+export {
+	syncPresentationToServer,
+	saveChanges,
+	saveCurrentState,
+	isSaving,
+	dirtySince,
+	isDirty,
+	syncThumbnail,
+}

--- a/frontend/src/stores/saving.js
+++ b/frontend/src/stores/saving.js
@@ -122,11 +122,6 @@ const syncPresentationToServer = async () => {
 		await syncSnapshotToServer(snapshot)
 	} catch (err) {
 		console.error('Sync to server failed: ', err)
-		// Reset presentationDoc to the reverted server state so isDirty detects
-		// the unsaved changes and retries on the next autosave cycle
-		if (presentationResource.value?.doc) {
-			presentationDoc.value = presentationResource.value.doc
-		}
 	}
 }
 
@@ -136,6 +131,9 @@ const getLatestSlideContent = () => {
 }
 
 const saveCurrentState = async () => {
+	if (isSaving.value) return
+	if (!slides.value?.length || !presentationId.value) return
+
 	isSaving.value = true
 
 	try {
@@ -159,23 +157,13 @@ const saveCurrentState = async () => {
 	}
 }
 
-const saveChanges = () => {
-	if (isSaving.value) return
-
+const saveChanges = async () => {
 	if (!isDirty.value && syncThumbnail === 0) return
 
 	if (isDirty.value) syncThumbnail = 1
 	else syncThumbnail = 0
 
-	saveCurrentState()
+	await saveCurrentState()
 }
 
-export {
-	syncPresentationToServer,
-	saveChanges,
-	saveCurrentState,
-	isSaving,
-	dirtySince,
-	isDirty,
-	syncThumbnail,
-}
+export { saveCurrentState, saveChanges, dirtySince, isDirty, syncThumbnail }


### PR DESCRIPTION


Fixed a condition where multiple overlapping save calls for same snapshot started at the same time even though one save call is already in progress. Since these calls use the snapshot which has become stale after the first call completes, slides are lost. 

