### PR TITLE
fix: listitem fixes in tiptap

### DIFF
--- a/frontend/src/components/SlideElement.vue
+++ b/frontend/src/components/SlideElement.vue
@@ -83,6 +83,7 @@ const elementStyle = computed(() => {
 		zIndex: element.value.zIndex,
 		transform: element.value.type == 'text' ? element.value.transform : '',
 		transformOrigin: element.value.type == 'text' ? element.value.transformOrigin : '',
+		minWidth: element.value.type == 'text' ? '2px' : '',
 	}
 })
 

--- a/frontend/src/stores/element.js
+++ b/frontend/src/stores/element.js
@@ -589,7 +589,10 @@ const blurAndSaveContent = (element) => {
 	activeEditor.value.setEditable(false)
 	activeEditor.value.commands.blur()
 
-	if (activeEditor.value.isEmpty) {
+	const text = activeEditor.value?.getText() || ''
+	const isEmpty = text.replace(/\u200B/g, '') === ''
+
+	if (isEmpty) {
 		deleteElements(null, [element.id])
 	} else {
 		updateElementContent(element)

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -13,6 +13,7 @@ import Color from '@tiptap/extension-color'
 
 import { Plugin, PluginKey } from 'prosemirror-state'
 import { joinBackward } from 'prosemirror-commands'
+import { liftListItem } from 'prosemirror-schema-list'
 import { TextSelection } from 'prosemirror-state'
 
 import { getDocFromHTML } from '@/utils/helpers'
@@ -389,6 +390,29 @@ const handleSpaceKey = (event, view) => {
 	}
 }
 
+const handleBackspaceInListItem = (event, view, $from) => {
+	const { selection } = view.state
+	const { from, to, start, end } = getSelectionRange(selection)
+	const text = getTextForSelection($from)
+
+	const lastCharOnLine = text.length === 1 && text !== ZWSP
+	const isEntireParagraphSelected = from === start && to === end
+
+	// last real character or full selection - replace with ZWSP placeholder
+	if (lastCharOnLine || isEntireParagraphSelected) {
+		return addPlaceholderAndRetainMarks(event, view, start, end)
+	}
+
+	// only ZWSP - lift list item into paragraph and retain ZWSP
+	if (text === ZWSP) {
+		event.preventDefault()
+		liftListItem(view.state.schema.nodes.listItem)(view.state, view.dispatch)
+		return true
+	}
+
+	return false
+}
+
 const handleKeyDown = (view, event) => {
 	if (event.key === ' ') return handleSpaceKey(event, view)
 
@@ -397,7 +421,7 @@ const handleKeyDown = (view, event) => {
 	const { selection } = view.state
 	const $from = selection.$from
 
-	if (isInList($from)) return false
+	if (isInList($from)) return handleBackspaceInListItem(event, view, $from)
 
 	const text = getTextForSelection($from)
 	if (text === undefined) return false
@@ -430,7 +454,7 @@ const handleKeyDown = (view, event) => {
 	}
 
 	if (prevNode && prevNode.isTextblock && prevNode.textContent === ZWSP) {
-		return joinBackwardAfterPlaceholder(event, view, $from)
+		return joinBackwardAfterPlaceholder(view)
 	}
 
 	return false

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -139,15 +139,16 @@ const CustomListItem = ListItem.extend({
 
 		const { color, fontSize, fontFamily, letterSpacing, opacity } = getItemAttributes(node)
 
-		liAttrs.style = [
-			liAttrs.style || '',
-			`color: ${color};`,
-			`font-size: ${fontSize}px;`,
-			`font-family: ${fontFamily};`,
-			`letter-spacing: ${letterSpacing};`,
-			`opacity: ${opacity};`,
-			`line-height: ${node.attrs.lineHeight || '1.5'};`,
-		].join(' ')
+		const styleAttrs = [liAttrs.style || '']
+
+		if (color != null) styleAttrs.push(`color: ${color};`)
+		if (fontSize != null) styleAttrs.push(`font-size: ${fontSize}px;`)
+		if (fontFamily != null) styleAttrs.push(`font-family: ${fontFamily};`)
+		if (letterSpacing != null) styleAttrs.push(`letter-spacing: ${letterSpacing};`)
+		if (opacity != null) styleAttrs.push(`opacity: ${opacity};`)
+		styleAttrs.push(`line-height: ${node.attrs.lineHeight || '1.5'};`)
+
+		liAttrs.style = styleAttrs.join(' ')
 
 		return ['li', liAttrs, 0]
 	},
@@ -204,7 +205,7 @@ const handleListItemEnterKey = (editor, pos, marks) => {
 	// move cursor to end of current item and then split
 	// so new list already has placeholder
 
-	let tr = state.tr.insertText(ZWSP, endPos, endPos, marks)
+	let tr = state.tr.replaceWith(endPos, endPos, state.schema.text(ZWSP, marks))
 	tr = tr.setSelection(TextSelection.create(tr.doc, endPos))
 	view.dispatch(tr)
 
@@ -530,7 +531,7 @@ const handleTextInput = (view, from, to, text) => {
 	tr = tr.setStoredMarks(marks)
 
 	const cursorPos = tr.mapping.map(end)
-	tr = tr.setSelection(TextSelection.create(tr.doc, cursorPos))
+	tr = tr.setSelection(TextSelection.near(tr.doc.resolve(cursorPos)))
 
 	view.dispatch(tr)
 

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -337,7 +337,61 @@ const joinBackwardAfterPlaceholder = (view) => {
 	return true
 }
 
+const createListItemWithMarks = (event, view, listType) => {
+	const { selection, schema } = view.state
+	const $from = selection.$from
+
+	const marks = $from.parent.content.firstChild?.marks ?? []
+
+	event.preventDefault()
+
+	const { start, end } = getSelectionRange(selection)
+
+	const zwsp = schema.text(ZWSP, marks)
+	const listItemPara = schema.nodes.paragraph.create($from.parent.attrs, zwsp)
+	const listItem = schema.nodes.listItem.create(null, listItemPara)
+
+	let listNode, selectionPos
+
+	if (listType === 'unordered') {
+		listNode = schema.nodes.bulletList.create(null, listItem)
+		selectionPos = start + listNode.nodeSize - 3
+	} else {
+		listNode = schema.nodes.orderedList.create(null, listItem)
+		selectionPos = start + listNode.nodeSize - 4
+	}
+
+	const tr = view.state.tr.replaceWith(start - 1, end, listNode)
+
+	const resolvedPos = tr.doc.resolve(selectionPos)
+	tr.setSelection(TextSelection.near(resolvedPos))
+
+	view.dispatch(tr)
+	return true
+}
+
+const handleSpaceKey = (event, view) => {
+	const { selection } = view.state
+	const $from = selection.$from
+
+	if (isInList($from)) return
+
+	const text = getTextForSelection($from)
+
+	// Bullet list: "- " or ZWSP + "- "
+	if (text === '-' || text === `${ZWSP}-`) {
+		return createListItemWithMarks(event, view, 'unordered')
+	}
+
+	// Ordered list: "1. " or ZWSP + "1."
+	if (/^1\.$/.test(text) || new RegExp(`^${ZWSP}1\\.$`).test(text)) {
+		return createListItemWithMarks(event, view, 'ordered')
+	}
+}
+
 const handleKeyDown = (view, event) => {
+	if (event.key === ' ') return handleSpaceKey(event, view)
+
 	if (event.key !== 'Backspace') return false
 
 	const { selection } = view.state

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -338,6 +338,24 @@ const joinBackwardAfterPlaceholder = (view) => {
 	return true
 }
 
+const joinIntoPrevList = (event, view, $from) => {
+	event.preventDefault()
+
+	const { state } = view
+	const posBeforeBlock = $from.before($from.depth)
+	const posAfterBlock = $from.after($from.depth)
+
+	// delete the entire empty paragraph
+	let tr = state.tr.delete(posBeforeBlock, posAfterBlock)
+
+	// place cursor at the end of the last list item
+	const resolvedPos = tr.doc.resolve(posBeforeBlock - 1)
+	tr = tr.setSelection(TextSelection.near(resolvedPos, -1))
+
+	view.dispatch(tr)
+	return true
+}
+
 const createListItemWithMarks = (event, view, listType) => {
 	const { selection, schema } = view.state
 	const $from = selection.$from
@@ -445,6 +463,15 @@ const handleKeyDown = (view, event) => {
 		// deleting it and adding <br class="ProseMirror-trailingBreak">
 		// so manually delete ZWSP and join with previous line which is expected behavior without the placeholder
 		return removePlaceholderAndJoinBackward(event, view, start, end)
+	}
+
+	if (
+		text === ZWSP &&
+		prevNode &&
+		(prevNode.type.name === 'bulletList' || prevNode.type.name === 'orderedList')
+	) {
+		// paragraph is after a list - delete the empty paragraph and move cursor to last list item
+		return joinIntoPrevList(event, view, $from)
 	}
 
 	if (text === ZWSP) {

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -168,7 +168,13 @@ const isInList = ($pos) => {
 const handleListItemEnterKey = (editor, pos, marks) => {
 	const { state, view } = editor
 
+	const { from } = state.selection
 	const endPos = pos.end()
+
+	if (from < endPos) {
+		editor.commands.splitListItem('listItem')
+		return true
+	}
 
 	// before splitting to next list item, insert ZWSP at end of current item
 	// move cursor to end of current item and then split

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -436,32 +436,24 @@ const handleKeyDown = (view, event) => {
 	return false
 }
 
-const removePlaceholderAndInsertText = (view, pos, text) => {
-	const { state, dispatch } = view
-	const { selection, storedMarks } = state
-
-	const marks = storedMarks || selection.$from.marks()
-
-	// remove ZWSP when user enters actual text
-	let tr = state.tr
-
-	tr = tr.delete(pos.pos - 1, pos.pos)
-	tr = tr.setStoredMarks(marks)
-	tr = tr.insertText(text)
-
-	dispatch(tr)
-
-	return true
-}
-
 const handleTextInput = (view, from, to, text) => {
 	const $pos = view.state.selection.$from
-	const nodeBefore = $pos.nodeBefore
 
-	// if the prev char is not ZWSP, use default behavior
-	if (!nodeBefore || nodeBefore.text !== ZWSP) return false
+	const lineText = getTextForSelection($pos)
+	if (lineText.replace(new RegExp(ZWSP, 'g'), '') !== '') return false
 
-	return removePlaceholderAndInsertText(view, $pos, text)
+	const { state } = view
+	const { selection } = state
+	const { start, end } = getSelectionRange(selection)
+	const marks = getMarksForPlaceholder(state)
+
+	let tr = state.tr
+	tr = tr.replaceWith(start, end, state.schema.text(text, marks))
+	tr = tr.setStoredMarks(marks)
+	tr = tr.setSelection(TextSelection.create(tr.doc, start + text.length))
+	view.dispatch(tr)
+
+	return true
 }
 
 const styledEmptyLinePlugin = new Plugin({

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -5,16 +5,14 @@ import Paragraph from '@tiptap/extension-paragraph'
 import { StarterKit } from '@tiptap/starter-kit'
 import { TextStyle } from '@tiptap/extension-text-style'
 import { TextAlign } from '@tiptap/extension-text-align'
-import { Underline } from '@tiptap/extension-underline'
 import BulletList from '@tiptap/extension-bullet-list'
 import OrderedList from '@tiptap/extension-ordered-list'
 import ListItem from '@tiptap/extension-list-item'
 import Color from '@tiptap/extension-color'
 
-import { Plugin, PluginKey } from 'prosemirror-state'
+import { Plugin, PluginKey, TextSelection } from 'prosemirror-state'
 import { joinBackward } from 'prosemirror-commands'
 import { liftListItem } from 'prosemirror-schema-list'
-import { TextSelection } from 'prosemirror-state'
 
 import { getDocFromHTML } from '@/utils/helpers'
 

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -126,7 +126,7 @@ const CustomListItem = ListItem.extend({
 			...this.parent?.(),
 
 			lineHeight: {
-				default: () => '1.5',
+				default: '1.5',
 				parseHTML: (element) => element.style.lineHeight || '1.5',
 			},
 		}
@@ -511,20 +511,27 @@ const handleKeyDown = (view, event) => {
 }
 
 const handleTextInput = (view, from, to, text) => {
-	const $pos = view.state.selection.$from
-
-	const lineText = getTextForSelection($pos)
-	if (lineText.replace(new RegExp(ZWSP, 'g'), '') !== '') return false
-
 	const { state } = view
+
+	const $pos = state.selection.$from
 	const { selection } = state
 	const { start, end } = getSelectionRange(selection)
+
+	const lineText = getTextForSelection($pos)
+	const isEmptyLine = lineText.replace(/\u200B/g, '') === ''
+	const isEntireParagraphSelected = from === start && to === end
+
+	if (!isEmptyLine && !isEntireParagraphSelected) return false
+
 	const marks = getMarksForPlaceholder(state)
 
 	let tr = state.tr
 	tr = tr.replaceWith(start, end, state.schema.text(text, marks))
 	tr = tr.setStoredMarks(marks)
-	tr = tr.setSelection(TextSelection.create(tr.doc, start + text.length))
+
+	const cursorPos = tr.mapping.map(end)
+	tr = tr.setSelection(TextSelection.create(tr.doc, cursorPos))
+
 	view.dispatch(tr)
 
 	return true

--- a/frontend/src/stores/tiptapSetup.js
+++ b/frontend/src/stores/tiptapSetup.js
@@ -166,11 +166,36 @@ const isInList = ($pos) => {
 	return false
 }
 
+const isListItemEmpty = (pos) => {
+	for (let d = pos.depth; d > 0; d--) {
+		const node = pos.node(d)
+		if (node.type.name === 'listItem') {
+			let text = ''
+			node.forEach((child) => {
+				child.forEach((inline) => {
+					text += inline.text || ''
+				})
+			})
+
+			// li is empty if no text or only ZWSP characters
+			return text.replace(/\u200B/g, '').trim() === ''
+		}
+	}
+	return false
+}
+
 const handleListItemEnterKey = (editor, pos, marks) => {
 	const { state, view } = editor
 
 	const { from } = state.selection
 	const endPos = pos.end()
+
+	// if enter is pressed on an empty list item
+	// lift the item out of the list instead of splitting
+	if (isListItemEmpty(pos)) {
+		liftListItem(state.schema.nodes.listItem)(state, view.dispatch)
+		return true
+	}
 
 	if (from < endPos) {
 		editor.commands.splitListItem('listItem')


### PR DESCRIPTION
Fixed the following issues for lists in text elements -

### Highlight Disappearing 

Highlight Disappearing - Before

https://github.com/user-attachments/assets/82b88a55-5da4-4f72-b4f9-8d31f0c7b23f

<br>

Highlight Disappearing - After

https://github.com/user-attachments/assets/4757b909-8548-4a8b-864b-c24bac693f12

<br>

---


### Emptying content loses styles for first list node

Emptying content loses styles for first list node - Before

https://github.com/user-attachments/assets/221a4c57-e784-4384-a9fc-f49e5477f230

<br>

Emptying content loses styles for first list node - After

https://github.com/user-attachments/assets/cc994276-b755-48ec-a27a-027cad5cb500

<br>

----

### Incorrect lifting of list items to come out of list and go back to list using just keyboard

Incorrect lifting of list items to come out of list and go back to list using just keyboard - Before

https://github.com/user-attachments/assets/db1027a8-ce6d-4c23-8ab0-e21c6ae7898f


<br>


Incorrect lifting of list items to come out of list and go back to list using just keyboard - After

https://github.com/user-attachments/assets/bd9f964d-19ac-443e-916a-5c4445cabcec


<br>

---


### Empty list item incorrect marker

Empty list item incorrect marker - Before

https://github.com/user-attachments/assets/d6773bcd-5fb3-4a2e-b945-9f09639e829f

<br>

Empty list item incorrect marker - After

https://github.com/user-attachments/assets/a69f3b26-6d46-4dc7-a409-4bedd225fbf8


Closes #147
