### PR TITLE
fix: incorrect saving logic after duplicated slide

### DIFF
--- a/frontend/src/stores/presentation.js
+++ b/frontend/src/stores/presentation.js
@@ -214,7 +214,7 @@ const hasSlideChanged = (originalState, slideState) => {
 		if (slideState[key] != originalState[key]) return true
 	}
 
-	if (slideState.name != '' && slideState.name != originalState.name) return true
+	if (slideState.name && slideState.name != originalState.name) return true
 
 	const currElements = parseElements(slideState.elements)
 	const origElements = parseElements(originalState.elements)
@@ -241,8 +241,8 @@ const updateNewlyAddedSlideUUIDs = () => {
 	// required for correct jumping to slide during undo / redo operations
 	ignoreUpdates(() => {
 		slides.value.forEach((slide, idx) => {
-			if (slide.name === '') {
-				slide.name = presentationResource.value.doc.slides[idx]?.name
+			if (!slide.name) {
+				slide.name = presentationResource.value.doc.slides[idx]?.name ?? ''
 			}
 		})
 	})

--- a/frontend/src/stores/presentation.js
+++ b/frontend/src/stores/presentation.js
@@ -240,9 +240,10 @@ const updateNewlyAddedSlideUUIDs = () => {
 	// for newly added slides, update their names from server response
 	// required for correct jumping to slide during undo / redo operations
 	ignoreUpdates(() => {
-		slides.value.forEach((slide, idx) => {
-			if (!slide.name) {
-				slide.name = presentationResource.value.doc.slides[idx]?.name ?? ''
+		presentationResource.value.doc.slides.forEach((slide, idx) => {
+			const localSlide = slides.value[idx]
+			if (localSlide && !localSlide.name) {
+				localSlide.name = slide.name
 			}
 		})
 	})

--- a/frontend/src/stores/slide.js
+++ b/frontend/src/stores/slide.js
@@ -183,12 +183,14 @@ const guideVisibilityMap = reactive({
 })
 
 const insertSlide = async (newSlide, index) => {
-	slides.value.splice(index + 1, 0, newSlide)
-	slides.value.forEach((slide, index) => {
-		slide.idx = index + 1
+	const updated = [...slides.value]
+	updated.splice(index + 1, 0, newSlide)
+	updated.forEach((slide, i) => {
+		slide.idx = i + 1
 	})
 
-	slidesLength.value = slides.value.length
+	slides.value = updated
+	slidesLength.value = updated.length
 }
 
 const getNewSlide = (toDuplicate = false, layoutObject) => {

--- a/slides/slides/doctype/presentation/presentation.py
+++ b/slides/slides/doctype/presentation/presentation.py
@@ -115,7 +115,7 @@ def get_presentations() -> list[dict]:
 		"Presentation",
 		fields=["name", "title", "owner", "creation", "modified_by", "modified"],
 		order_by="modified desc",
-		filters=[["owner", "=", frappe.session.user]],
+		filters=[["owner", "=", frappe.session.user], ["is_template", "=", 0]],
 	)
 
 	for presentation in presentations:


### PR DESCRIPTION
Fixed infinite autosave loop and slide loss caused by duplicating slides one after the other due to name getting defined as undefined instead of name being an empty string, which was checked to evaluate the dirty flag in consecutive saves and led to an incorrect dirty value.

1. User duplicated slide and `getNewSlide` assigns `name: ''` to newly added slide. `isDirty` becomes true and save triggers.
2. User duplicated the newly added slide while the previous save call is still being processed. Another save call is triggered.
4. Server assigns a new name to the 2nd slide and on completion `updateNewlyAddedSlideUUIDs` runs but at this point there are three slides - the original slide, the first duplicated slide and the second duplicated slide but the very first save call only had 2 slides to save so its response does not have the third slide at all so `presentationResource.value.doc.slides[idx]?.name` is undefined for the third slide and is assigned to the name key by the first save call. 
5. The second save call completes and server assigns a new name to the third slide and on completion of that call `updateNewlyAddedSlideUUIDs` runs again but at that point the third slide name is undefined and not `''` so the newly returned name is not updated.
6. `presentationDoc.value = presentationResource.value.doc` runs but now presentationDoc.slides[2].name = 'real-uuid' (from the second save response which had all 3 slides).
7. Autosave checks dirty state and `isDirty` compares original[2].name = 'real-uuid' vs current[2].name = undefined. hasSlideChanged hits slideState.name != '' && slideState.name != originalState.name — undefined != '' is true → dirty forever. Every iteration destroys the server's slide row and creates a new one. 

On reload, we get back whichever UUID was last committed but since the save was still running, if we reload mid-save the server may have just deleted the previous row and not yet inserted the new one, resulting in only 2 slides coming back instead of 3.


### Before

https://github.com/user-attachments/assets/90ed3003-bb10-4ed7-9783-3c852fde4075



### After

https://github.com/user-attachments/assets/53849f38-794e-4372-873b-28bd9c5ae6be

