### PR TITLE
fix: avoid touching editor state for unsaved edits before slideshow

### DIFF
--- a/frontend/src/pages/PresentationEditor.vue
+++ b/frontend/src/pages/PresentationEditor.vue
@@ -237,6 +237,11 @@ const loadEditorState = async () => {
 	if (!id) return
 
 	performBeforeLoadOperations()
+	if (presentationDoc.value && presentationId.value === id && slides.value.length) {
+		performAfterLoadOperations()
+		return
+	}
+
 	await loadPresentation(id)
 	performAfterLoadOperations()
 }


### PR DESCRIPTION
`loadEditorState`previously ran without checking latest edit batch. Might lead to missing last of the few edits before switching routes.